### PR TITLE
Fixed: Null error while creating single and multiple variants

### DIFF
--- a/erpnext/utilities/product.py
+++ b/erpnext/utilities/product.py
@@ -154,8 +154,6 @@ def get_item_codes_by_attributes(attribute_filters, template_item_code=None):
 				)
 			GROUP BY
 				t1.parent
-			ORDER BY
-				NULL
 		"""
 
 		item_codes = set([r[0] for r in frappe.db.sql(query, query_values)])


### PR DESCRIPTION
Fixed: Null syntax error while creating single and multiple variant from item.