### PR TITLE
fix: error on merging one account with another || on multiple click o…

### DIFF
--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -131,6 +131,11 @@ frappe.ui.form.on("Account", {
 				},
 			],
 			primary_action: function () {
+				d.hide();
+				frappe.show_alert({
+					message: __('Accounts are being merged'),
+					indicator: 'orange'
+				});		
 				var data = d.get_values();
 				frappe.call({
 					method: "erpnext.accounts.doctype.account.account.merge_account",
@@ -143,7 +148,6 @@ frappe.ui.form.on("Account", {
 							if (r.message) {
 								frappe.set_route("Form", "Account", r.message);
 							}
-							d.hide();
 						}
 					},
 				});

--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -130,14 +130,11 @@ frappe.ui.form.on("Account", {
 					default: frm.doc.name,
 				},
 			],
-			primary_action: function () {
-				d.hide();
-				frappe.show_alert({
-					message: __('Accounts are being merged'),
-					indicator: 'orange'
-				});		
+			primary_action: function () {		
 				var data = d.get_values();
 				frappe.call({
+					freeze: true,
+    				freeze_message: __('Accounts are being merged'), 
 					method: "erpnext.accounts.doctype.account.account.merge_account",
 					args: {
 						old: frm.doc.name,
@@ -148,6 +145,7 @@ frappe.ui.form.on("Account", {
 							if (r.message) {
 								frappe.set_route("Form", "Account", r.message);
 							}
+							d.hide();
 						}
 					},
 				});


### PR DESCRIPTION
…f merge button in short time db was returning SerializationFailure

[Overview]
While merging one account with another, a dialog box appears with a field to select the account to merge with and a primary action button labeled Merge. Upon clicking the Merge button, a Python method is triggered that executes a series of SQL queries. This process takes some time to complete.

However, if the Merge button is clicked again during the execution, the database would return the following error:
psycopg2.errors.SerializationFailure: could not serialize access due to concurrent update

[Fix]
To resolve this, the JavaScript code has been modified. Now, once the Merge button is clicked:

Freeze parameter is passed in frappe call API with freeze_message as "Accounts are being merged."
This prevents the user from clicking the button multiple times. The Python method will now only run once, ensuring the process executes properly without errors.

