### PR TITLE
Revert "Test customer group creation"

### DIFF
--- a/erpnext/setup/doctype/customer_group/test_customer_group.py
+++ b/erpnext/setup/doctype/customer_group/test_customer_group.py
@@ -1,28 +1,9 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+test_ignore = ["Price List"]
+
+
 import frappe
-import unittest
 
 test_records = frappe.get_test_records("Customer Group")
-
-class TestCustomerGroup(unittest.TestCase):
-    def setUp(self):
-        self.customer_group_name = "_Test Customer Group"
-
-        # Check if Customer Group already exists
-        if not frappe.db.exists("Customer Group", self.customer_group_name):
-            # Create new Customer Group if it doesn't exist
-            self.customer_group = frappe.get_doc({
-                "doctype": "Customer Group",
-                "customer_group_name": self.customer_group_name,
-                "is_group": 0
-            })
-            self.customer_group.insert()
-        else:
-            # Fetch the existing Customer Group if it exists
-            self.customer_group = frappe.get_doc("Customer Group", self.customer_group_name)
-
-    def test_customer_group_creation(self):
-        self.assertEqual(self.customer_group.customer_group_name, self.customer_group_name, "Customer Group name does not match.")
-        self.assertFalse(self.customer_group.is_group, "Customer Group should not be a group.")
-
-    def tearDown(self):
-        frappe.delete_doc("Customer Group", self.customer_group.name)


### PR DESCRIPTION
Reverts 8848digital/erpnext#454


bench run-tests --doctype "Customer Group"
E
======================================================================
ERROR: test_customer_group_creation (erpnext.setup.doctype.customer_group.test_customer_group.TestCustomerGroup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/frappe-bench/apps/erpnext/erpnext/setup/doctype/customer_group/test_customer_group.py", line 28, in tearDown
    frappe.delete_doc("Customer Group", self.customer_group.name)
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/__init__.py", line 1399, in delete_doc
    return frappe.model.delete_doc.delete_doc(
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 140, in delete_doc
    raise e
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 131, in delete_doc
    check_if_doc_is_linked(doc)
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 318, in check_if_doc_is_linked
    raise_link_exists_exception(doc, linked_parent_doctype, reference_docname)
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 383, in raise_link_exists_exception
    frappe.throw(
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/__init__.py", line 652, in throw
    msgprint(
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/__init__.py", line 617, in msgprint
    _raise_exception()
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/__init__.py", line 568, in _raise_exception
    raise exc
frappe.exceptions.LinkExistsError: Cannot delete or cancel because Customer Group _Test Customer Group is linked with Sales Order SAL-ORD-2024-00010 

----------------------------------------------------------------------
Ran 1 test in 0.241s