### PR TITLE
fix: System Error When Unreconciling Payment via Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.py
+++ b/erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.py
@@ -138,7 +138,7 @@ def get_linked_payments_for_doc(
 				)
 				.where(Criterion.all(criteria))
 				.groupby(ple.voucher_no, ple.against_voucher_no, ple.company, ple.voucher_type, ple.account_currency)
-				.having(qb.Field("allocated_amount") > 0)
+				.having(Abs(Sum(ple.amount_in_account_currency)) > 0)
 				.run(as_dict=True)
 			)
 			return res


### PR DESCRIPTION
Alias column name not read properly with Postgres db.

Here the query builder has formed the query as 
"""SELECT "company","voucher_type","voucher_no",ABS(SUM("amount_in_account_currency")) "allocated_amount","account_currency" FROM "tabPayment Ledger Entry" WHERE "company"='French Connections' AND "delinked"=0 AND "against_voucher_no"='ACC-PINV-2024-22163' AND "amount"<0 GROUP BY "voucher_no","against_voucher_no","company","voucher_type","account_currency" HAVING "allocated_amount">0""";

so corrected having clause.