### PR TITLE
fix: taxes and charges issue

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -519,6 +519,9 @@ class AccountsController(TransactionBase):
 	def calculate_taxes_and_totals(self):
 		from erpnext.controllers.taxes_and_totals import calculate_taxes_and_totals
 
+		if self.taxes_and_charges and not len(self.get("taxes")):
+			self.append_taxes_from_master()
+
 		calculate_taxes_and_totals(self)
 
 		if self.doctype in (


### PR DESCRIPTION
issue: While sales order/invoice created by server script (data import or API call). Taxes and Charges Template is given, but Taxes Table will not fill.