### PR TITLE
fix: remove hide field in SI

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -804,7 +804,6 @@ frappe.ui.form.on("Sales Invoice", {
 			// "project",
 			"due_date",
 			"is_opening",
-			"source",
 			"total_advance",
 			"get_advances",
 			"advances",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/04800f15-3e86-43ce-97bb-84894f479e09)
In sales invoice "Create" and "Preview" button is not visible. due to js file error.
In hide_field => source field is removed for the parent_fields list
![image](https://github.com/user-attachments/assets/66b9126e-a879-4121-8892-14003d03577f)
