### PR TITLE
fix: Server Error on_submit of Payment Entry

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -385,7 +385,6 @@ doc_events = {
 	"Payment Entry": {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
-			"erpnext.accounts.doctype.payment_request.payment_request.update_payment_req_status",
 			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning",
 		],
 		"on_cancel": ["erpnext.accounts.doctype.dunning.dunning.resolve_dunning"],


### PR DESCRIPTION
- From standard ERPNext app 'update_payment_req_status()'  and from hooks.py referenced is removed.
