### PR TITLE
fix: Asset Issue 96. Read only condition in JSON file

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -54,7 +54,6 @@ frappe.ui.form.on("Item", {
 
 	refresh: function (frm) {
 		if (frm.doc.is_stock_item) {
-			frm.set_df_property("is_fixed_asset", "read_only", 1);
 			frm.add_custom_button(
 				__("Stock Balance"),
 				function () {


### PR DESCRIPTION
Read only condition have put in the JSON file in Assets app along with other condition as asked in Issue 96 (Assets app). 
From js file it wasn't working fine in some cases, such as in quick entry form. 