### PR TITLE
fix: filter for shipping rule

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -17,10 +17,11 @@ erpnext.buying = {
 				this.setup_queries(doc, cdt, cdn);
 				super.onload();
 
-				this.frm.set_query('shipping_rule', function() {
+				this.frm.set_query('shipping_rule', function(doc) {
 					return {
 						filters: {
-							"shipping_rule_type": "Buying"
+							"shipping_rule_type": "Buying",
+							company: doc.company
 						}
 					};
 				});

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -19,6 +19,7 @@ erpnext.sales_common = {
 					return {
 						filters: {
 							shipping_rule_type: "Selling",
+							company: doc.company
 						},
 					};
 				});


### PR DESCRIPTION
The Shipment Rule selection should be filtered according to the chosen company in Sales Order, Sales Invoice, Delivery Note, POS Invoice, Purchase Order, Purchase Invoice, Purchase Receipt