### PR TITLE
fix: journal entry sum of debit credit

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -355,6 +355,7 @@ def get_paid_amount(payment_entry, currency, gl_bank_account):
 				"Journal Entry Account",
 				{"parent": payment_entry.payment_entry, "account": gl_bank_account},
 				"sum(debit_in_account_currency-credit_in_account_currency)",
+				order_by=None
 			)
 			or 0
 		)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dc1c7411-8cd0-480c-8b4f-ba2f51e350d3)
in frappe.db.set_value while taking sum of value "order_by" is not allowed by postgres