### PR TITLE
fix: test case error fixed TC_B_094

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -3399,6 +3399,7 @@ class TestPurchaseOrder(FrappeTestCase):
 			'doctype': 'Purchase Invoice',
 			'supplier': po.supplier,
 			'company': po.company,
+			'credit_to': "_Test Creditors - _TC",
 			'items': [{
 				'item_code': item.item_code,
 				'qty': 1,


### PR DESCRIPTION
error fixed - frappe.exceptions.ValidationError: Please ensure that the Credit To account Creditors - _TC is a Payable account. You can change the account type to Payable or select a different account.