### PR TITLE
Fix:Removing dependencies of CRM and Sales Commission App

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -245,7 +245,7 @@
    "fieldname": "applicable_for",
    "fieldtype": "Select",
    "label": "Applicable For",
-   "options": "\nCustomer\nCustomer Group\nTerritory\nSales Partner\nCampaign\nSupplier\nSupplier Group"
+   "options": "\nCustomer\nCustomer Group\nTerritory\nSupplier\nSupplier Group"
   },
   {
    "depends_on": "eval:doc.applicable_for==\"Customer\"",
@@ -632,7 +632,7 @@
  "icon": "fa fa-gift",
  "idx": 1,
  "links": [],
- "modified": "2024-11-21 20:32:47.997150",
+ "modified": "2025-02-07 16:02:10.372217",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -29,7 +29,7 @@ class PricingRule(Document):
 		from erpnext.accounts.doctype.pricing_rule_item_group.pricing_rule_item_group import PricingRuleItemGroup
 		from frappe.types import DF
 
-		applicable_for: DF.Literal["", "Customer", "Customer Group", "Territory", "Sales Partner", "Campaign", "Supplier", "Supplier Group"]
+		applicable_for: DF.Literal["", "Customer", "Customer Group", "Territory", "Supplier", "Supplier Group"]
 		apply_discount_on: DF.Literal["Grand Total", "Net Total"]
 		apply_discount_on_rate: DF.Check
 		apply_multiple_pricing_rules: DF.Check

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1659,7 +1659,7 @@ class TestPricingRule(FrappeTestCase):
 		coupon_code.insert()
 		self.assertEqual(coupon_code.coupon_type, "Gift Card")
 		self.assertEqual(coupon_code.pricing_rule, pr.name)
-test_dependencies = ["Campaign"]
+# test_dependencies = ["Campaign"]
 
 
 def make_pricing_rule(**args):

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -22,7 +22,6 @@
   "finance_book",
   "currency",
   "payment_terms_template",
-  "sales_person",
   "show_remarks",
   "based_on_payment_terms",
   "section_break_3",
@@ -122,7 +121,7 @@
    "fieldname": "customer_collection",
    "fieldtype": "Select",
    "label": "Select Customers By",
-   "options": "\nCustomer Group\nTerritory\nSales Partner\nSales Person"
+   "options": "\nCustomer Group\nTerritory"
   },
   {
    "depends_on": "eval: doc.customer_collection !== ''",
@@ -340,13 +339,6 @@
   },
   {
    "depends_on": "eval: (doc.report == 'Accounts Receivable');",
-   "fieldname": "sales_person",
-   "fieldtype": "Link",
-   "label": "Sales Person",
-   "options": "Sales Person"
-  },
-  {
-   "depends_on": "eval: (doc.report == 'Accounts Receivable');",
    "fieldname": "territory",
    "fieldtype": "Link",
    "label": "Territory",
@@ -384,7 +376,7 @@
   }
  ],
  "links": [],
- "modified": "2024-12-11 12:11:13.543134",
+ "modified": "2025-02-07 16:29:21.597239",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -29,11 +29,10 @@ class ProcessStatementOfAccounts(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from erpnext.accounts.doctype.process_statement_of_accounts_cc.process_statement_of_accounts_cc import (
-			ProcessStatementOfAccountsCC,
-		)
+		from erpnext.accounts.doctype.process_statement_of_accounts_cc.process_statement_of_accounts_cc import ProcessStatementOfAccountsCC
 		from erpnext.accounts.doctype.process_statement_of_accounts_customer.process_statement_of_accounts_customer import ProcessStatementOfAccountsCustomer
 		from erpnext.accounts.doctype.psoa_cost_center.psoa_cost_center import PSOACostCenter
+		from frappe.types import DF
 
 		account: DF.Link | None
 		ageing_based_on: DF.Literal["Due Date", "Posting Date"]
@@ -44,7 +43,7 @@ class ProcessStatementOfAccounts(Document):
 		company: DF.Link
 		cost_center: DF.TableMultiSelect[PSOACostCenter]
 		currency: DF.Link | None
-		customer_collection: DF.Literal["", "Customer Group", "Territory", "Sales Partner", "Sales Person"]
+		customer_collection: DF.Literal["", "Customer Group", "Territory"]
 		customers: DF.Table[ProcessStatementOfAccountsCustomer]
 		enable_auto_email: DF.Check
 		filter_duration: DF.Int
@@ -63,7 +62,6 @@ class ProcessStatementOfAccounts(Document):
 		posting_date: DF.Date | None
 		primary_mandatory: DF.Check
 		report: DF.Literal["General Ledger", "Accounts Receivable"]
-		sales_person: DF.Link | None
 		sender: DF.Link | None
 		show_net_values_in_party_account: DF.Check
 		show_remarks: DF.Check

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
@@ -31,7 +31,6 @@
   "customer",
   "customer_group",
   "territory",
-  "campaign",
   "supplier",
   "supplier_group",
   "period_settings_section",
@@ -166,7 +165,7 @@
    "fieldname": "applicable_for",
    "fieldtype": "Select",
    "label": "Applicable For",
-   "options": "\nCustomer\nCustomer Group\nTerritory\nSales Partner\nCampaign\nSupplier\nSupplier Group"
+   "options": "\nCustomer\nCustomer Group\nTerritory\nSupplier\nSupplier Group"
   },
   {
    "depends_on": "eval:doc.applicable_for=='Customer'",
@@ -188,13 +187,6 @@
    "fieldtype": "Table MultiSelect",
    "label": "Territory",
    "options": "Territory Item"
-  },
-  {
-   "depends_on": "eval:doc.applicable_for==\"Campaign\"",
-   "fieldname": "campaign",
-   "fieldtype": "Table MultiSelect",
-   "label": "Campaign",
-   "options": "Campaign Item"
   },
   {
    "depends_on": "eval:doc.applicable_for=='Supplier'",
@@ -270,10 +262,11 @@
   }
  ],
  "links": [],
- "modified": "2024-12-03 15:34:43.287222",
+ "modified": "2025-02-07 16:06:19.746224",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Promotional Scheme",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -79,44 +79,23 @@ class PromotionalScheme(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		from erpnext.accounts.doctype.campaign_item.campaign_item import CampaignItem
 		from erpnext.accounts.doctype.customer_group_item.customer_group_item import CustomerGroupItem
 		from erpnext.accounts.doctype.customer_item.customer_item import CustomerItem
 		from erpnext.accounts.doctype.pricing_rule_brand.pricing_rule_brand import PricingRuleBrand
-		from erpnext.accounts.doctype.pricing_rule_item_code.pricing_rule_item_code import (
-			PricingRuleItemCode,
-		)
-		from erpnext.accounts.doctype.pricing_rule_item_group.pricing_rule_item_group import (
-			PricingRuleItemGroup,
-		)
-		from erpnext.accounts.doctype.promotional_scheme_price_discount.promotional_scheme_price_discount import (
-			PromotionalSchemePriceDiscount,
-		)
-		from erpnext.accounts.doctype.promotional_scheme_product_discount.promotional_scheme_product_discount import (
-			PromotionalSchemeProductDiscount,
-		)
-		from erpnext.accounts.doctype.sales_partner_item.sales_partner_item import SalesPartnerItem
+		from erpnext.accounts.doctype.pricing_rule_item_code.pricing_rule_item_code import PricingRuleItemCode
+		from erpnext.accounts.doctype.pricing_rule_item_group.pricing_rule_item_group import PricingRuleItemGroup
+		from erpnext.accounts.doctype.promotional_scheme_price_discount.promotional_scheme_price_discount import PromotionalSchemePriceDiscount
+		from erpnext.accounts.doctype.promotional_scheme_product_discount.promotional_scheme_product_discount import PromotionalSchemeProductDiscount
 		from erpnext.accounts.doctype.supplier_group_item.supplier_group_item import SupplierGroupItem
 		from erpnext.accounts.doctype.supplier_item.supplier_item import SupplierItem
 		from erpnext.accounts.doctype.territory_item.territory_item import TerritoryItem
+		from frappe.types import DF
 
-		applicable_for: DF.Literal[
-			"",
-			"Customer",
-			"Customer Group",
-			"Territory",
-			"Sales Partner",
-			"Campaign",
-			"Supplier",
-			"Supplier Group",
-		]
+		applicable_for: DF.Literal["", "Customer", "Customer Group", "Territory", "Supplier", "Supplier Group"]
 		apply_on: DF.Literal["", "Item Code", "Item Group", "Brand", "Transaction"]
 		apply_rule_on_other: DF.Literal["", "Item Code", "Item Group", "Brand"]
 		brands: DF.Table[PricingRuleBrand]
 		buying: DF.Check
-		campaign: DF.TableMultiSelect[CampaignItem]
 		company: DF.Link
 		currency: DF.Link | None
 		customer: DF.TableMultiSelect[CustomerItem]
@@ -131,7 +110,6 @@ class PromotionalScheme(Document):
 		other_item_group: DF.Link | None
 		price_discount_slabs: DF.Table[PromotionalSchemePriceDiscount]
 		product_discount_slabs: DF.Table[PromotionalSchemeProductDiscount]
-		sales_partner: DF.TableMultiSelect[SalesPartnerItem]
 		selling: DF.Check
 		supplier: DF.TableMultiSelect[SupplierItem]
 		supplier_group: DF.TableMultiSelect[SupplierGroupItem]

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -5,7 +5,7 @@
 from urllib.parse import urlparse
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase,if_app_installed
 from frappe.utils import nowdate
 
 from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
@@ -14,8 +14,6 @@ from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
 	get_pdf,
 	make_supplier_quotation_from_rfq,
 )
-from crm.crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
-from crm.crm.doctype.opportunity.test_opportunity import make_opportunity
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.templates.pages.rfq import check_supplier_has_docname_access
 
@@ -107,7 +105,10 @@ class TestRequestforQuotation(FrappeTestCase):
 		self.assertEqual(supplier_quotation.items[0].qty, 5)
 		self.assertEqual(supplier_quotation.items[0].stock_qty, 10)
 
+	@if_app_installed("crm")
 	def test_make_rfq_from_opportunity(self):
+		from crm.crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
+		from crm.crm.doctype.opportunity.test_opportunity import make_opportunity
 		opportunity = make_opportunity(with_items=1)
 		supplier_data = get_supplier_data()
 		rfq = make_rfq(opportunity.name)

--- a/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.json
+++ b/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.json
@@ -13,7 +13,6 @@
   "scheduled_date",
   "actual_date",
   "section_break_6",
-  "sales_person",
   "column_break_8",
   "completion_status",
   "section_break_10",
@@ -66,18 +65,6 @@
    "report_hide": 1
   },
   {
-   "allow_on_submit": 1,
-   "columns": 2,
-   "fieldname": "sales_person",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Sales Person",
-   "oldfieldname": "incharge_name",
-   "oldfieldtype": "Link",
-   "options": "Sales Person",
-   "read_only_depends_on": "eval:doc.completion_status != \"Pending\""
-  },
-  {
    "fieldname": "serial_no",
    "fieldtype": "Small Text",
    "in_list_view": 1,
@@ -126,7 +113,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-09-16 21:25:22.506485",
+ "modified": "2025-02-07 18:40:33.168562",
  "modified_by": "Administrator",
  "module": "Maintenance",
  "name": "Maintenance Schedule Detail",
@@ -135,5 +122,6 @@
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
@@ -22,7 +22,6 @@ class MaintenanceScheduleDetail(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		sales_person: DF.Link | None
 		scheduled_date: DF.Date
 		serial_no: DF.SmallText | None
 	# end: auto-generated types

--- a/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
+++ b/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -17,7 +17,6 @@
   "schedule_details",
   "no_of_visits",
   "column_break_10",
-  "sales_person",
   "reference",
   "serial_no",
   "sales_order",
@@ -106,14 +105,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "sales_person",
-   "fieldtype": "Link",
-   "label": "Sales Person",
-   "oldfieldname": "incharge_name",
-   "oldfieldtype": "Link",
-   "options": "Sales Person"
-  },
-  {
    "fieldname": "reference",
    "fieldtype": "Section Break",
    "label": "Reference"
@@ -164,7 +155,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-03-22 18:44:36.816037",
+ "modified": "2025-02-07 18:09:41.944811",
  "modified_by": "Administrator",
  "module": "Maintenance",
  "name": "Maintenance Schedule Item",

--- a/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
@@ -24,7 +24,6 @@ class MaintenanceScheduleItem(Document):
 		parenttype: DF.Data
 		periodicity: DF.Literal["", "Weekly", "Monthly", "Quarterly", "Half Yearly", "Yearly", "Random"]
 		sales_order: DF.Link | None
-		sales_person: DF.Link | None
 		serial_and_batch_bundle: DF.Link | None
 		serial_no: DF.SmallText | None
 		start_date: DF.Date

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
@@ -5,6 +5,7 @@
 import frappe
 from frappe import _
 from frappe.utils import format_date, get_datetime
+from frappe.tests.utils import if_app_installed
 
 from erpnext.utilities.transaction_base import TransactionBase
 
@@ -129,13 +130,14 @@ class MaintenanceVisit(TransactionBase):
 						actual_date,
 					)
 
+
 	def update_customer_issue(self, flag):
 		if not self.maintenance_schedule:
 			for d in self.get("purposes"):
 				if d.prevdoc_docname and d.prevdoc_doctype == "Warranty Claim":
 					if flag == 1:
 						mntc_date = self.mntc_date
-						service_person = d.service_person
+						service_person = d.service_person if if_app_installed("sales_commission") else None
 						work_done = d.work_done
 						status = "Open"
 						if self.completion_status == "Fully Completed":
@@ -143,8 +145,12 @@ class MaintenanceVisit(TransactionBase):
 						elif self.completion_status == "Partially Completed":
 							status = "Work In Progress"
 					else:
+						if "sales_commission" in frappe.get_installed_apps():
+							service_person_field = "t2.service_person"  # Keep original field
+						else:
+							service_person_field = "NULL"
 						nm = frappe.db.sql(
-							"select t1.name, t1.mntc_date, t2.service_person, t2.work_done from `tabMaintenance Visit` t1, `tabMaintenance Visit Purpose` t2 where t2.parent = t1.name and t1.completion_status = 'Partially Completed' and t2.prevdoc_docname = %s and t1.name!=%s and t1.docstatus = 1 order by t1.name desc limit 1",
+							"select t1.name, t1.mntc_date, {service_person_field}, t2.work_done from `tabMaintenance Visit` t1, `tabMaintenance Visit Purpose` t2 where t2.parent = t1.name and t1.completion_status = 'Partially Completed' and t2.prevdoc_docname = %s and t1.name!=%s and t1.docstatus = 1 order by t1.name desc limit 1",
 							(d.prevdoc_docname, self.name),
 						)
 

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
@@ -5,8 +5,6 @@
 import frappe
 from frappe import _
 from frappe.utils import format_date, get_datetime
-from frappe.tests.utils import if_app_installed
-
 from erpnext.utilities.transaction_base import TransactionBase
 
 
@@ -137,7 +135,7 @@ class MaintenanceVisit(TransactionBase):
 				if d.prevdoc_docname and d.prevdoc_doctype == "Warranty Claim":
 					if flag == 1:
 						mntc_date = self.mntc_date
-						service_person = d.service_person if if_app_installed("sales_commission") else None
+						service_person = d.service_person if "sales_commission" in frappe.get_installed_apps() else None
 						work_done = d.work_done
 						status = "Open"
 						if self.completion_status == "Fully Completed":

--- a/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.json
+++ b/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.json
@@ -10,7 +10,6 @@
   "item_code",
   "item_name",
   "column_break_3",
-  "service_person",
   "serial_no",
   "section_break_6",
   "description",
@@ -66,16 +65,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "service_person",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Sales Person",
-   "oldfieldname": "service_person",
-   "oldfieldtype": "Link",
-   "options": "Sales Person",
-   "reqd": 1
-  },
-  {
    "fieldname": "work_done",
    "fieldtype": "Small Text",
    "in_list_view": 1,
@@ -117,7 +106,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-01-05 21:46:53.239830",
+ "modified": "2025-02-07 17:43:10.033962",
  "modified_by": "Administrator",
  "module": "Maintenance",
  "name": "Maintenance Visit Purpose",

--- a/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.py
+++ b/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.py
@@ -24,7 +24,6 @@ class MaintenanceVisitPurpose(Document):
 		prevdoc_docname: DF.DynamicLink | None
 		prevdoc_doctype: DF.Link | None
 		serial_no: DF.Link | None
-		service_person: DF.Link
 		work_done: DF.SmallText
 	# end: auto-generated types
 

--- a/erpnext/selling/doctype/sales_team/sales_team.json
+++ b/erpnext/selling/doctype/sales_team/sales_team.json
@@ -6,7 +6,6 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "sales_person",
   "contact_no",
   "allocated_percentage",
   "allocated_amount",
@@ -14,20 +13,6 @@
   "incentives"
  ],
  "fields": [
-  {
-   "allow_on_submit": 1,
-   "fieldname": "sales_person",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Sales Person",
-   "oldfieldname": "sales_person",
-   "oldfieldtype": "Link",
-   "options": "Sales Person",
-   "print_width": "200px",
-   "reqd": 1,
-   "search_index": 1,
-   "width": "200px"
-  },
   {
    "allow_on_submit": 1,
    "fieldname": "contact_no",
@@ -87,7 +72,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-11-09 23:55:20.670475",
+ "modified": "2025-02-07 18:35:00.396443",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Team",
@@ -96,5 +81,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/selling/doctype/sales_team/sales_team.py
+++ b/erpnext/selling/doctype/sales_team/sales_team.py
@@ -22,7 +22,6 @@ class SalesTeam(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		sales_person: DF.Link
 	# end: auto-generated types
 
 	pass


### PR DESCRIPTION
Error:
Getting an error frappe.exceptions.DoesNotExistError: DocType Campaign not found #1204
![image](https://github.com/user-attachments/assets/471bbf23-3d00-40e1-b051-5416a6948057)


Fix : Removing the dependencies of CRM and Sales commission app 
Removed the doctype references of select and options Fields :
Rmoved options fields are:
1.sales partner
2.sales person 
3.and the campaign 
And added the respective fields which are removed are added  for the CRM and Sales commission custom app 

