### PR TITLE
fix: error While creating purchase Invoice showing server error no attribute(project)

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -855,7 +855,7 @@ class PurchaseInvoice(BuyingController):
 			else grand_total,
 			"against_voucher": against_voucher,
 			"against_voucher_type": self.doctype,
-			"project": self.get("project"),
+			"project": self.get("project") if "projects" in frappe.get_installed_apps() else "",
 			"cost_center": self.cost_center,
 			"_skip_merge": skip_merge,
 		}


### PR DESCRIPTION
Fix: issue fixed while submitting the Purchase Invoice (no attribute(project))

added condition for project dependency

Before
![Screenshot from 2025-02-11 17-18-22](https://github.com/user-attachments/assets/cf047ace-b3dd-462c-be6c-7da71cc27e9d)


After
![Screenshot from 2025-02-11 17-18-49](https://github.com/user-attachments/assets/c12087cc-b481-4be7-9f28-f281e6633ee6)
