### PR TITLE
TC: TC_SCK_181

### DIFF
--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -103,48 +103,6 @@ class TestWarehouse(FrappeTestCase):
 		children = get_children("Warehouse", parent=company, company=company, is_root=True)
 		self.assertTrue(any(wh["value"] == "_Test Warehouse - _TC" for wh in children))
 
-	def test_create_warehouse_TC_SCK_157(self):
-		"""Test warehouse creation with valid inputs."""
-		if not frappe.db.exists("Company", "_Test Company"):
-				company = frappe.new_doc("Company")
-				company.company_name = "_Test Company"
-				company.default_currency = "INR"
-				company.insert()
-		warehouse = create_warehouse("_Test Warehouse", properties=None, company="_Test Company")
-		print("Warehouse", warehouse)
-
-		# Fetch created warehouse
-		created_warehouse = frappe.get_doc("Warehouse", warehouse)
-
-		# Assertions
-		self.assertEqual(created_warehouse.warehouse_name, "_Test Warehouse")
-		self.assertEqual(created_warehouse.company, "_Test Company")
-		self.assertFalse(created_warehouse.is_rejected_warehouse)
-
-		warehouse_rej = create_warehouse("_Test Warehouse - Rejected", properties={"is_rejected_warehouse":1}, company="_Test Company")
-		
-		# Fetch created warehouse
-		created_warehouse = frappe.get_doc("Warehouse", warehouse_rej)
-
-		# Assertions
-		self.assertTrue(created_warehouse.is_rejected_warehouse)
-
-		# Attempt to use this warehouse in a Stock Entry (should fail)
-		stock_entry = frappe.get_doc({
-			"doctype": "Stock Entry",
-			"stock_entry_type": "Material Receipt",
-			"items": [
-				{
-					"item_code": "Test Item",
-					"qty": 1,
-					"t_warehouse": created_warehouse.name
-				}
-			]
-		})
-
-		with self.assertRaises(frappe.ValidationError):
-			stock_entry.insert()
-
 
 def create_warehouse(warehouse_name, properties=None, company=None):
 	if not company:

--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -103,6 +103,48 @@ class TestWarehouse(FrappeTestCase):
 		children = get_children("Warehouse", parent=company, company=company, is_root=True)
 		self.assertTrue(any(wh["value"] == "_Test Warehouse - _TC" for wh in children))
 
+	def test_create_warehouse_TC_SCK_157(self):
+		"""Test warehouse creation with valid inputs."""
+		if not frappe.db.exists("Company", "_Test Company"):
+				company = frappe.new_doc("Company")
+				company.company_name = "_Test Company"
+				company.default_currency = "INR"
+				company.insert()
+		warehouse = create_warehouse("_Test Warehouse", properties=None, company="_Test Company")
+		print("Warehouse", warehouse)
+
+		# Fetch created warehouse
+		created_warehouse = frappe.get_doc("Warehouse", warehouse)
+
+		# Assertions
+		self.assertEqual(created_warehouse.warehouse_name, "_Test Warehouse")
+		self.assertEqual(created_warehouse.company, "_Test Company")
+		self.assertFalse(created_warehouse.is_rejected_warehouse)
+
+		warehouse_rej = create_warehouse("_Test Warehouse - Rejected", properties={"is_rejected_warehouse":1}, company="_Test Company")
+		
+		# Fetch created warehouse
+		created_warehouse = frappe.get_doc("Warehouse", warehouse_rej)
+
+		# Assertions
+		self.assertTrue(created_warehouse.is_rejected_warehouse)
+
+		# Attempt to use this warehouse in a Stock Entry (should fail)
+		stock_entry = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"stock_entry_type": "Material Receipt",
+			"items": [
+				{
+					"item_code": "Test Item",
+					"qty": 1,
+					"t_warehouse": created_warehouse.name
+				}
+			]
+		})
+
+		with self.assertRaises(frappe.ValidationError):
+			stock_entry.insert()
+
 
 def create_warehouse(warehouse_name, properties=None, company=None):
 	if not company:


### PR DESCRIPTION
TC SCK 181  - 
This test case validates over-receipt handling in ERPNext by creating a Purchase Order (PO) and a Purchase Receipt (PR) with a received quantity exceeding the ordered quantity, within the allowed over-delivery limit.

1. Set Over Billing Allowance to 25% for the expected results.
2. Create item and supplier
3. Create purchase order with qty 8
4. Create Purchase Receipt with 25% extra qty which is 10
5. check if PR creates