### PR TITLE
test: test case TC_SCK_189

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1917,6 +1917,35 @@ class TestStockEntry(FrappeTestCase):
 		current_s_bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": source_warehouse}, "actual_qty") or 0
 		self.assertEqual(current_s_bin_qty, s_bin_qty)
 
+	def test_create_partial_material_request_stock_entry_for_batch_item_TC_SCK_189(self):
+		from erpnext.stock.doctype.material_request.material_request import make_stock_entry as _make_stock_entry
+		company = "_Test Company"
+		if not frappe.db.exists("Company", company):
+			company_doc = frappe.new_doc("Company")
+			company_doc.company_doc_name = company
+			company_doc.country="India"
+			company_doc.default_currency= "INR"
+			company_doc.save()
+		else:
+			company_doc = frappe.get_doc("Company", company) 
+		warehouse = create_warehouse("_Test Warehouse",  company=company_doc.name)
+		properties = {
+			"has_batch_no":1,
+			"create_new_batch":1,
+			"has_expiry_date":1,
+			"shelf_life_in_days":365
+		}
+		item = make_item("_Test Item MR", properties=properties)
+		item.batch_number_series = f"{item.name}.-BT-.####."
+		item.save()
+		mr = make_material_request(material_request_type="Material Issue", qty=10, warehouse=warehouse, item=item.name)
+		se = _make_stock_entry(mr.name)
+		se.get("items")[0].qty = 5
+		se.save()
+		se.submit()
+		mr.reload()
+		self.assertEqual(mr.status, "Partially Ordered")
+
 	def test_stock_entry_for_mr_purpose(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
 


### PR DESCRIPTION
TC_SCK_189- test_create_partial_material_request_stock_entry_for_batch_item_TC_SCK_189
Description: This test case verifies the creation of a partial Material Request Stock Entry for a batch-tracked item. It ensures that a Material Request is correctly updated to "Partially Ordered" status when only a portion of the requested quantity is fulfilled through a Stock Entry