### PR TITLE
fix: added company abbr end of warehouse name

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1553,7 +1553,7 @@ class TestStockReconciliation(FrappeTestCase, StockTestMixin):
 			"_Test Stock Reco Item",
 			is_stock_item=1,
 			valuation_rate=500,
-			warehouse="_Test reco Warehouse",
+			warehouse="_Test reco Warehouse - _TC",
 		)
 
 		stock_reco = create_stock_reconciliation(


### PR DESCRIPTION
Fix code coverage issue -> warehouse name mismatch in link filed(Link Validation Error:Could not find Row #1: Default Warehouse: _Test reco Warehouse)

> TC_SCK_051