### PR TITLE
test: test case TC_SCK_125

### DIFF
--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -925,6 +925,21 @@ class TestItem(FrappeTestCase):
 		self.assertEqual(item.has_expiry_date, 1)
 		self.assertEqual(item.shelf_life_in_days, 30)
 
+	def test_create_variant_item_TC_SCK_125(self):
+		item = make_item(
+			"_Test Template Item",
+			{
+				"variant_based_on":"Item Attribute",
+				"attributes": [
+					{"attribute": "Test Size"}
+				],
+				"has_variants": 1,
+			},
+		)
+		self.assertEqual(item.item_code, "_Test Template Item")
+		self.assertEqual(item.has_variants, 1)
+		self.assertEqual(item.attributes[0].attribute, "Test Size")
+
 	def test_cr_item_TC_SCK_129(self):
 		from frappe.utils import random_string
 		item_fields1 = {


### PR DESCRIPTION
TC_SCK_125- test_create_variant_item_TC_SCK_125
Description: This test verifies that an item template is successfully created with variant attributes based on "Item Attribute" and includes "Test Size" as an attribute. It ensures the item has variants enabled and retains the expected item code