### PR TITLE
fix: item group not found error in test cases

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -4410,28 +4410,24 @@ class TestPurchaseReceipt(FrappeTestCase):
 			self.assertEqual(expected_values[gle.account][1], gle.credit)
 
 	def test_pr_ignore_pricing_rule_TC_B_050(self):
-		company = "_Test Company"
-		item_code = "Testing-31"
-		target_warehouse = "Stores - _TC"
-		supplier = "_Test Supplier 1"
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
+		get_company_supplier = create_data()
+		company = get_company_supplier.get("child_company")
+		supplier = get_company_supplier.get("supplier")
+		target_warehouse = "Stores - TC-3"
 		item_price = 130
 
-		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
-				"doctype": "Item",
-				"item_code": item_code,
-				"item_name": item_code,
-				"is_stock_item": 1,
-				"is_purchase_item": 1,
-				"is_sales_item": 0,
-				"company": company
-			}).insert()
+		item = make_test_item("test_item_1")
+		item.is_purchase_item = 1
+		item.is_sales_item = 0
+		item.save()
 
-		if not frappe.db.exists("Item Price", {"item_code": item_code, "price_list": "Standard Buying"}):
+		if not frappe.db.exists("Item Price", {"item_code": item.item_code, "price_list": "Standard Buying"}):
 			frappe.get_doc({
 				"doctype": "Item Price",
 				"price_list": "Standard Buying",
-				"item_code": item_code,
+				"item_code": item.item_code,
 				"price_list_rate": item_price
 			}).insert()
 
@@ -4443,7 +4439,7 @@ class TestPurchaseReceipt(FrappeTestCase):
 				"apply_on": "Item Code",
 				"items": [
 					{
-						"item_code": item_code
+						"item_code": item.item_code
 					}
 				],
 				"rate_or_discount": "Discount Percentage",
@@ -4460,7 +4456,7 @@ class TestPurchaseReceipt(FrappeTestCase):
 			"set_warehouse": target_warehouse,
 			"items": [
 				{
-					"item_code": item_code,
+					"item_code": item.	item_code,
 					"warehouse": target_warehouse,
 					"qty": 1
 				}
@@ -4479,21 +4475,19 @@ class TestPurchaseReceipt(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 130)
 
 	def test_pr_with_additional_discount_TC_B_056(self):
-		company = "_Test Company"
-		item_code = "Testing-31"
-		target_warehouse = "Stores - _TC"
-		supplier = "_Test Supplier 1"
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
+		get_company_supplier = create_data()
+		company = get_company_supplier.get("child_company")
+		supplier = get_company_supplier.get("supplier")
+		target_warehouse = "Stores - TC-3"
+
 		item_price = 10000
-		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
-				"doctype": "Item",
-				"item_code": item_code,
-				"item_name": item_code,
-				"is_stock_item": 1,
-				"is_purchase_item": 1,
-				"is_sales_item": 0,
-				"company": company
-			}).insert()
+		item = make_test_item("testing_item_12")
+		item.is_purchase_item = 1
+		item.is_sales_item = 0
+		item.save()
+
 		pi = frappe.get_doc({
 			"doctype": "Purchase Receipt",
 			"supplier": supplier,
@@ -4502,7 +4496,7 @@ class TestPurchaseReceipt(FrappeTestCase):
 			"set_warehouse": target_warehouse,
 			"items": [
 				{
-					"item_code": item_code,
+					"item_code": item.item_code,
 					"warehouse": target_warehouse,
 					"qty": 1,
 					"rate": item_price


### PR DESCRIPTION
**fixed item not found error(code coverage) for the followoing test cases**

TC_B_094 - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_057  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_106  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_109 - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_115  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_107  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_110  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_116  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_108  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_117  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_050  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item
TC_B_056  - issue -  frappe.exceptions.MandatoryError: [Item, test_expense]:_group item - added item group to the item


