### PR TITLE
fix: TC_SCK_072 - Validation Error

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -3942,10 +3942,10 @@ class TestPurchaseReceipt(FrappeTestCase):
 			purchase_order=po.name,
 			company=company,
 			supplier=po.supplier,
+			currency=po.currency,
 			posting_date=posting_date,
 			items=item_list
 		)
-		
 		self.assertEqual(pr.items[0].item_code, item1.name)
 		self.assertEqual(pr.items[0].qty, 150)
 		self.assertEqual(pr.items[0].warehouse, warehouse1)


### PR DESCRIPTION
test_purchase_order_and_receipt_TC_SCK_072 
fix: TC_SCK_072 - Validation Error
Incorrect value:Currency must be equal to 'USD'