### PR TITLE
Multiple pricing rule

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -3329,6 +3329,27 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		self.assertEqual(pi_status, "Paid")
 	
 	def test_pi_ignore_pricing_rule_TC_B_051(self):
+		from erpnext.accounts.doctype.pricing_rule.test_pricing_rule import make_pricing_rule
+
+		frappe.delete_doc_if_exists("Pricing Rule", "Boat Earpods - Monica Discount")
+		self.pricing_rule =make_pricing_rule(
+			apply_on="Item Code",
+			title="Boat Earpods - Monica Discount",
+			items=[{"item_code": "Boat Earpods"}],
+			supplier="Monica",
+			min_qty= 10,
+			company= "_Test Company",
+			rate_or_discount="Discount Percentage",
+			discount_percentage=10,
+			valid_from="2024-12-01",
+			selling = 0,
+			buying = 1,
+			apply_discount_on = "Rate",
+			price_or_product_discount= "Price",
+			apply_rule_on = "Transaction",
+			apply_on_transaction = "Purchase Invoice"
+		)
+
 		frappe.set_user("Administrator")
 		company = "_Test Company"
 		item_code = "Testing-31"
@@ -4046,11 +4067,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			error_msg = str(e)
 			self.assertEqual(error_msg, f'Supplier Invoice No exists in Purchase Invoice {pi.name}')
 
-	def setUp(self):
-		from erpnext.accounts.doctype.pricing_rule.test_pricing_rule import make_pricing_rule
+	def setUp(self):	
 		from erpnext.stock.doctype.item.test_item import make_item
-
-		import random
         # Ensure supplier exists
 		if not frappe.db.exists("Company", "_Test Company"):
 			company = frappe.new_doc("Company")
@@ -4076,26 +4094,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		}
 		
 		item = make_item("Boat Earpods", it_fields).name
-		
-		self.pricing_rule =make_pricing_rule(
-			apply_on="Item Code",
-			title="Boat Earpods - Monica Discount",
-			items=[{"item_code": "Boat Earpods"}],
-			supplier="Monica",
-			min_qty= 10,
-			company= "_Test Company",
-			rate_or_discount="Discount Percentage",
-			discount_percentage=10,
-			valid_from="2024-12-01",
-			selling = 0,
-			buying = 1,
-			apply_discount_on = "Rate",
-			price_or_product_discount= "Price",
-			apply_rule_on = "Transaction",
-			apply_on_transaction = "Purchase Invoice"
-		)
-		frappe.db.commit()
-		
+
+
 	def test_purchase_invoice_discount(self):
         # Create Purchase Invoice
 		pi = make_purchase_invoice(
@@ -4115,7 +4115,6 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		sle = frappe.get_all("Stock Ledger Entry", 
                              filters={"voucher_no": pi.name},
                              fields=["actual_qty", "valuation_rate", "incoming_rate", "stock_value", "stock_value_difference"])
-		print(sle[0]["actual_qty"], sle[0]["valuation_rate"], sle[0]["incoming_rate"], sle[0]["stock_value"], sle[0]["stock_value_difference"])
 		self.assertEqual(sle[0]["actual_qty"], 20)
 		self.assertEqual(sle[0]["valuation_rate"], 4500)
 

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2473,7 +2473,10 @@ class TestDeliveryNote(FrappeTestCase):
 			make_test_item
 		)
 		
-		make_test_item("_Test Item 1")
+		item= make_test_item("_Test Item 1")
+		item.is_stock_item = 1
+		item.save()
+		frappe.db.set_value("Company", "_Test Company", "stock_adjustment_account", "Stock Adjustment - _TC")
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		make_stock_entry(item_code="_Test Item 1", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		dn = create_delivery_note(qty = 5, rate = 1000)


### PR DESCRIPTION
In the **setUp** method of the test class, the creation of the Pricing Rule has been removed. Previously, every test run would create a **Pricing Rule** with identical inputs, leading to **duplicate data**.

Upon review, it was found that the Pricing Rule was used in only one test case. Therefore, instead of creating it in **setUp**, it has been moved directly into that specific test case.

Additionally, **db.commit()** was preventing automatic rollback of changes during tests, so it has been removed to ensure proper database cleanup.
![Screenshot from 2025-02-24 12-17-13](https://github.com/user-attachments/assets/968145e5-fdf2-4da4-a868-71a99ed3be3e)
 