### PR TITLE
fix: data validation errors resolved

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1597,10 +1597,10 @@ def future_sle_exists(args, sl_entries=None, allow_force_reposting=True):
 	data = frappe.db.sql(
 		"""
 		select item_code, warehouse, count(name) as total_row
-		from "tabStock Ledger Entry"
+		from `tabStock Ledger Entry`
 		where
 			({})
-			and (posting_date + posting_time::time) >= %(posting_date)s::date + %(posting_time)s::time
+			and (posting_date + posting_time) >= (CAST(%(posting_date)s AS date) + CAST(%(posting_time)s AS time))
 			and voucher_no != %(voucher_no)s
 			and is_cancelled = 0
 		GROUP BY

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -2884,7 +2884,14 @@ class TestMaterialRequest(FrappeTestCase):
 		self.assertEqual(sle.qty_after_transaction, 0)
 
 	def test_create_material_req_to_2po_to_1pr_cancel_TC_SCK_058(self):
-		mr = make_material_request()
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		create_company()
+		create_customer(name="_Test Customer")
+		create_supplier(supplier_name="_Test Supplier")
+		create_item("_Test Item",warehouse="Stores - _TC")
+		create_fiscal_with_company("_Test Company")
+		cost_center = frappe.db.get_all('Cost Center',{'company':"_Test Company",'is_group':0},"name")
+		mr = make_material_request(warehouse= 'Goods In Transit - _TC',uom = "Unit",cost_center = cost_center[0].name)
 		
 		#partially qty
 		po = make_purchase_order(mr.name)
@@ -2906,7 +2913,7 @@ class TestMaterialRequest(FrappeTestCase):
 		pr = make_purchase_receipt(po1.name, target_doc=pr)
 		pr.submit()
 		
-		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "_Test Warehouse - _TC"}, "actual_qty")
+		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "Goods In Transit - _TC"}, "actual_qty")
 		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':pr.name})
 		self.assertEqual(sle.qty_after_transaction, bin_qty)
 		self.assertEqual(sle.warehouse, mr.get("items")[0].warehouse)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -34,6 +34,8 @@ from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_i
 from erpnext.buying.doctype.supplier.test_supplier import create_supplier
 from erpnext.stock.doctype.material_request.material_request import make_purchase_order_based_on_supplier
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_customer
+
 
 class TestMaterialRequest(FrappeTestCase):
 	def test_make_purchase_order(self):
@@ -3166,7 +3168,6 @@ class TestMaterialRequest(FrappeTestCase):
 
 	def test_create_material_req_to_2po_to_1pi_TC_SCK_085(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_customer
 		create_company()
 		create_customer(name="_Test Customer")
 		create_supplier(supplier_name="_Test Supplier")
@@ -3674,7 +3675,14 @@ class TestMaterialRequest(FrappeTestCase):
 		
 
 	def test_create_material_req_to_2po_to_1pi_cancel_TC_SCK_089(self):
-		mr = make_material_request()
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		create_company()
+		create_customer(name="_Test Customer")
+		create_supplier(supplier_name="_Test Supplier")
+		create_item("_Test Item",warehouse="Stores - _TC")
+		create_fiscal_with_company("_Test Company")
+		cost_center = frappe.db.get_all('Cost Center',{'company':"_Test Company",'is_group':0},"name")
+		mr = make_material_request(warehouse= 'Goods In Transit - _TC',uom = "Unit",cost_center = cost_center[0].name)
 		
 		#partially qty
 		po = make_purchase_order(mr.name)
@@ -3915,7 +3923,14 @@ class TestMaterialRequest(FrappeTestCase):
 			self.assertEqual(gl_stock_debit, 500)
 
 	def test_create_material_req_to_2po_to_1pi_return_TC_SCK_103(self):
-		mr = make_material_request()
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		create_company()
+		create_customer(name="_Test Customer")
+		create_supplier(supplier_name="_Test Supplier")
+		create_item("_Test Item",warehouse="Stores - _TC")
+		create_fiscal_with_company("_Test Company")
+		cost_center = frappe.db.get_all('Cost Center',{'company':"_Test Company",'is_group':0},"name")
+		mr = make_material_request(warehouse= 'Goods In Transit - _TC',uom = "Unit",cost_center = cost_center[0].name)
 		
 		#partially qty
 		po = make_purchase_order(mr.name)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -3165,7 +3165,15 @@ class TestMaterialRequest(FrappeTestCase):
 			self.assertEqual(gl_stock_debit, 500)
 
 	def test_create_material_req_to_2po_to_1pi_TC_SCK_085(self):
-		mr = make_material_request()
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_customer
+		create_company()
+		create_customer(name="_Test Customer")
+		create_supplier(supplier_name="_Test Supplier")
+		create_item("_Test Item",warehouse="Stores - _TC")
+		create_fiscal_with_company("_Test Company")
+		cost_center = frappe.db.get_all('Cost Center',{'company':"_Test Company",'is_group':0},"name")
+		mr = make_material_request(warehouse= 'Goods In Transit - _TC',uom = "Unit",cost_center = cost_center[0].name)
 
 		#partially qty
 		po = make_purchase_order(mr.name)
@@ -7656,3 +7664,20 @@ def make_company(company):
 		company.company_name = company
 		company.default_currency = "INR"
 		company.insert()
+
+
+def create_fiscal_with_company(company):
+	today = date.today()
+	if today.month >= 4:  # Fiscal year starts in April
+		start_date = date(today.year, 4, 1)
+		end_date = date(today.year + 1, 3, 31)
+	else:
+		start_date = date(today.year - 1, 4, 1)
+		end_date = date(today.year, 3, 31)
+
+	fy_doc = frappe.new_doc("Fiscal Year")
+	fy_doc.year = "2025 PO"
+	fy_doc.year_start_date = start_date
+	fy_doc.year_end_date = end_date
+	fy_doc.append("companies", {"company": company})
+	fy_doc.submit()

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1063,9 +1063,9 @@ def get_item_wise_returned_qty(pr_doc):
                 pri.purchase_receipt_item,
                 SUM(ABS(pri.qty)) as qty
             FROM 
-                "tabPurchase Receipt" pr
+                `tabPurchase Receipt` pr
             INNER JOIN 
-                "tabPurchase Receipt Item" pri
+                `tabPurchase Receipt Item` pri
             ON 
                 pr.name = pri.parent
             WHERE

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -455,7 +455,7 @@ def get_items_to_be_repost(voucher_type=None, voucher_no=None, doc=None, reposti
 		items_to_be_repost = frappe.db.sql(
 			"""
 			SELECT item_code, warehouse, posting_date, posting_time, creation
-			FROM "tabStock Ledger Entry"
+			FROM `tabStock Ledger Entry`
 			WHERE voucher_type = %(voucher_type)s
 			AND voucher_no = %(voucher_no)s
 			GROUP BY item_code, warehouse, posting_date, posting_time, creation


### PR DESCRIPTION
TC_SCK_085 -->  **frappe.exceptions.LinkValidationError: Could not find Customer: _Test Customer, Company: _Test Company, Row #1: Target Warehouse: _Test Warehouse - _TC, Row #1: UOM: _Test UOM, Row #1: Cost Center: _Test Cost Center - _TC**

**Almost getting same Link validation error for all test cases in Material Request mentioned above**

TC_SCK_089

TC_SCK_103

TC_SCK_058 --->  **self.assertEqual(sle.qty_after_transaction, bin_qty)AssertionError: 10.0 != None**

TC_SCK_033

TC_SCK_036

TC_SCK_084

TC_SCK_088

TC_SCK_102

TC_SCK_040

TC_SCK_056

TC_SCK_031

TC_SCK_057 --->  **self.assertEqual(sle.qty_after_transaction, bin_qty + 5) TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'**

TC_SCK_032


