### PR TITLE
fix: MultiplePricingRuleConflict Put a validation to create Pricing rule and cleanup data after test execution

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -2364,8 +2364,9 @@ class TestPurchaseOrder(FrappeTestCase):
 			"company" : "_Test Company",
 
 		}
-		rule = frappe.get_doc(pricing_rule_record)
-		rule.insert()
+		if not frappe.db.exists('Pricing Rule', {'title': 'Discount on _Test Item'}):
+			rule = frappe.get_doc(pricing_rule_record)
+			rule.insert()
 
 		frappe.get_doc(
 			{
@@ -2388,6 +2389,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi_item = doc_pi.items[0]
 		self.assertEqual(pi_item.rate, 117)
 		self.assertEqual(pi_item.amount, 117)
+		frappe.delete_doc_if_exists("Pricing Rule", "Discount on _Test Item")
+		
+	def setUp(self):
+		validate_fiscal_year('_Test Company')
 
 	def test_po_with_pricing_rule_TC_B_047(self):
 		# Scenario : PO => Pricing Rule => PR 
@@ -2425,8 +2430,9 @@ class TestPurchaseOrder(FrappeTestCase):
 			"company" : "_Test Company",
 
 		}
-		rule = frappe.get_doc(pricing_rule_record)
-		rule.insert()
+		if not frappe.db.exists('Pricing Rule', {'title': 'Discount on _Test Item'}):
+			rule = frappe.get_doc(pricing_rule_record)
+			rule.insert()
 
 		frappe.get_doc(
 			{
@@ -2448,6 +2454,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr_item = doc_pr.items[0]
 		self.assertEqual(pr_item.rate, 117) 
 		self.assertEqual(pr_item.amount, 117)
+		frappe.delete_doc_if_exists("Pricing Rule", "Discount on _Test Item")
 
 	def test_po_additional_discount_TC_B_052(self):
 		# Scenario : PO => PR => PI [With Additional Discount]


### PR DESCRIPTION
Put a validation to create Pricing rule and clean up the data after test case execution **TC_B_046** and **TC_B_047**

On running the test cases for complete app (erpnext) we were getting MultiplePricingRuleConflict issue in multiple test cases. 

After debugging found out that these two test cases were creating similar Pricing Rules with all inputs being the same for _Test Item due to which other test cases running after in which records were generated with _Test Item and pricing rules were applicable started getting MultiplePricingRuleConflict conflict error.  ( When we run test cases for complete doctype it rollbacks the data after execution of complete test cases)

Some of the test cases were getting FiscalYearError so have called the validate_fiscal_year method on setup. 
