### PR TITLE
Fix: Renaming crm to custom_crm in import statments in erpnext app

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -6,8 +6,8 @@ import unittest
 import frappe
 
 from erpnext.accounts.doctype.tax_rule.tax_rule import ConflictingTaxRule, get_tax_template
-from crm.crm.doctype.opportunity.opportunity import make_quotation
-from crm.crm.doctype.opportunity.test_opportunity import make_opportunity
+from custom_crm.crm.doctype.opportunity.opportunity import make_quotation
+from custom_crm.crm.doctype.opportunity.test_opportunity import make_opportunity
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import  create_sales_invoice
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -340,7 +340,7 @@ erpnext.buying.RequestforQuotationController = class RequestforQuotationControll
 				__("Opportunity"),
 				function () {
 					erpnext.utils.map_current_doc({
-						method: "crm.crm.doctype.opportunity.opportunity.make_request_for_quotation",
+						method: "custom_crm.crm.doctype.opportunity.opportunity.make_request_for_quotation",
 						source_doctype: "Opportunity",
 						target: me.frm,
 						setters: {

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -107,8 +107,8 @@ class TestRequestforQuotation(FrappeTestCase):
 
 	@if_app_installed("crm")
 	def test_make_rfq_from_opportunity(self):
-		from crm.crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
-		from crm.crm.doctype.opportunity.test_opportunity import make_opportunity
+		from custom_crm.crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
+		from custom_crm.crm.doctype.opportunity.test_opportunity import make_opportunity
 		opportunity = make_opportunity(with_items=1)
 		supplier_data = get_supplier_data()
 		rfq = make_rfq(opportunity.name)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -90,7 +90,7 @@ class SellingController(StockController):
 			self.update_if_missing(party_details)
 
 		elif lead:
-			from crm.crm.doctype.lead.lead import get_lead_details
+			from custom_crm.crm.doctype.lead.lead import get_lead_details
 
 			self.update_if_missing(
 				get_lead_details(

--- a/erpnext/public/js/communication.js
+++ b/erpnext/public/js/communication.js
@@ -45,7 +45,7 @@ frappe.ui.form.on("Communication", {
 
 	make_lead_from_communication: (frm) => {
 		return frappe.call({
-			method: "crm.crm.doctype.lead.lead.make_lead_from_communication",
+			method: "custom_crm.crm.doctype.lead.lead.make_lead_from_communication",
 			args: {
 				communication: frm.doc.name,
 			},
@@ -89,7 +89,7 @@ frappe.ui.form.on("Communication", {
 			fields,
 			(data) => {
 				frappe.call({
-					method: "crm.crm.doctype.opportunity.opportunity.make_opportunity_from_communication",
+					method: "custom_crm.crm.doctype.opportunity.opportunity.make_opportunity_from_communication",
 					args: {
 						communication: frm.doc.name,
 						company: data.company,

--- a/erpnext/public/js/utils/crm_activities.js
+++ b/erpnext/public/js/utils/crm_activities.js
@@ -25,7 +25,7 @@ erpnext.utils.CRMActivities = class CRMActivities {
 
 		// open activities
 		// frappe.call({
-		// 	method: "crm.crm.utils.get_open_activities",
+		// 	method: "custom_crm.crm.utils.get_open_activities",
 		// 	args: {
 		// 		ref_doctype: this.frm.doc.doctype,
 		// 		ref_docname: this.frm.doc.name,

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -154,7 +154,7 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 				__("Opportunity"),
 				function () {
 					erpnext.utils.map_current_doc({
-						method: "crm.crm.doctype.opportunity.opportunity.make_quotation",
+						method: "custom_crm.crm.doctype.opportunity.opportunity.make_quotation",
 						source_doctype: "Opportunity",
 						target: me.frm,
 						setters: [
@@ -262,7 +262,7 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 		}
 
 		frappe.call({
-			method: "crm.crm.doctype.lead.lead.get_lead_details",
+			method: "custom_crm.crm.doctype.lead.lead.get_lead_details",
 			args: {
 				lead: this.frm.doc.party_name,
 				posting_date: this.frm.doc.transaction_date,

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -532,7 +532,7 @@ def _make_customer(source_name, ignore_permissions=False):
 
 
 def create_customer_from_lead(lead_name, ignore_permissions=False):
-	from crm.crm.doctype.lead.lead import _make_customer
+	from custom_crm.crm.doctype.lead.lead import _make_customer
 
 	customer = _make_customer(lead_name, ignore_permissions=ignore_permissions)
 	customer.flags.ignore_permissions = ignore_permissions
@@ -545,7 +545,7 @@ def create_customer_from_lead(lead_name, ignore_permissions=False):
 
 
 def create_customer_from_prospect(prospect_name, ignore_permissions=False):
-	from crm.crm.doctype.prospect.prospect import make_customer as make_customer_from_prospect
+	from custom_crm.crm.doctype.prospect.prospect import make_customer as make_customer_from_prospect
 
 	customer = make_customer_from_prospect(prospect_name)
 	customer.flags.ignore_permissions = ignore_permissions

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2683,7 +2683,7 @@ class TestDeliveryNote(FrappeTestCase):
 	def test_dn_submission_TC_SCK_148(self):
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
-		# from crm.crm.doctype.lead.lead import make_customer
+		# from custom_crm.crm.doctype.lead.lead import make_customer
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 		"""Test Purchase Receipt Creation, Submission, and Stock Ledger Update"""
 

--- a/erpnext/telephony/doctype/call_log/call_log.py
+++ b/erpnext/telephony/doctype/call_log/call_log.py
@@ -8,8 +8,8 @@ from frappe.contacts.doctype.contact.contact import get_contact_with_phone_numbe
 from frappe.core.doctype.dynamic_link.dynamic_link import deduplicate_dynamic_links
 from frappe.model.document import Document
 
-# from crm.crm.doctype.lead.lead import get_lead_with_phone_number
-# from crm.crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
+# from custom_crm.crm.doctype.lead.lead import get_lead_with_phone_number
+# from custom_crm.crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
 
 END_CALL_STATUSES = ["No Answer", "Completed", "Busy", "Failed"]
 ONGOING_CALL_STATUSES = ["Ringing", "In Progress"]

--- a/erpnext/telephony/doctype/call_log/call_log.py
+++ b/erpnext/telephony/doctype/call_log/call_log.py
@@ -8,8 +8,8 @@ from frappe.contacts.doctype.contact.contact import get_contact_with_phone_numbe
 from frappe.core.doctype.dynamic_link.dynamic_link import deduplicate_dynamic_links
 from frappe.model.document import Document
 
-# from custom_crm.crm.doctype.lead.lead import get_lead_with_phone_number
-# from custom_crm.crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
+from custom_crm.crm.doctype.lead.lead import get_lead_with_phone_number
+from custom_crm.crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
 
 END_CALL_STATUSES = ["No Answer", "Completed", "Busy", "Failed"]
 ONGOING_CALL_STATUSES = ["Ringing", "In Progress"]


### PR DESCRIPTION
Renaming the crm to custom_crm in the import statments of the erpnext Apps