### PR TITLE
fix: codecoverage gst_hsn_code issue test_purchase_receipt_with_seria…

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -4238,6 +4238,7 @@ class TestPurchaseReceipt(FrappeTestCase):
 				"item_group": "Test Item Group",
 				"is_stock_item": 1,
 				"is_purchase_item": 1,
+				"gst_hsn_code": "01011010",
 				"has_serial_no": 1,
 				"serial_no_series": "SERI-.#####",
 				"company": company


### PR DESCRIPTION
test_purchase_receipt_with_serialized_item_TC_SCK_145
frappe.exceptions.MandatoryError: HSN/SAC Code is required. Please enter a valid HSN/SAC code.
