### PR TITLE
fix: codecoverage TC_SCK_193 erpnext.stock.doctype.serial_and_batch_b…

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -6412,7 +6412,8 @@ class TestMaterialRequest(FrappeTestCase):
 
 		bin_qty = frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": "_Test Warehouse - _TC"}, "actual_qty")
 		pr = make_purchase_receipt(po.name)
-		serial_numbers = [f"test_item_00{i}" for i in range(1, int(po.get("items")[0].qty) + 1)]
+		serial_number = [f"test_item_00{i}" for i in range(1, int(po.get("items")[0].qty) + 1)]
+		serial_numbers = [i for i in serial_number if i not in frappe.db.get_all("Serial No", pluck = 'name')]
 		pr.items[0].serial_no = "\n".join(serial_numbers)
 		pr.insert()
 		pr.submit()


### PR DESCRIPTION
test_create_mr_to_2po_to_2pr_serial_return_TC_SCK_193
erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.SerialNoDuplicateError: Serial No <strong>test_item_001</strong> is already present in the warehouse <strong>_Test Warehouse - _TC</strong>.
