### PR TITLE
Fix failed test cases for account validations

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4975,8 +4975,11 @@ class TestSalesInvoice(FrappeTestCase):
 		gl_entries_dn = frappe.get_all("GL Entry", filters={"voucher_no": dn_return.name}, fields=["account", "debit", "credit"])
 		gl_debits_dn = {entry.account: entry.debit for entry in gl_entries_dn}
 		gl_credits_dn = {entry.account: entry.credit for entry in gl_entries_dn}
-		self.assertAlmostEqual(gl_credits_dn['Cost of Goods Sold - _TC'], 5000)
-		self.assertAlmostEqual(gl_debits_dn['Stock In Hand - _TC'], 5000)
+		inventory_account = frappe.db.get_value("Company", "_Test Company", "default_inventory_account")
+		expense_account = frappe.db.get_value("Company", "_Test Company", "default_expense_account")
+
+		self.assertAlmostEqual(gl_credits_dn[expense_account], 5000)
+		self.assertAlmostEqual(gl_debits_dn[inventory_account], 5000)
 
 
 		sle_dn_return = frappe.get_all(

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -5039,6 +5039,8 @@ class TestSalesInvoice(FrappeTestCase):
 		gl_credits_si = {entry.account: entry.credit for entry in gl_entries_si}
 		debtor_account = frappe.db.get_value("Company", "_Test Company", "default_receivable_account")
 		sales_account = frappe.db.get_value("Company", "_Test Company", "default_income_account")
+		inventory_account = frappe.db.get_value("Company", "_Test Company", "default_inventory_account")
+		expense_account = frappe.db.get_value("Company", "_Test Company", "default_expense_account")
 		
 		self.assertAlmostEqual(gl_debits_si[debtor_account], 15000)
 		self.assertAlmostEqual(gl_credits_si[sales_account], 15000)
@@ -5059,8 +5061,8 @@ class TestSalesInvoice(FrappeTestCase):
 		gl_entries_dn = frappe.get_all("GL Entry", filters={"voucher_no": dn_return.name}, fields=["account", "debit", "credit"])
 		gl_debits_dn = {entry.account: entry.debit for entry in gl_entries_dn}
 		gl_credits_dn = {entry.account: entry.credit for entry in gl_entries_dn}
-		self.assertAlmostEqual(gl_credits_dn['Cost of Goods Sold - _TC'], 5000)
-		self.assertAlmostEqual(gl_debits_dn['Stock In Hand - _TC'], 5000)
+		self.assertAlmostEqual(gl_credits_dn[expense_account], 5000)
+		self.assertAlmostEqual(gl_debits_dn[inventory_account], 5000)
 
 		crn = create_sales_invoice(
 			item="_Test Item Home Desktop 100",
@@ -5076,8 +5078,8 @@ class TestSalesInvoice(FrappeTestCase):
 		gl_debits_crn = {entry.account: entry.debit for entry in gl_entries_crn}
 		gl_credits_crn = {entry.account: entry.credit for entry in gl_entries_crn}
 		
-		self.assertAlmostEqual(gl_debits_crn['Sales - _TC'], 6000)
-		self.assertAlmostEqual(gl_credits_crn['Debtors - _TC'], 6000)
+		self.assertAlmostEqual(gl_debits_crn[sales_account], 6000)
+		self.assertAlmostEqual(gl_credits_crn[debtor_account], 6000)
 
 		stock_entries_crn = frappe.get_all(
 			"Stock Ledger Entry",

--- a/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
@@ -357,7 +357,10 @@ def make_blanket_order(**args):
 		},
 	)
 
+	# bypass permission checks to allow creation
+	bo.flags.ignore_permissions = True 
 	bo.insert()
+	bo.flags.ignore_permissions = True 
 	bo.submit()
 	return bo
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2522,6 +2522,13 @@ class TestStockEntry(FrappeTestCase):
 			self.assertEqual(serial['batch_no'], batch[0]['name'])
 
 	def test_stock_entry_for_multiple_items_with_serial_batch_no_TC_SCK_078(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no": 1,
@@ -2539,14 +2546,15 @@ class TestStockEntry(FrappeTestCase):
 
 		se = make_stock_entry(
 			item_code=item_1, qty=5, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt", do_not_save=True
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		se.append("items", {
 			"item_code": item_2,
 			"qty": 5,
 			"basic_rate": 150,
-			"t_warehouse": "_Test Warehouse - _TC"
+			"t_warehouse": "_Test Warehouse - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		se.save()
@@ -2577,6 +2585,13 @@ class TestStockEntry(FrappeTestCase):
 				self.assertEqual(serial['batch_no'], batch[0]['name'])
 
 	def test_stock_entry_for_multiple_items_with_batch_no_TC_SCK_079(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no": 1,
@@ -2592,14 +2607,15 @@ class TestStockEntry(FrappeTestCase):
 
 		se = make_stock_entry(
 			item_code=item_1, qty=5, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt", do_not_save=True
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		se.append("items", {
 			"item_code": item_2,
 			"qty": 5,
 			"basic_rate": 150,
-			"t_warehouse": "_Test Warehouse - _TC"
+			"t_warehouse": "_Test Warehouse - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		se.save()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2906,6 +2906,13 @@ class TestStockEntry(FrappeTestCase):
 
 	@change_settings("Stock Settings", {"use_serial_batch_fields": 0,"disable_serial_no_and_batch_selector":0,"auto_create_serial_and_batch_bundle_for_outward":0,"pick_serial_and_batch_based_on":"FIFO"})
 	def test_mt_with_different_warehouse_disable_serial_batch_no_outward_TC_SCK_119(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -2924,14 +2931,15 @@ class TestStockEntry(FrappeTestCase):
 
 		semr = make_stock_entry(
 			item_code=item_1, qty=15, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt", do_not_save=True
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semr.append("items", {
 			"item_code": item_2,
 			"qty": 15,
 			"basic_rate": 150,
-			"t_warehouse": "Stores - _TC"
+			"t_warehouse": "Stores - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		semr.save()
@@ -2939,7 +2947,7 @@ class TestStockEntry(FrappeTestCase):
 
 		semt = make_stock_entry(
 			item_code=item_1, qty=10, rate=100, source="_Test Warehouse - _TC", target = "Stores - _TC",
-			purpose="Material Transfer", do_not_save=True
+			purpose="Material Transfer", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semt.append("items", {
@@ -2947,7 +2955,8 @@ class TestStockEntry(FrappeTestCase):
 			"qty": 10,
 			"basic_rate": 150,
 			"t_warehouse": "_Test Warehouse - _TC",
-			"s_warehouse": "Stores - _TC"
+			"s_warehouse": "Stores - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		semt.save()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2871,7 +2871,17 @@ class TestStockEntry(FrappeTestCase):
 
 	@change_settings("Stock Settings", {"default_warehouse": "_Test Warehouse - _TC"})
 	def test_item_creation_TC_SCK_118(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		item_1 = create_item(item_code="_Test Item New", is_stock_item=1, opening_stock=15,valuation_rate=100)
+		item_1.get("item_defaults")[0].get("expense_account") = "Stock Adjustment - _TC"
+		item_1.save()
+		
 		stock = frappe.get_all("Stock Ledger Entry", filters={"item_code": item_1.name}, 
 							 fields=["warehouse", "actual_qty"])
 		

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2993,7 +2993,7 @@ class TestStockEntry(FrappeTestCase):
 
 		semt = make_stock_entry(
 			item_code=item_1, qty=10, rate=100, source="_Test Warehouse - _TC", target = "Stores - _TC",
-			purpose="Material Issue"
+			purpose="Material Issue", expense_account="Stock Adjustment - _TC"
 		)
 
 		sle = frappe.get_all("Stock Ledger Entry", filters={"voucher_no": semt.name}, fields=["actual_qty", "item_code"])
@@ -3005,6 +3005,13 @@ class TestStockEntry(FrappeTestCase):
 
 	@change_settings("Stock Settings", {"use_serial_batch_fields": 0,"disable_serial_no_and_batch_selector":0,"auto_create_serial_and_batch_bundle_for_outward":0,"pick_serial_and_batch_based_on":"FIFO"})
 	def test_mi_with_multiple_item_disable_batch_selector_TC_SCK_121(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -3023,14 +3030,15 @@ class TestStockEntry(FrappeTestCase):
 
 		semr = make_stock_entry(
 			item_code=item_1, qty=15, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt", do_not_save=True
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semr.append("items", {
 			"item_code": item_2,
 			"qty": 15,
 			"basic_rate": 150,
-			"t_warehouse": "Stores - _TC"
+			"t_warehouse": "Stores - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		semr.save()
@@ -3038,7 +3046,7 @@ class TestStockEntry(FrappeTestCase):
 
 		semt = make_stock_entry(
 			item_code=item_1, qty=10, rate=100, source="_Test Warehouse - _TC", target = "Stores - _TC",
-			purpose="Material Issue", do_not_save=True
+			purpose="Material Issue", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semt.append("items", {
@@ -3046,7 +3054,8 @@ class TestStockEntry(FrappeTestCase):
 			"qty": 10,
 			"basic_rate": 150,
 			"t_warehouse": "_Test Warehouse - _TC",
-			"s_warehouse": "Stores - _TC"
+			"s_warehouse": "Stores - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		semt.save()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2455,6 +2455,13 @@ class TestStockEntry(FrappeTestCase):
 		se1.submit()
 
 	def test_stock_enrty_with_batch_TC_SCK_076(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -2466,7 +2473,7 @@ class TestStockEntry(FrappeTestCase):
 			fields["gst_hsn_code"] = "01011010"
 
 		item = make_item("_Test Batch Item", properties=fields).name
-		se = make_stock_entry(item_code=item, qty=10, rate=100, target="_Test Warehouse - _TC",purpose="Material Receipt")
+		se = make_stock_entry(item_code=item, qty=10, rate=100, target="_Test Warehouse - _TC",purpose="Material Receipt", expense_account="Stock Adjustment - _TC")
 
 		batch = frappe.get_all('Batch',filters={'item': item,"reference_name":se.name},fields=['name',"batch_qty",'item',"reference_name"])
 		

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2836,6 +2836,13 @@ class TestStockEntry(FrappeTestCase):
 
 	@change_settings("Stock Settings", {"use_serial_batch_fields": 0,"disable_serial_no_and_batch_selector":0,"auto_create_serial_and_batch_bundle_for_outward":0,"pick_serial_and_batch_based_on":"FIFO"})
 	def test_mt_with_multiple_items_disable_serial_batch_no_outward_TC_SCK_117(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -2854,14 +2861,15 @@ class TestStockEntry(FrappeTestCase):
 
 		semr = make_stock_entry(
 			item_code=item_1, qty=15, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt", do_not_save=True
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semr.append("items", {
 			"item_code": item_2,
 			"qty": 15,
 			"basic_rate": 150,
-			"t_warehouse": "_Test Warehouse - _TC"
+			"t_warehouse": "_Test Warehouse - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		semr.save()
@@ -2869,7 +2877,7 @@ class TestStockEntry(FrappeTestCase):
 
 		semt = make_stock_entry(
 			item_code=item_1, qty=10, rate=100, source="_Test Warehouse - _TC", target = "Stores - _TC",
-			purpose="Material Transfer", do_not_save=True
+			purpose="Material Transfer", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semt.append("items", {
@@ -2877,7 +2885,8 @@ class TestStockEntry(FrappeTestCase):
 			"qty": 10,
 			"basic_rate": 150,
 			"t_warehouse": "Stores - _TC",
-			"s_warehouse": "_Test Warehouse - _TC"
+			"s_warehouse": "_Test Warehouse - _TC",
+			"expense_account":"Stock Adjustment - _TC"
 		})
 
 		semt.save()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2748,7 +2748,7 @@ class TestStockEntry(FrappeTestCase):
 			"item_code": item_2,
 			"qty": 15,
 			"basic_rate": 150,
-			"t_warehouse": "_Test Warehouse - _TC"
+			"t_warehouse": "_Test Warehouse - _TC",
 		})
 
 		semr.save()
@@ -2886,7 +2886,8 @@ class TestStockEntry(FrappeTestCase):
 		)
 
 		item_1 = create_item(item_code="_Test Item New", is_stock_item=1, opening_stock=15,valuation_rate=100)
-		item_1.get("item_defaults")[0].get("expense_account") = "Stock Adjustment - _TC"
+		for itm in item_1.item_defaults:
+			itm.expense_account = "Stock Adjustment - _TC"
 		item_1.save()
 		
 		stock = frappe.get_all("Stock Ledger Entry", filters={"item_code": item_1.name}, 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2964,6 +2964,13 @@ class TestStockEntry(FrappeTestCase):
 	
 	@change_settings("Stock Settings", {"use_serial_batch_fields": 0,"disable_serial_no_and_batch_selector":0,"auto_create_serial_and_batch_bundle_for_outward":0})
 	def test_mi_with_disable_batch_selector_TC_SCK_120(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -2981,7 +2988,7 @@ class TestStockEntry(FrappeTestCase):
 
 		semr = make_stock_entry(
 			item_code=item_1, qty=15, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt"
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC"
 		)
 
 		semt = make_stock_entry(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2723,6 +2723,13 @@ class TestStockEntry(FrappeTestCase):
 
 	@change_settings("Stock Settings", {"use_serial_batch_fields": 0,"disable_serial_no_and_batch_selector":0,"auto_create_serial_and_batch_bundle_for_outward":1,"pick_serial_and_batch_based_on":"FIFO"})
 	def test_material_transfer_with_disable_selector_TC_SCK_091(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -2741,7 +2748,7 @@ class TestStockEntry(FrappeTestCase):
 
 		semr = make_stock_entry(
 			item_code=item_1, qty=15, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt", do_not_save=True
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semr.append("items", {
@@ -2749,6 +2756,7 @@ class TestStockEntry(FrappeTestCase):
 			"qty": 15,
 			"basic_rate": 150,
 			"t_warehouse": "_Test Warehouse - _TC",
+			"expense_account": "Stock Adjustment - _TC",
 		})
 
 		semr.save()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2764,7 +2764,7 @@ class TestStockEntry(FrappeTestCase):
 
 		semt = make_stock_entry(
 			item_code=item_1, qty=10, rate=100, source="_Test Warehouse - _TC", target = "Stores - _TC",
-			purpose="Material Transfer", do_not_save=True
+			purpose="Material Transfer", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 
 		semt.append("items", {
@@ -2772,7 +2772,8 @@ class TestStockEntry(FrappeTestCase):
 			"qty": 10,
 			"basic_rate": 150,
 			"t_warehouse": "Stores - _TC",
-			"s_warehouse": "_Test Warehouse - _TC"
+			"s_warehouse": "_Test Warehouse - _TC",
+			"expense_account": "Stock Adjustment - _TC"
 		})
 
 		semt.save()
@@ -2789,6 +2790,13 @@ class TestStockEntry(FrappeTestCase):
 	
 	@change_settings("Stock Settings", {"use_serial_batch_fields": 0,"disable_serial_no_and_batch_selector":0,"auto_create_serial_and_batch_bundle_for_outward":0,"pick_serial_and_batch_based_on":"FIFO"})
 	def test_mt_with_disable_serial_batch_no_outward_TC_SCK_116(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -2806,14 +2814,14 @@ class TestStockEntry(FrappeTestCase):
 
 		semr = make_stock_entry(
 			item_code=item_1, qty=15, rate=100, target="_Test Warehouse - _TC",
-			purpose="Material Receipt", do_not_save=True
+			purpose="Material Receipt", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 		semr.save()
 		semr.submit()
 
 		semt = make_stock_entry(
 			item_code=item_1, qty=10, rate=100, source="_Test Warehouse - _TC", target = "Stores - _TC",
-			purpose="Material Transfer", do_not_save=True
+			purpose="Material Transfer", expense_account="Stock Adjustment - _TC", do_not_save=True
 		)
 		semt.save()
 		semt.submit()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2483,6 +2483,13 @@ class TestStockEntry(FrappeTestCase):
 		self.assertEqual(batch[0]['reference_name'], se.name)
 
 	def test_stock_enrty_with_serial_and_batch_TC_SCK_077(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		create_account(
+			account_name= "Stock Adjustment",
+			parent_account="Stock Expenses - _TC",
+			company="_Test Company",
+		)
+
 		fields = {
 			"is_stock_item": 1, 
 			"has_batch_no":1,
@@ -2496,7 +2503,7 @@ class TestStockEntry(FrappeTestCase):
 			fields["gst_hsn_code"] = "01011010"
 
 		item = make_item("_Test Batch Item", properties=fields).name
-		se = make_stock_entry(item_code=item, qty=5, rate=100, target="_Test Warehouse - _TC",purpose="Material Receipt")
+		se = make_stock_entry(item_code=item, qty=5, rate=100, target="_Test Warehouse - _TC",purpose="Material Receipt", expense_account="Stock Adjustment - _TC")
 
 		batch = frappe.get_all('Batch',filters={'item': item,"reference_name":se.name},fields=['name',"batch_qty",'item',"reference_name"])
 


### PR DESCRIPTION
**test_item_creation_TC_SCK_118** - fixed validation error of expense_account

**test_stock_enrty_with_batch_TC_SCK_076** - fixed validation error of expense_account

**test_material_transfer_with_disable_selector_TC_SCK_091** - fixed validation error of expense_account

**test_mi_with_disable_batch_selector_TC_SCK_120** - fixed validation error of expense_account

**test_mi_with_multiple_item_disable_batch_selector_TC_SCK_121** - fixed validation error of expense_account

**test_mt_with_different_warehouse_disable_serial_batch_no_outward_TC_SCK_119** - fixed validation error of expense_account

**test_mt_with_disable_serial_batch_no_outward_TC_SCK_116**- fixed validation error of expense_account

**test_mt_with_multiple_items_disable_serial_batch_no_outward_TC_SCK_117**- fixed validation error of expense_account

**test_stock_enrty_with_serial_and_batch_TC_SCK_077**- fixed validation error of expense_account

**test_stock_entry_for_multiple_items_with_serial_batch_no_TC_SCK_078**- fixed validation error of expense_account

**test_blanket_order_creating_quotation_TC_S_157** - bypass permission checks to allow creation of blanket_order

**test_sales_invoice_with_SR_and_CRN_TC_S_038** - fixed assertion error of inventory and expense account

**test_sales_invoice_with_sr_crn_and_payment_TC_S_039** - fixed assertion error of inventory and expense account