### PR TITLE
fix: alternate_item field and assertion error fixed

### DIFF
--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -1198,7 +1198,8 @@ class TestItem(FrappeTestCase):
 
 		wo.submit()
 		self.assertTrue(frappe.db.exists("Work Order", wo.name))
-		self.assertEqual(wo.alternate_item, alt_item.name, "Alternative item not found in Work Order")
+		alternate_item_in_wo = next((item.item_code for item in wo_items if item.item_code == alt_item.name), None)
+		self.assertEqual(alternate_item_in_wo, alt_item.name, "Alternative item not found in Work Order")
 
 def set_item_variant_settings(fields):
 	doc = frappe.get_doc("Item Variant Settings")


### PR DESCRIPTION
**Testcase :- test_cr_item_alternative_TC_SCK_149**

**This PR is regarding 2 different issues raised:** 
**https://github.com/8848digital/erpnext/issues/1519
https://github.com/8848digital/erpnext/issues/1470**

"Traceback (most recent call last):
  File ""/home/frappe/test-postgres/test-bench/apps/erpnext/erpnext/stock/doctype/item/test_item.py"", line 1201, in test_cr_item_alternative_TC_SCK_149
    self.assertEqual(wo.alternate_item, alt_item.name, ""Alternative item not found in Work Order"")
AttributeError: 'WorkOrder' object has no attribute 'alternate_item'"


ImportError: cannot import name 'get_qty_after_transaction' from partially initialized module 'erpnext.stock.doctype.stock_entry.test_stock_entry' (most likely due to a circular import) (/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/test_stock_entry.py)

