### PR TITLE
fix: positional argument and account type error resolved

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1327,7 +1327,7 @@ class PaymentEntry(AccountsController):
 					"Journal Entry",
 					"Payment Entry",
 				):
-					self.add_advance_gl_for_reference(gl_entries, ref, clearing_date)
+					self.add_advance_gl_for_reference(gl_entries, ref)
 
 	def get_dr_and_account_for_advances(self, reference):
 		if reference.reference_doctype == "Sales Invoice":

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1441,14 +1441,14 @@ class TestPaymentEntry(FrappeTestCase):
 			make_purchase_invoice as _make_purchase_invoice,
 		)
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
-
+		
 		company = "_Test Company"
-
+		from erpnext.accounts.doctype.account.test_account import create_account
 		advance_account = create_account(
 			parent_account="Current Liabilities - _TC",
 			account_name="Advances Paid",
 			company=company,
-			account_type="Liability",
+			account_type="Payable",
 		)
 
 		frappe.db.set_value(


### PR DESCRIPTION
test_advance_as_liability_against_order

Traceback (most recent call last):
  File "/home/frappe/test-postgres/test-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/test_payment_entry.py", line 1447, in test_advance_as_liability_against_order
    advance_account = create_account(
TypeError: create_account() got an unexpected keyword argument 'parent_account'


frappe.exceptions.Validation.Error: "Party Type and Party can only be set for Receivable / Payable account