### PR TITLE
fix: unexpected keyword argument 'parent_account'

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1727,7 +1727,7 @@ class TestPaymentEntry(FrappeTestCase):
 
 	def test_opening_flag_for_advance_as_liability(self):
 		company = "_Test Company"
-
+		from erpnext.accounts.doctype.account.test_account import create_account
 		advance_account = create_account(
 			parent_account="Current Assets - _TC",
 			account_name="Advances Received",


### PR DESCRIPTION
test_opening_flag_for_advance_as_liability


Traceback (most recent call last):
  File "/home/frappe/test-postgres/test-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/test_payment_entry.py", line 1447, in test_advance_as_liability_against_order
    advance_account = create_account(
TypeError: create_account() got an unexpected keyword argument 'parent_account'