### PR TITLE
fix: variable assignment error in TC 234,235,236

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1803,7 +1803,7 @@ class StockEntry(StockController):
 
 						item_wh = frappe._dict(item_wh)
 
-					for item in item_dict.values():
+					for original_item, item in item_dict.items():
 						if self.pro_doc and cint(self.pro_doc.from_wip_warehouse):
 							item["from_warehouse"] = self.pro_doc.wip_warehouse
 						# Get Reserve Warehouse from Subcontract Order


### PR DESCRIPTION
**test_wo_without_consum_bom_TC_SCK_234
test_wo_without_consum_bom_bth_TC_SCK_235
test_wo_without_consum_bom_bth_srl_TC_SCK_236**

getting same trackback error in all 3 test cases
File ""/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py"", line 1818, in get_items
  if original_item != item.get(""item_code""):
 **UnboundLocalError: local variable 'original_item' referenced before assignment"**
 