### PR TITLE
fix: out state category not found issue

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -3245,6 +3245,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
 		create_company()
 		company = "_Test Company"
+		if not frappe.db.exists("Tax Category", "Out-State"):
+			tax_category = frappe.new_doc("Tax Category")
+			tax_category.title = "Out-State"
+			tax_category.save()
 
 		exists_purchase_tax = frappe.db.get_value('Purchase Taxes and Charges Template',{'company':company,'tax_category':'Out-State'},'name')
 		if exists_purchase_tax is None:


### PR DESCRIPTION
Fix the Out state Tax Category Not Found issue | 
**test_outer_state_IGST_TC_B_098** : frappe.exceptions.LinkValidationError: Could not find Tax Category: Out-State

https://github.com/8848digital/erpnext/issues/1556