### PR TITLE
fix: fix the syntax issue of the query

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -32,6 +32,8 @@ from erpnext.stock.tests.test_utils import StockTestMixin
 
 class TestStockLedgerEntry(FrappeTestCase, StockTestMixin):
 	def setUp(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		create_company()
 		items = create_items()
 		reset("Stock Entry")
 
@@ -549,6 +551,10 @@ class TestStockLedgerEntry(FrappeTestCase, StockTestMixin):
 		self.assertSLEs(sr2, expected_sles)
 
 	def test_batch_wise_valuation_across_warehouse(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.selling.doctype.sales_order.test_sales_order import get_or_create_fiscal_year
+		create_company()
+		get_or_create_fiscal_year("_Test Company")
 		item_code, warehouses, batches = setup_item_valuation_test()
 		source = warehouses[0]
 		target = warehouses[1]

--- a/erpnext/stock/tests/test_utils.py
+++ b/erpnext/stock/tests/test_utils.py
@@ -24,7 +24,7 @@ class StockTestMixin:
 			"Stock Ledger Entry",
 			fields=["*"],
 			filters=filters,
-			order_by="timestamp(posting_date, posting_time), creation",
+			order_by="posting_date, posting_time, creation",
 		)
 		self.assertGreaterEqual(len(sles), len(expected_sles))
 


### PR DESCRIPTION
**_SQL Syntax error :_** 
-----------------------------------------------
**test_batch_wise_valuation_across_warehouse**
psycopg2.errors.SyntaxError: syntax error at or near "posting_date"
LINE 5: order by timestamp(posting_date, posting_time), creation
https://github.com/8848digital/erpnext/issues/1541