### PR TITLE
Fixed: Duplicate entry error

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -8095,7 +8095,7 @@ def create_fiscal_year(company=None):
 			fy_doc = frappe.get_doc("Fiscal Year",fiscal_years.get("name"))
 			if not frappe.db.exists("Fiscal Year Company", {"company": company}):
 				fy_doc.append("companies", {"company": company})
-				fy_doc.insert()
+				fy_doc.save()
 	else:
 		fy_doc = frappe.new_doc("Fiscal Year")
 		fy_doc.year = "2025 PO"

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -4446,7 +4446,7 @@ def create_fiscal_with_company(company):
 			fy_doc = frappe.get_doc("Fiscal Year",fiscal_years.get("name"))
 			if not frappe.db.exists("Fiscal Year Company", {"company": company}):
 				fy_doc.append("companies", {"company": company})
-				fy_doc.insert()
+				fy_doc.save()
 	else:
 		fy_doc = frappe.new_doc("Fiscal Year")
 		fy_doc.year = "2024-2025"


### PR DESCRIPTION
Issue - frappe.exceptions.DuplicateEntryError: ('Fiscal Year', '2025')

solution - Using save() instead of insert() because we are modifying an existing document/