### PR TITLE
fix: resolved While creating Promotional Scheme getting error frappe.exceptions.ValidationError: Value for Sales Partner cannot be a list  issue.

### DIFF
--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -343,6 +343,8 @@ def get_args_for_pricing_rule(doc):
 			for applicable_for_values in doc.get(applicable_for):
 				items.append(applicable_for_values.get(applicable_for))
 			args[d] = items
+		elif doc.meta.get_field(d) and doc.meta.get_field(d).fieldtype == "Table MultiSelect":
+			args[d] = ""
 		else:
 			args[d] = doc.get(d)
 	return args


### PR DESCRIPTION
Modified the get_args_for_pricing_rule function in the Promotional Scheme Doctype to handle table multi-select fields. If the field is multi-select, it is added as an empty string.
<img width="1470" alt="Screenshot 2025-03-21 at 12 41 17 PM" src="https://github.com/user-attachments/assets/9e8ef388-5fbb-404a-ad4d-bc87303545ae" />
