### PR TITLE
fix: issue in payment reconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -149,12 +149,10 @@ class PaymentReconciliation(Document):
 		non_reconciled_payments = sorted(
 			non_reconciled_payments, key=lambda k: k["posting_date"] or getdate(nowdate())
 		)
-
 		self.add_payment_entries(non_reconciled_payments)
 
 	def get_payment_entries(self):
 		party_account = [self.receivable_payable_account]
-
 		order_doctype = "Sales Order" if self.party_type == "Customer" else "Purchase Order"
 		condition = frappe._dict(
 			{
@@ -526,7 +524,7 @@ class PaymentReconciliation(Document):
 				reconciled_entry.append(payment_details)
 
 		if entry_list:
-			reconcile_against_document(entry_list, skip_ref_details_update_for_pe, self.dimensions, self.clearing_date)
+			reconcile_against_document(entry_list, skip_ref_details_update_for_pe, self.dimensions)
 
 		if dr_or_cr_notes:
 			reconcile_dr_cr_note(dr_or_cr_notes, self.company, self.dimensions)
@@ -765,7 +763,7 @@ class PaymentReconciliation(Document):
 		pay_rec = frappe.new_doc("Payment Reconciliation Record")
 		pay_rec.company = self.company
 		pay_rec.party_type = self.party_type
-		pay_rec.clearing_date = self.clearing_date
+		# pay_rec.clearing_date = self.clearing_date
 		pay_rec.party = self.party
 		pay_rec.receivable_payable_account = self.receivable_payable_account
 		pay_rec.default_advance_account = self.default_advance_account

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3047,7 +3047,6 @@ def get_common_query(
 		.where(payment_entry.party == party)
 		.where(payment_entry.docstatus == 1)
 	)
-
 	field = "paid_from" if payment_type == "Receive" else "paid_to"
 	q = q.select((payment_entry[f"{field}_account_currency"]).as_("currency"))
 	q = q.select(payment_entry[field])
@@ -3056,19 +3055,16 @@ def get_common_query(
 		q = q.where(
 			account_condition
 			| (
-				(payment_entry[field] == field)
+				(payment_entry[field] == default_advance_account)
 				& (payment_entry.book_advance_payments_in_separate_party_account == 1)
 			)
 		)
-
 	else:
 		q = q.where(account_condition)
-
 	if payment_type == "Receive":
 		q = q.select((payment_entry.source_exchange_rate).as_("exchange_rate"))
 	else:
 		q = q.select((payment_entry.target_exchange_rate).as_("exchange_rate"))
-
 	if condition:
 		# conditions should be built as an array and passed as Criterion
 		common_filter_conditions = []
@@ -3104,7 +3100,6 @@ def get_common_query(
 
 	q = q.orderby(payment_entry.posting_date)
 	q = q.limit(limit) if limit else q
-
 	return q
 
 


### PR DESCRIPTION
**test_advance_reverse_payment_reconciliation**

**payments child table entry was not getting, also assertion errors resolved** 

FAIL: test_advance_reverse_payment_reconciliation (erpnext.accounts.doctype.payment_entry.test_payment_entry.TestPaymentEntry)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/test_payment_entry.py", line 1698, in test_advance_reverse_payment_reconciliation
    self.check_gl_entries()
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/test_payment_entry.py", line 1529, in check_gl_entries
    self.assertEqual(gl_entries[row][field],self.expected_gle[row][field])
AssertionError: '_Test Cash - _TC' != 'Advances Received - _TC'
- _Test Cash - _TC
+ Advances Received - _TC


----------------------------------------------------------------------
Ran 1 test in 2.246s

FAILED (failures=1)



**test_ledger_entries_for_advance_as_liability**
FAIL: test_ledger_entries_for_advance_as_liability (erpnext.accounts.doctype.payment_entry.test_payment_entry.TestPaymentEntry)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/test_payment_entry.py", line 1415, in test_ledger_entries_for_advance_as_liability
    self.check_gl_entries()
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/test_payment_entry.py", line 1529, in check_gl_entries
    self.assertEqual(gl_entries[row][field],self.expected_gle[row][field])
AssertionError: '_Test Cash - _TC' != ''Advances Received - _TC'
- _Test Cash - _TC
+ 'Advances Received - _TC'


----------------------------------------------------------------------
Ran 1 test in 2.977s

FAILED (failures=1)