### PR TITLE
fix: date format issue in test_qa_for_pr_TC_SCK_159

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -8497,7 +8497,7 @@ def create_fiscal_with_company(company):
 def get_or_create_fiscal_year(company):
 	from datetime import datetime
 	current_date = datetime.today()
-	formatted_date = current_date.strftime("%m-%d-%Y")
+	formatted_date = current_date.strftime("%d-%m-%Y")
 	existing_fy = frappe.get_all(
 		"Fiscal Year",
 		filters={ 


### PR DESCRIPTION
**test_qa_for_pr_TC_SCK_159
test_qa_for_pr_out_TC_SCK_162
test_qa_for_pr_proc_TC_SCK_166**

was getting same error in all 3 TC

Traceback (most recent call last):
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py", line 509, in test_qa_for_pr_proc_TC_SCK_166
    get_or_create_fiscal_year("_Test Company")
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/buying/doctype/purchase_order/test_purchase_order.py", line 8501, in get_or_create_fiscal_year
    existing_fy = frappe.get_all(
  File "/home/aarti/postgres/frappe-bench/apps/frappe/frappe/__init__.py", line 2047, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/aarti/postgres/frappe-bench/apps/frappe/frappe/__init__.py", line 2022, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/aarti/postgres/frappe-bench/apps/frappe/frappe/model/db_query.py", line 194, in execute
    result = self.build_and_run()
  File "/home/aarti/postgres/frappe-bench/apps/frappe/frappe/model/db_query.py", line 256, in build_and_run
    return frappe.db.sql(
  File "/home/aarti/postgres/frappe-bench/apps/frappe/frappe/database/postgres/database.py", line 326, in sql
    return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
  File "/home/aarti/postgres/frappe-bench/apps/frappe/frappe/database/database.py", line 236, in sql
    self._cursor.execute(query, values)
psycopg2.errors.DatetimeFieldOverflow: date/time field value out of range: "03-25-2025"
LINE 3: ...bFiscal Year"."year_start_date", '0001-01-01') <= '03-25-202...
                                                             ^
HINT:  Perhaps you need a different "datestyle" setting.


----------------------------------------------------------------------
Ran 1 test in 1.377s

FAILED (errors=1)