### PR TITLE
fix: workstation assignment issue

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -434,19 +434,19 @@ class TestJobCard(FrappeTestCase):
 			transfer_material_against=self.transfer_material_against,
 			source_warehouse=self.source_warehouse,
 		)
-		workstation = job_card.workstation
 		self.generate_required_stock(wo)
 		job_card = frappe.get_last_doc("Job Card", {"work_order": wo.name})
 		job_card.update({"for_quantity": 4})
-		job_card.workstation = workstation
 		job_card.append(
 			"time_logs",
 			{"from_time": now(), "to_time": add_to_date(now(), hours=1), "completed_qty": 4},
 		)
 		job_card.submit()
+
 		corrective_action = frappe.get_doc(
 			doctype="Operation", is_corrective_operation=1, name=frappe.generate_hash()
 		).insert()
+
 		corrective_job_card = make_corrective_job_card(
 			job_card.name, operation=corrective_action.name, for_operation=job_card.operation
 		)
@@ -457,18 +457,59 @@ class TestJobCard(FrappeTestCase):
 			{
 				"from_time": add_to_date(now(), hours=2),
 				"to_time": add_to_date(now(), hours=2, minutes=30),
-				"completed_qty": 2,
+				"completed_qty": 4,
 			},
 		)
 		corrective_job_card.submit()
-		self.work_order.reload()
+		wo.reload()
+
 		from erpnext.manufacturing.doctype.work_order.work_order import (
 			make_stock_entry as make_stock_entry_for_wo,
 		)
-		stock_entry = make_stock_entry_for_wo(self.work_order.name, "Manufacture")
-		self.assertEqual(stock_entry.additional_costs[1].description, "Corrective Operation Cost")
-		self.assertEqual(stock_entry.additional_costs[1].amount, 50)
-		self.assertEqual(stock_entry["items"][-1].additional_cost, 6050)
+
+		stock_entry = make_stock_entry_for_wo(wo.name, "Manufacture", qty=3)
+		self.assertEqual(stock_entry.additional_costs[1].amount, 37.5)
+		frappe.get_doc(stock_entry).submit()
+
+		from erpnext.manufacturing.doctype.work_order.work_order import make_job_card
+
+		make_job_card(
+			wo.name,
+			[{"name": wo.operations[0].name, "operation": "_Test Operation 1", "qty": 3, "pending_qty": 3}],
+		)
+		workstation = job_card.workstation
+		job_card = frappe.get_last_doc("Job Card", {"work_order": wo.name})
+		job_card.update({"for_quantity": 3})
+		job_card.workstation = workstation
+		job_card.append(
+			"time_logs",
+			{
+				"from_time": add_to_date(now(), hours=3),
+				"to_time": add_to_date(now(), hours=4),
+				"completed_qty": 3,
+			},
+		)
+		job_card.submit()
+
+		corrective_job_card = make_corrective_job_card(
+			job_card.name, operation=corrective_action.name, for_operation=job_card.operation
+		)
+		corrective_job_card.hour_rate = 80
+		corrective_job_card.insert()
+		corrective_job_card.append(
+			"time_logs",
+			{
+				"from_time": add_to_date(now(), hours=4),
+				"to_time": add_to_date(now(), hours=4, minutes=30),
+				"completed_qty": 3,
+			},
+		)
+		corrective_job_card.submit()
+		wo.reload()
+
+		stock_entry = make_stock_entry_for_wo(wo.name, "Manufacture", qty=4)
+		self.assertEqual(stock_entry.additional_costs[1].amount, 52.5)
+
 
 	def test_job_card_statuses(self):
 		def assertStatus(status):


### PR DESCRIPTION
**test_if_corrective_jc_ops_cost_is_added_to_manufacture_stock_entry**


ERROR: test_if_corrective_jc_ops_cost_is_added_to_manufacture_stock_entry (erpnext.manufacturing.doctype.job_card.test_job_card.TestJobCard)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/frappe/test-postgres/test-bench/apps/erpnext/erpnext/manufacturing/doctype/job_card/test_job_card.py", line 437, in test_if_corrective_jc_ops_cost_is_added_to_manufacture_stock_entry
    workstation = job_card.workstation
UnboundLocalError: local variable 'job_card' referenced before assignment