### PR TITLE
fix: NegativeStockError and bad operand type for abs():tuple

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -413,6 +413,8 @@ def process_debit_credit_difference(gl_map):
 		make_round_off_gle(gl_map, debit_credit_diff, trx_cur_debit_credit_diff, precision)
 
 	debit_credit_diff = get_debit_credit_difference(gl_map, precision)
+	if isinstance(debit_credit_diff, tuple):
+		debit_credit_diff = debit_credit_diff[0]
 	if abs(debit_credit_diff) > allowance:
 		if not (
 			voucher_type == "Journal Entry"

--- a/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
@@ -282,9 +282,11 @@ class TestBlanketOrder(FrappeTestCase):
 
 	def test_blanket_order_to_sales_invoice_with_update_stock_TC_S_055(self):
 		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		
 		frappe.flags.args.doctype = "Sales Order"
 
-		bo = make_blanket_order(blanket_order_type="Selling",quantity=50,rate=1000)
+		bo = make_blanket_order(blanket_order_type="Selling", quantity=50, rate=1000)
 		so = make_order(bo.name)
 		so.delivery_date = add_days(nowdate(), 5)
 		so.submit()
@@ -292,8 +294,16 @@ class TestBlanketOrder(FrappeTestCase):
 		bo.reload()
 		self.assertEqual(bo.items[0].ordered_qty, 50)
 
+		make_stock_entry(
+			item_code=bo.items[0].item_code,
+			qty=50,
+			to_warehouse="_Test Warehouse - _TC", 
+			rate=1000,
+			purpose="Material Receipt"
+		)
+
 		si = make_sales_invoice(so.name)
-		si.update_stock =1
+		si.update_stock = 1
 		si.insert()
 		si.submit()
 


### PR DESCRIPTION
**test_blanket_order_to_sales_invoice_with_update_stock_TC_S_055**


erpnext.stock.stock_ledger.NegativeStockError: 40.0 units of Item _Test Item needed in Warehouse _Test Warehouse - _TC on 2025-03-24 14:57:36.148417 for Delivery Note _Test Customer to complete this transaction.


  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/accounts/general_ledger.py", line 416, in process_debit_credit_difference
    if abs(debit_credit_diff) > allowance:
TypeError: bad operand type for abs(): 'tuple'