### PR TITLE
fix: fixed fiscal year date format changed

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -5423,7 +5423,7 @@ def create_company(company):
 def get_or_create_fiscal_year(company):
 	from datetime import datetime
 	current_date = datetime.today()
-	formatted_date = current_date.strftime("%m-%d-%Y")
+	formatted_date = current_date.strftime("%d-%m-%Y")
 	existing_fy = frappe.get_all(
 		"Fiscal Year",
 		filters={ 


### PR DESCRIPTION
**test_stock_ledger_report_TC_SCK_225
test_stock_ledger_report_TC_SCK_226**

**both TC getting below error:**
psycopg2.errors.DatetimeFieldOverflow: date/time field value out of range: "03-26-2025"
LINE 3: ...bFiscal Year"."year_start_date", '0001-01-01') <= '03-26-202...
                                                             ^
HINT:  Perhaps you need a different "datestyle" setting.

