### PR TITLE
fix: fiscal year date format and assertion errors

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -4107,8 +4107,6 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		get_or_create_fiscal_year("_Test Company")
 		create_supplier(supplier_name="_Test Supplier 1")
 		warehouse = frappe.db.get_all('Warehouse',{'is_group':0,'company':'_Test Company'},['name'])
-		account = frappe.db.get_all('Account',{'company':'_Test Company'},['name'])
-		cost_center = frappe.db.get_all('Cost Center',{'company':'_Test Company'},['name'])
 		pi = make_purchase_invoice(
 			supplier="_Test Supplier 1",
 			item_code="Book",
@@ -4117,8 +4115,6 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			warehouse=warehouse[-1].name,
 			supplier_warehouse = warehouse[0].name,
 			uom = "Box",
-			expense_account = account[3].name,
-			cost_center = cost_center[1].name,
 			do_not_save=True
 		)
 		pi.due_date = today()
@@ -4133,7 +4129,7 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		)
 		self.assertEqual(len(sle), 1)
 		self.assertEqual(sle[0].item_code, "Book")
-		self.assertEqual(sle[0].warehouse, "Stores - _C")
+		self.assertEqual(sle[0].warehouse, "Stores - _TC")
 		self.assertEqual(sle[0].actual_qty, 5)
 
 		# Check Accounting Ledger Entries
@@ -4144,8 +4140,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		)
 		self.assertTrue(gl_entries)
 		expected_gl_entries = [
-			{"account": "Creditors - _C", "debit": 0, "credit": pi.grand_total},
-			{"account": "Stock In Hand - _C", "debit": pi.grand_total, "credit": 0}
+			{"account": "Creditors - _TC", "debit": 0, "credit": pi.grand_total},
+			{"account": "_Test Account Cost for Goods Sold - _TC", "debit": pi.grand_total, "credit": 0}
 		]
 		for gle in expected_gl_entries:
 			self.assertTrue(any(entry["account"] == gle["account"] and entry["debit"] == gle["debit"] and entry["credit"] == gle["credit"] for entry in gl_entries))

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -6561,7 +6561,7 @@ def make_sales_order_workflow():
 def get_or_create_fiscal_year(company):
 	from datetime import datetime
 	current_date = datetime.today()
-	formatted_date = current_date.strftime("%m-%d-%Y")
+	formatted_date = current_date.strftime("%d-%m-%Y")
 	existing_fy = frappe.get_all(
 		"Fiscal Year",
 		filters={ 

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -338,10 +338,8 @@ class TestQualityInspection(FrappeTestCase):
 		)
 		get_or_create_fiscal_year("_Test Company")
 		create_supplier(supplier_name="_Test Supplier")
-		
-		account = frappe.db.get_value('Account',{'company':'_Test Company'},'name')
-		cost_center = frappe.db.get_all('Cost Center',{'company':'_Test Company'},['name'])
-		pr = make_purchase_invoice(item_code="_Test Item with QA",uom = "Box",expense_account = account,cost_center = cost_center[1]['name'],do_not_save =True)
+
+		pr = make_purchase_invoice(item_code="_Test Item with QA",uom = "Box",do_not_save =True)
 		pr.due_date = date.today()
 		pr.save()
 		pr.submit()


### PR DESCRIPTION
**test_direct_purchase_invoice_via_update_stock_TC_SCK_131**

FAIL: test_direct_purchase_invoice_via_update_stock_TC_SCK_131 (erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice.TestPurchaseInvoice)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py", line 4136, in test_direct_purchase_invoice_via_update_stock_TC_SCK_131
    self.assertEqual(sle[0].warehouse, "Stores - _C")
AssertionError: 'Stores - _TC' != 'Stores - _C'
- Stores - _TC
?           -
+ Stores - _C


FAIL: test_direct_purchase_invoice_via_update_stock_TC_SCK_131 (erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice.TestPurchaseInvoice)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py", line 4151, in test_direct_purchase_invoice_via_update_stock_TC_SCK_131
    self.assertTrue(any(entry["account"] == gle["account"] and entry["debit"] == gle["debit"] and entry["credit"] == gle["credit"] for entry in gl_entries))
AssertionError: False is not true

----------------------------------------------------------------------
Ran 1 test in 1.693s

FAILED (failures=1)


**test_qa_for_pi_TC_SCK_160**
ERROR: test_qa_for_pi_TC_SCK_160 (erpnext.stock.doctype.quality_inspection.test_quality_inspection.TestQualityInspection)
----------------------------------------------------------------------
frappe.exceptions.ValidationError: Purchase Invoice ACC-PINV-2025-00001: Supplier is required against Payable account Debtors - _TC

----------------------------------------------------------------------
Ran 1 test in 1.184s

FAILED (errors=1)