### PR TITLE
fix: group by creation and circular import errors

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -31,10 +31,7 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 	get_serial_nos_from_bundle,
 	make_serial_batch_bundle,
 )
-from erpnext.stock.doctype.stock_entry.test_stock_entry import (
-	get_qty_after_transaction,
-	make_stock_entry,
-)
+
 from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import (
 	create_stock_reconciliation,
 )
@@ -1487,6 +1484,7 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_bin_details_of_packed_item(self):
 		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
 		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
 		# test Update Items with product bundle
 		if not frappe.db.exists("Item", "_Test Product Bundle Item New"):
@@ -1729,6 +1727,8 @@ class TestSalesInvoice(FrappeTestCase):
 		si.save()
 
 	def test_return_sales_invoice(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import get_qty_after_transaction
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		make_stock_entry(item_code="_Test Item", target="Stores - TCP1", qty=50, basic_rate=100)
 
 		actual_qty_0 = get_qty_after_transaction(item_code="_Test Item", warehouse="Stores - TCP1")
@@ -2837,6 +2837,7 @@ class TestSalesInvoice(FrappeTestCase):
 		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", old_negative_stock)
 
 	def test_sle_for_target_warehouse(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		se = make_stock_entry(
 			item_code="138-CMS Shoe",
 			target="Finished Goods - _TC",
@@ -2868,6 +2869,7 @@ class TestSalesInvoice(FrappeTestCase):
 		se.cancel()
 
 	def test_internal_transfer_gl_entry(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		si = create_sales_invoice(
 			company="_Test Company with perpetual inventory",
 			customer="_Test Internal Customer 2",
@@ -2942,6 +2944,7 @@ class TestSalesInvoice(FrappeTestCase):
 		check_gl_entries(self, target_doc.name, pi_gl_entries, add_days(nowdate(), -1))
 
 	def test_internal_transfer_gl_precision_issues(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		# Make a stock queue of an item with two valuations
 
 		# Remove all existing stock for this
@@ -4788,7 +4791,7 @@ class TestSalesInvoice(FrappeTestCase):
 	@if_app_installed("india_compliance")
 	def test_sales_invoice_with_update_stock_checked_with_gst_TC_S_017(self): 
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		create_registered_company()
 
 		if not frappe.db.exists("Warehouse", "Stores - _TIRC"):
@@ -4849,6 +4852,7 @@ class TestSalesInvoice(FrappeTestCase):
 
  
 	def test_sales_invoice_and_delivery_note_with_shipping_rule_TC_S_026(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		frappe.db.set_single_value("Selling Settings", "so_required", "No")
 		make_stock_entry(item="_Test Item Home Desktop 100", target="Stores - _TC", qty=10, rate=4000)
 
@@ -4906,6 +4910,7 @@ class TestSalesInvoice(FrappeTestCase):
 		self.assertEqual(delivery_note.sales_invoice, sales_invoice.name)
 	
 	def test_sales_invoice_with_update_stock_and_SR_TC_S_027(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		# Set up accounts if they don't exist
 		if not frappe.db.exists("Account", "Stock In Hand - _TC"):
 			frappe.get_doc({
@@ -5123,7 +5128,7 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_sales_invoice_with_sr_crn_and_payment_TC_S_039(self):
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_delivery_note
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		# Set up required accounts if they don't exist
 		required_accounts = [
 			("Stock In Hand - _TC", "Current Assets - _TC", "Stock"),
@@ -5703,7 +5708,7 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			make_test_item
 		)
-		
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		make_test_item("_Test Item 1")
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		make_stock_entry(item_code="_Test Item 1", qty=5, rate=1000, target="_Test Warehouse - _TC")
@@ -5721,7 +5726,7 @@ class TestSalesInvoice(FrappeTestCase):
 		self.assertEqual(amended_si.status, "Unpaid")
 		
 	def test_si_cancel_amend_with_customer_change_TC_S_129(self):
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		create_customer(customer_name="_Test Customer Selling",company="_Test Company")
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 
@@ -5741,6 +5746,7 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_si_cancel_amend_with_payment_terms_change_TC_S_130(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_terms_template
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		create_payment_term("Basic Amount Receivable for Selling")
 
@@ -5784,7 +5790,7 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_terms_template
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		create_payment_term("Basic Amount Receivable for Selling")
 
@@ -5833,7 +5839,7 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_si_with_deferred_revenue_item_TC_S_135(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.doctype.account.test_account import create_account
-		
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		item=make_test_item("_Test Item 1")
 		item.enable_deferred_revenue =1
 		item.no_of_months =5
@@ -5855,7 +5861,7 @@ class TestSalesInvoice(FrappeTestCase):
 
 	def test_si_with_sr_calculate_with_fixed_TC_S_139(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		shipping_rule = create_shipping_rule(
 			shipping_rule_type="Selling", 
 			shipping_rule_name="Shipping Rule - Test Fixed",
@@ -5876,7 +5882,7 @@ class TestSalesInvoice(FrappeTestCase):
 
 	def test_si_with_sr_calculate_with_net_total_TC_S_140(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		shipping_rule = create_shipping_rule(
 			shipping_rule_type="Selling", 
 			shipping_rule_name="Shipping Rule - Test Net Total",
@@ -5898,7 +5904,7 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_si_with_sr_calculate_with_net_weight_TC_S_141(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
 		shipping_rule = create_shipping_rule(
 			shipping_rule_type="Selling", 
@@ -6230,6 +6236,7 @@ class TestSalesInvoice(FrappeTestCase):
 			self.assertEqual(entry["credit"], expected_pi_entries.get(entry["account"], {}).get("credit", 0))
 
 	def test_direct_sales_invoice_via_update_stock_TC_SCK_132(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		customer = "_Test Customer"
 		warehouse = "_Test Warehouse - _TC"
 		item_code = "_Test Item"
@@ -6276,7 +6283,7 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_sales_invoice_with_child_item_rates_of_product_bundle_TC_S_152(self):
 		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
 		from erpnext.stock.doctype.item.test_item import make_item
-  
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		selling_setting = frappe.get_doc('Stock Settings')
 		selling_setting.editable_bundle_item_rates = 1
 		selling_setting.save()
@@ -6350,7 +6357,7 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_inter_company_purchase_invoice
 		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
-
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		get_required_data = create_company_and_supplier()
 
 		parent_company = get_required_data.get("parent_company")
@@ -7500,3 +7507,5 @@ def create_registered_company():
 			"company_email": "test@example.com",
 			"abbr":"_TIRC"
 		}).insert(ignore_permissions=True)
+
+

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -787,7 +787,7 @@ def get_sre_reserved_batch_nos_details(item_code: str, warehouse: str, batch_nos
 			& (sre.status.notin(["Delivered", "Cancelled"]))
 			& (sre.reservation_based_on == "Serial and Batch")
 		)
-		.groupby(sb_entry.batch_no)
+		.groupby(sb_entry.batch_no, sb_entry.creation)
 		.orderby(sb_entry.creation)
 	)
 


### PR DESCRIPTION
**test_stock_reservation_against_sales_order**

ImportError: cannot import name 'get_qty_after_transaction' from partially initialized module 'erpnext.stock.doctype.stock_entry.test_stock_entry' (most likely due to a circular import) (/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/test_stock_entry.py)


ImportError: cannot import name 'make_stock_entry' from partially initialized module 'erpnext.stock.doctype.stock_entry.test_stock_entry' (most likely due to a circular import) (/home/aarti/postgres/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/test_stock_entry.py)


psycopg2.errors.GroupingError: column "tabSerial and Batch Entry.creation" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: ...Y "tabSerial and Batch Entry"."batch_no" ORDER BY "tabSerial...
                                                             ^


----------------------------------------------------------------------
Ran 1 test in 24.784s

FAILED (errors=1)

