### PR TITLE
Fixed: test case in dn

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -52,7 +52,9 @@ class SellingController(StockController):
 		super().set_missing_values(for_validate)
 
 		# set contact and address details for customer, if they are not mentioned
-		self.set_missing_lead_customer_details(for_validate=for_validate)
+		method = getattr(self, "set_missing_lead_customer_details", None)
+		if method:
+			method(for_validate=for_validate)
 		self.set_price_list_and_item_details(for_validate=for_validate)
 
 	@if_app_installed("erpnext_crm")

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -6619,7 +6619,7 @@ def make_sales_order_workflow():
 def get_or_create_fiscal_year(company):
 	from datetime import datetime
 	current_date = datetime.today()
-	formatted_date = current_date.strftime("%d-%m-%Y")
+	formatted_date = current_date.strftime("%Y-%m-%d")
 	existing_fy = frappe.get_all(
 		"Fiscal Year",
 		filters={ 


### PR DESCRIPTION
1. **test_sales_order**  Fixed  error- 
psycopg2.errors.DatetimeFieldOverflow: date/time field value out of range: "28-03-25"
LINE 3: ...bFiscal Year"."year_start_date", '0001-01-01') <= '28-03-25'...
                                                             ^
HINT:  Perhaps you need a different "datestyle" setting.

2. **selling_controller**  Fixed  error- 
File "/home/dell/coverageissproddev/frappe-bench-postgres/apps/erpnext/erpnext/controllers/selling_controller.py", line 56, in set_missing_values
    self.set_missing_lead_customer_details(for_validate=for_validate)
TypeError: 'NoneType' object is not callable
