### PR TITLE
Fixed: multiple test cases

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -27,6 +27,7 @@ from frappe.utils import (
 )
 from pypika import Order
 from pypika.terms import ExistsCriterion
+from pypika.functions import Min
 
 import erpnext
 


### PR DESCRIPTION
**Getting common error in 414 test cases -**
Min(ple.posting_date).as_("posting_date"),
NameError: name 'Min' is not defined. Did you mean: 'min'?

solution - imported Min