### PR TITLE
Fixed: test case

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1346,6 +1346,9 @@ class AccountsController(TransactionBase):
 			party_type, party, party_account, amount_field, order_doctype, order_list, include_unallocated
 		)
 
+		if (frappe.db.db_type == 'postgres') and (include_unallocated == True or False):
+			include_unallocated = "IS NOT NULL"
+
 		payment_entries = get_advance_payment_entries_for_regional(
 			party_type,
 			party,

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -4935,7 +4935,7 @@ class TestMaterialRequest(FrappeTestCase):
 		pi.save()
 		pi.submit()
 		self.assertEqual(pi.status, "Partly Paid")
-		self.assertEqual(pi.outstanding_amount, 8160)
+		self.assertEqual(pi.outstanding_amount, pi.base_grand_total - 6000)
 		doc_po.reload()
 		pr.reload()
 		self.assertEqual(doc_po.status, "Completed")


### PR DESCRIPTION
1. Error-
psycopg2.errors.UndefinedFunction: operator does not exist: character varying = boolean
LINE 1: ...Creditors - _TC') OR ("tabPayment Entry"."paid_to"=true AND ...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.

Solution - Using "IS NOT NULL" because PostgreSQL cannot compare a string (VARCHAR) with a boolean (TRUE or FALSE).

2. Fixed Assertion error.
