### PR TITLE
Fixed: ModuleNotFoundError

### DIFF
--- a/erpnext/telephony/doctype/call_log/call_log.py
+++ b/erpnext/telephony/doctype/call_log/call_log.py
@@ -46,7 +46,7 @@ class CallLog(Document):
 		deduplicate_dynamic_links(self)
 
 
-	@if_app_installed("custom_crm")
+	@if_app_installed("erpnext_crm")
 	def before_insert(self):
 		from erpnext_crm.erpnext_crm.doctype.lead.lead import get_lead_with_phone_number
 		from erpnext_crm.erpnext_crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
@@ -95,6 +95,7 @@ class CallLog(Document):
 	def add_link(self, link_type, link_name):
 		self.append("links", {"link_doctype": link_type, "link_name": link_name})
 
+	@if_app_installed("erpnext_crm")
 	def trigger_call_popup(self):
 		from erpnext_crm.erpnext_crm.doctype.utils import get_scheduled_employees_for_popup
 		if not self.is_incoming_call():
@@ -135,6 +136,7 @@ def add_call_summary_and_call_type(call_log, summary, call_type):
 	doc.save()
 	doc.add_comment("Comment", frappe.bold(_("Call Summary")) + "<br><br>" + summary)
 
+@if_app_installed("erpnext_crm")
 def get_employees_with_number(number):
 	from erpnext_crm.erpnext_crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
 	number = strip_number(number)
@@ -155,6 +157,7 @@ def get_employees_with_number(number):
 
 	return employee_doc_name_and_emails
 
+@if_app_installed("erpnext_crm")
 def link_existing_conversations(doc, state):
 	from erpnext_crm.erpnext_crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
 	"""


### PR DESCRIPTION
Fixed error -
from erpnext_crm.erpnext_crm.doctype.utils import get_scheduled_employees_for_popup, strip_number
ModuleNotFoundError: No module named 'erpnext_crm'