### PR TITLE
fix: Pricing Rule | test_pricing_rule_for_product_free_item_rounded_qty_and_recursion | self.assertEqual(len(so.items), 1) AssertionError: 2 != #2060

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1184,6 +1184,7 @@ class TestPricingRule(FrappeTestCase):
 		so = make_sales_order(item_code="_Test Item", qty=5, do_not_submit=1)
 		so.items[0].qty = 1
 		del so.items[-1]
+		so.set_missing_values()
 		so.save()
 		self.assertEqual(len(so.items), 1)
 


### PR DESCRIPTION
Pricing Rule | test_pricing_rule_for_product_free_item_rounded_qty_and_recursion | self.assertEqual(len(so.items), 1) AssertionError: 2 != #2060