### PR TITLE
fix: fix issue no 1994

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -123,7 +123,7 @@ class BankTransaction(Document):
 		self.set_status()
 
 	def before_save(self):
-		if self.deposit > 0 and self.withdrawal == 0:
+		if self.deposit or 0 > 0 and self.withdrawal == 0:
 			if frappe.db.exists("Bank Transaction", {'date':self.date, 'deposit':self.deposit, 'reference_number': self.reference_number, 'description': self.description, 'docstatus':1}) :
 				frappe.throw("Entry already exists")
 		elif self.deposit == 0 and self.withdrawal > 0:


### PR DESCRIPTION
**_Bank Transaction Issue_**
---------------------------------------------

File "apps/erpnext/erpnext/accounts/doctype/bank_transaction/bank_transaction.py", line 126, in before_save
    if self.deposit > 0 and self.withdrawal == 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'