### PR TITLE
fix: fixed standard failed test case

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
@@ -42,6 +42,7 @@ class TestExchangeRateRevaluation(AccountsTestMixin, FrappeTestCase):
 		"""
 		Test Forex account balance and Journal creation post Revaluation
 		"""
+		frappe.db.set_value("Customer", self.customer, "default_currency", "USD")
 		si = create_sales_invoice(
 			item=self.item,
 			company=self.company,


### PR DESCRIPTION
**test_01_revaluation_of_forex_balance** - fix - frappe.exceptions.ValidationError: Party Account Debtors USD - _TC currency (USD) and document currency (INR) should be the same
