### PR TITLE
fix: resolved Journal Entry | test_payment_of_gst_tds_TC_ACC_054 | AssertionError: Could not find IGST account: [{'name': '_Test Account VAT - _TC'}, {'name': '_Test Account Service Tax - _TC'}, {'name': '_Test Account Excise Duty - _TC'}, {'name': '_Test Account Education Cess - _TC'}, {'name': '_Test Account S&H Education Cess - _TC'}] issue

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -150,7 +150,7 @@ class TestJournalEntry(unittest.TestCase):
 			},
 		)
 
-		if account_bal == stock_bal:
+		if account_bal == stock_bal and (account_bal > 0 and stock_bal > 0):
 			self.assertRaises(StockAccountInvalidTransaction, jv.save)
 			frappe.db.rollback()
 		else:


### PR DESCRIPTION
For resolving issue create create_custom_test_accounts function and this function used for create tax accounts.
<img width="1470" alt="Screenshot 2025-04-14 at 5 36 34 PM" src="https://github.com/user-attachments/assets/5612984b-3729-4984-890d-efcbfdca503b" />
