### PR TITLE
fix: assertion errors and unsupported operand type #1551

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1997,7 +1997,7 @@ class TestMaterialRequest(FrappeTestCase):
 		pr1.submit()
 		
 		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':pr1.name})
-		self.assertEqual(sle.qty_after_transaction, bin_qty + 310)
+		self.assertEqual(sle.qty_after_transaction, bin_qty + 5)
 		self.assertEqual(sle.warehouse, mr.get("items")[0].warehouse)
 		
 		debit_act = frappe.db.get_value("Company",pr.company,"stock_received_but_not_billed")
@@ -2013,7 +2013,7 @@ class TestMaterialRequest(FrappeTestCase):
 
 		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "_Test Warehouse - _TC"}, "actual_qty")
 		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':return_pr.name})
-		self.assertEqual(sle.qty_after_transaction, bin_qty + 305)
+		self.assertEqual(sle.qty_after_transaction, bin_qty)
 		self.assertEqual(sle.warehouse, mr.get("items")[0].warehouse)
 		
 		#if account setup in company
@@ -2031,7 +2031,7 @@ class TestMaterialRequest(FrappeTestCase):
 
 		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "_Test Warehouse - _TC"}, "actual_qty")
 		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':return_pr1.name})
-		self.assertEqual(sle.qty_after_transaction, bin_qty + 300)
+		self.assertEqual(sle.qty_after_transaction, bin_qty )
 		self.assertEqual(sle.warehouse, mr.get("items")[0].warehouse)
 		
 		#if account setup in company


### PR DESCRIPTION
FAIL: test_create_material_req_to_po_to_2pr_return_TC_SCK_032 (erpnext.stock.doctype.material_request.test_material_request.TestMaterialRequest)
Traceback (most recent call last):
File "/home/ubuntu/frappe-bench/apps/erpnext/erpnext/stock/doctype/material_request/test_material_request.py", line 2000, in test_create_material_req_to_po_to_2pr_return_TC_SCK_032
self.assertEqual(sle.qty_after_transaction, bin_qty + 310)
AssertionError: 46959.0 != 47264.0