### PR TITLE
fix: name 'make_test_item' is not defined

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -3071,6 +3071,7 @@ class TestMaterialRequest(FrappeTestCase):
 			self.assertEqual(gl_stock_debit, 1000)
 
 	def test_mr_po_2pi_TC_SCK_083(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		# MR =>  PO => 2PI
 		item = make_test_item("_test_item_1")
 		mr_dict_list = [{


### PR DESCRIPTION
TC_SCK_083 failed
NameError: name 'make_test_item' is not defined