### PR TITLE
Fix:Isusue with valuation rate as None

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1838,8 +1838,8 @@ def get_valuation_rate(
 			)
 
 	if (
-		not allow_zero_rate
-		and not valuation_rate
+		(valuation_rate is None or flt(valuation_rate) == 0)
+		and not cint(allow_zero_rate)
 		and raise_error_if_no_rate
 		and cint(erpnext.is_perpetual_inventory_enabled(company))
 	):


### PR DESCRIPTION
Fix: Issue with the valuation_rate as None or assigning it has 0
Due to this it was not raising any error in assertRaises on stock entry save

Method name: test_valuation_rate_missing_on_make_stock_entry 