### PR TITLE
fix: fix the fiscal year issue of the sales order tc

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -4459,6 +4459,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 	@if_app_installed("india_compliance")
 	def test_sales_order_creating_si_with_product_bundle_and_gst_rule_TC_S_059(self):
 		create_test_warehouse(name= "Stores - _TIRC", warehouse_name="Stores", company="_Test Indian Registered Company")
+		get_or_create_fiscal_year("_Test Indian Registered Company")
 		make_item("_Test Item", {"is_stock_item": 1})
 		product_bundle = make_item("_Test Product Bundle", {"is_stock_item": 0})
 		make_item("_Test Bundle Item 1", {"is_stock_item": 1})
@@ -4688,6 +4689,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 	@if_app_installed("india_compliance")
 	@change_settings("Stock Settings", {"enable_stock_reservation": 1})
 	def test_sales_order_for_stock_reservation_with_gst_TC_S_065(self):
+		get_or_create_fiscal_year("_Test Indian Registered Company")
 		create_test_warehouse(name= "Stores - _TIRC", warehouse_name="Stores", company="_Test Indian Registered Company")
 
 		if not frappe.db.exists("Company", "_Test Indian Registered Company"):
@@ -6009,6 +6011,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 
 	def create_and_submit_sales_order_with_gst(self, item_code, qty=None, rate=None):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_registered_company
+		get_or_create_fiscal_year("_Test Indian Registered Company")
 		create_registered_company()
 		create_test_warehouse(name= "Stores - _TIRC", warehouse_name="Stores", company="_Test Indian Registered Company")
 		make_item("_Test Item", {"is_stock_item": 1})


### PR DESCRIPTION
**_Fix the Fiscal year Issue of the Sales Order Test Cases_** 
---------------

raise FiscalYearError(error_msg)
erpnext.accounts.utils.FiscalYearError: Date 04-10-2025 is not in any active Fiscal Year for _Test Indian Registered Company"

**TC_S_014 , TC_S_015 , TC_S_043 , TC_S_042 , TC_S_062 , TC_S_059 ,TC_S_094 ,TC_S_020 ,TC_S_065 ,TC_S_011 ,TC_S_012 ,TC_S_013 ,TC_S_019 ,TC_S_018** 