### PR TITLE
fix: resolved frappe.exceptions.ValidationError: Party Account Creditors - _CM currency (INR) and document currency (USD) should be same issue

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -5500,7 +5500,7 @@ class TestMaterialRequest(FrappeTestCase):
 	def test_mr_to_2po_to_2pi_sr_partail_return_TC_SCK_114(self):
 		create_company()
 		create_fiscal_year()
-		supplier = create_supplier(supplier_name="_Test Supplier MR")
+		supplier = create_supplier(supplier_name="_Test Supplier MR",default_currency="INR")
 		warehouse = create_warehouse("_Test warehouse PO", company="_Test Company MR")
 		item = item_create("_Test MR")
 		cost_center = frappe.db.get_value("Company","_Test Company MR","cost_center")


### PR DESCRIPTION
For fixing issue added the default currency for supplier during creation in test_mr_to_2po_to_2pi_sr_partail_return_TC_SCK_114 test case
<img width="1449" alt="Screenshot 2025-04-17 at 10 21 58 AM" src="https://github.com/user-attachments/assets/8083593b-87b9-4d43-a018-e68e291ea3e1" />
 