### PR TITLE
fix: resolved Error in test cases (code coverage): Date 03-10-2025 is not in any active Fiscal Year issue

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2428,7 +2428,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 	def test_purchase_invoice_payment_and_cancel_invoice_TC_ACC_019(self):
 		"""Test payment against Purchase Invoices with advance adjustment."""
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		today = nowdate()
 		# Step 1: Create and Submit the First Purchase Invoice
 		first_purchase_invoice = make_purchase_invoice(
@@ -2527,6 +2528,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		
 	def test_tax_withholding_with_supplier_TC_ACC_023(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (create_records as records_for_pi,create_purchase_invoice,make_test_item)
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		records_for_pi('_Test Supplier TDS')
 		supplier=frappe.get_doc("Supplier","_Test Supplier TDS")
 		if supplier:
@@ -2890,7 +2893,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			make_test_item,
 		)
 		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		records_for_pi('_Test Supplier')
 
 		supplier = frappe.get_doc('Supplier', '_Test Supplier')
@@ -2942,8 +2946,9 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			create_purchase_invoice,
 			make_test_item,
 		)
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
-
+		get_or_create_fiscal_year("_Test Company")
 		records_for_pi('_Test Supplier')
 
 		supplier = frappe.get_doc('Supplier', '_Test Supplier')
@@ -3663,6 +3668,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 	def test_standalone_pi_is_fully_paid_TC_B_088(self):
 		frappe.set_user("Administrator")
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		purchase_tax = frappe.new_doc("Purchase Taxes and Charges Template")
 		purchase_tax.title = "TEST"
 		purchase_tax.company = "_Test Company"
@@ -3703,6 +3710,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 	
 	def test_standalone_pi_is_partly_paid_TC_B_090(self):
 		frappe.set_user("Administrator")
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		purchase_tax = frappe.new_doc("Purchase Taxes and Charges Template")
 		purchase_tax.title = "TEST"
 		purchase_tax.company = "_Test Company"
@@ -3742,6 +3751,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		self.assertEqual(pi_status, "Partly Paid")
 
 	def test_pi_with_additional_discount_TC_B_054(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		pi_data = {
 			"company" : "_Test Company",
 			"item_code" : "_Test Item",
@@ -3782,6 +3793,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		self.assertEqual(pi_total, 10080) 
 
 	def test_pi_with_additional_discount_TC_B_060(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		# Scenario : PI [With Additional Discount on Grand Total][StandAlone]	
 		pi_data = {
 			"company" : "_Test Company",
@@ -3825,7 +3838,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 	@if_app_installed("india_compliance")
 	def test_pi_standalone_pi_with_deferred_expense_TC_B_095(self):
 		gst_hsn_code = "11112222"
-	
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		if not frappe.db.exists("GST HSN Code", gst_hsn_code):
 			gst_hsn_doc = frappe.new_doc("GST HSN Code")
 			gst_hsn_doc.hsn_code = gst_hsn_code
@@ -4090,6 +4104,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			make_test_item
 		)
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		update_repost_settings()
 		company = "_Test Company"
 		item=make_test_item("_Test Item")
@@ -4126,6 +4142,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		from erpnext.buying.doctype.purchase_order.purchase_order import (
 			make_purchase_invoice as make_pi_from_po,
 		)
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		account_setting=frappe.get_doc("Accounts Settings")
 		account_setting.db_set("over_billing_allowance", 10)
 		account_setting.save()
@@ -4360,7 +4378,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 	def test_supplier_invoice_number_uniqueness_validation_TC_ACC_136(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		account_setting=frappe.get_doc("Accounts Settings")
 		account_setting.check_supplier_invoice_uniqueness=1
 		account_setting.save()
@@ -4597,6 +4616,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			make_test_item
 		)
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		if not frappe.db.exists("Payment Term","_Test Discount Term"):
 			pt = frappe.get_doc({
 				"doctype":"Payment Term",
@@ -4645,6 +4666,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			make_test_item
 		)
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		if not frappe.db.exists("Payment Term","_Test partially Discount Term"):
 			pt = frappe.get_doc({
 				"doctype":"Payment Term",		
@@ -4696,7 +4719,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 	def test_stop_pi_creation_when_value_exceeds_budget_TC_ACC_133(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.utils import get_fiscal_year
-		
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		year = get_fiscal_year(date=nowdate(), company="_Test Company")[0]
 		company = frappe.get_doc("Company","_Test Company")
 		if company.stock_received_but_not_billed !="Cost of Goods Sold - _TC":
@@ -4752,7 +4776,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 	def test_warn_pi_creation_when_value_exceeds_budget_TC_ACC_145(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.utils import get_fiscal_year
-		
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		year = get_fiscal_year(date=nowdate(), company="_Test Company")[0]
 		company = frappe.get_doc("Company","_Test Company")
 		if company.stock_received_but_not_billed !="Cost of Goods Sold - _TC":

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4231,6 +4231,8 @@ class TestSalesInvoice(FrappeTestCase):
 		self.assertEqual(expected, actual)
   
 	def test_sales_invoice_without_sales_order_TC_S_006(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		setting = frappe.get_doc("Selling Settings")
 		setting.so_required = 'No'
 		setting.save()
@@ -4262,6 +4264,8 @@ class TestSalesInvoice(FrappeTestCase):
 		self.assertEqual(qty_change, -5)
 
 	def test_sales_invoice_with_update_stock_checked_TC_S_007(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		si = create_sales_invoice(cost_center='Main - _TC', selling_price_list='Standard Selling', income_account='Sales - _TC', expense_account='Cost of Goods Sold - _TC',
 							debit_to='Debtors - _TC', qty=5, rate=3000, do_not_save=True)
 		si.update_stock = 1
@@ -4283,7 +4287,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import get_jv_entry_account
-		
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_cost_center(
 			cost_center_name="_Test Cost Center",
 			company="_Test Company",
@@ -4374,7 +4379,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item,create_payment_entry
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import get_jv_entry_account 
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_cost_center(
 			cost_center_name="_Test Cost Center",
 			company="_Test Company",
@@ -4489,7 +4495,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		setup_bank_accounts()
   
 		create_cost_center(
@@ -4582,7 +4589,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		setup_bank_accounts()
   
 		create_cost_center(
@@ -4841,6 +4849,8 @@ class TestSalesInvoice(FrappeTestCase):
  
 	def test_sales_invoice_and_delivery_note_with_shipping_rule_TC_S_026(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value("Selling Settings", "so_required", "No")
 		make_stock_entry(item="_Test Item Home Desktop 100", target="Stores - _TC", qty=10, rate=4000)
 
@@ -5003,7 +5013,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		# Enable perpetual inventory and set up accounts
 		frappe.db.set_value("Company", "_Test Company", "enable_perpetual_inventory", 1)
 		
@@ -5118,6 +5129,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_delivery_note
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		# Set up required accounts if they don't exist
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		required_accounts = [
 			("Stock In Hand - _TC", "Current Assets - _TC", "Stock"),
 			("Cost of Goods Sold - _TC", "Cost of Goods Sold - _TC", "Cost of Goods Sold"),
@@ -5223,7 +5236,8 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_deferred_revenue_invoice_line_item_TC_ACC_039(self):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
   
 		create_cost_center(
 			cost_center_name="_Test Cost Center",
@@ -5301,7 +5315,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.stock.get_item_details import calculate_service_end_date
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_cost_center(
 			cost_center_name="_Test Cost Center",
 			company="_Test Company",
@@ -5419,7 +5434,8 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_repost_account_ledger_for_si_TC_ACC_118(self):
 		from erpnext.accounts.doctype.repost_accounting_ledger.test_repost_accounting_ledger import update_repost_settings
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		update_repost_settings()
 		company = "_Test Company"
 		item = make_test_item(item_name="_Test Item")
@@ -5528,6 +5544,8 @@ class TestSalesInvoice(FrappeTestCase):
 
 	def test_create_sales_invoice_for_interstate_branch_transfer_TC_ACC_123(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		internal_customer=frappe.get_value("Customer",{"is_internal_customer":1,"represents_company":"_Test Company"})
 		if not internal_customer:
 			customer = frappe.get_doc({
@@ -5629,7 +5647,8 @@ class TestSalesInvoice(FrappeTestCase):
 			make_test_item,
 			create_supplier,
 		)
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		selling_setting = frappe.get_doc("Selling Settings")
 		selling_setting.validate_selling_price = 1
 		selling_setting.save()
@@ -5671,6 +5690,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			make_test_item
 		)
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		si_name = None
 		pe_name = None
 		account_setting = frappe.get_doc("Accounts Settings")
@@ -5701,6 +5722,8 @@ class TestSalesInvoice(FrappeTestCase):
 			make_test_item
 		)
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		make_test_item("_Test Item 1")
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		make_stock_entry(item_code="_Test Item 1", qty=5, rate=1000, target="_Test Warehouse - _TC")
@@ -5719,6 +5742,8 @@ class TestSalesInvoice(FrappeTestCase):
 		
 	def test_si_cancel_amend_with_customer_change_TC_S_129(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_customer(customer_name="_Test Customer Selling",company="_Test Company")
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 
@@ -5739,6 +5764,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_terms_template
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		create_payment_term("Basic Amount Receivable for Selling")
 
@@ -5783,6 +5810,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		make_stock_entry(item_code="_Test Item", qty=5, rate=1000, target="_Test Warehouse - _TC")
 		create_payment_term("Basic Amount Receivable for Selling")
 
@@ -5832,6 +5861,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.doctype.account.test_account import create_account
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		item=make_test_item("_Test Item 1")
 		item.enable_deferred_revenue =1
 		item.no_of_months =5
@@ -5854,6 +5885,8 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_si_with_sr_calculate_with_fixed_TC_S_139(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		shipping_rule = create_shipping_rule(
 			shipping_rule_type="Selling", 
 			shipping_rule_name="Shipping Rule - Test Fixed",
@@ -5875,6 +5908,8 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_si_with_sr_calculate_with_net_total_TC_S_140(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		shipping_rule = create_shipping_rule(
 			shipping_rule_type="Selling", 
 			shipping_rule_name="Shipping Rule - Test Net Total",
@@ -5897,7 +5932,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		shipping_rule = create_shipping_rule(
 			shipping_rule_type="Selling", 
 			shipping_rule_name="Shipping Rule - Test Net Weight",
@@ -6229,6 +6265,8 @@ class TestSalesInvoice(FrappeTestCase):
 
 	def test_direct_sales_invoice_via_update_stock_TC_SCK_132(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		customer = "_Test Customer"
 		warehouse = "_Test Warehouse - _TC"
 		item_code = "_Test Item"
@@ -6276,6 +6314,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
 		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		selling_setting = frappe.get_doc('Stock Settings')
 		selling_setting.editable_bundle_item_rates = 1
 		selling_setting.save()
@@ -6309,7 +6349,8 @@ class TestSalesInvoice(FrappeTestCase):
   
 	def test_sales_invoice_creating_dunning_from_si_TC_S_154(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-  
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		item = make_test_item("_Test Item")
 		si = create_sales_invoice(
 				customer="_Test Customer",
@@ -6608,6 +6649,8 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.utils import get_fiscal_year
 		from frappe.tests.utils import if_app_installed
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		fiscal_year = get_fiscal_year(nowdate())[0]
 		if if_app_installed("Sales Commission"):
 			if not frappe.db.exists("Monthly Distribution", "_Test Sales Distribution"):
@@ -6657,7 +6700,8 @@ class TestSalesInvoice(FrappeTestCase):
    
 	def test_payment_term_discount_for_si_at_fully_paid_TC_ACC_097(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		if not frappe.db.exists("Payment Term","_Test Discount Term"):
 			pt = frappe.get_doc({
 				"doctype":"Payment Term",
@@ -6702,7 +6746,8 @@ class TestSalesInvoice(FrappeTestCase):
   
 	def test_payment_term_discount_for_si_at_partially_paid_TC_ACC_099(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		if not frappe.db.exists("Payment Term","_Test partially Discount Term"):
 			pt = frappe.get_doc({
 				"doctype":"Payment Term",
@@ -6752,7 +6797,8 @@ class TestSalesInvoice(FrappeTestCase):
 			create_account
 		)
 		from erpnext.accounts.doctype.tax_withholding_category.test_tax_withholding_category import create_tax_withholding_category
-  
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_account()
 
 		create_tax_withholding_category(

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -549,7 +549,8 @@ class TestSubscription(FrappeTestCase):
     
 	def test_subscription_plan_with_template_for_pi_TC_ACC_086(self):
 		create_plan(plan_name="_Test Plan For PI", cost=900, currency="INR")
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		subscription = create_subscription(
 			start_date=nowdate(),
 			party_type="Supplier",
@@ -569,7 +570,8 @@ class TestSubscription(FrappeTestCase):
 		
 	def test_subscription_plan_with_template_for_si_TC_ACC_087(self):
 		create_plan(plan_name="_Test Plan For SI", cost=900, currency="INR")
-
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		subscription = create_subscription(
 			start_date=nowdate(),
 			party_type="Customer",

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -296,6 +296,8 @@ class TestTaxRule(unittest.TestCase):
 		self.assertTrue(len(quotation.taxes) > 0)
 
 	def test_create_tax_rule_and_apply_to_sales_invoice_TC_ACC_101(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		# Step 1: Create a tax rule for a customer with a sales tax template
 		make_tax_rule(
 			customer="_Test Customer",
@@ -320,6 +322,8 @@ class TestTaxRule(unittest.TestCase):
 	
 	def test_create_tax_rule_and_apply_to_purchase_invoice_TC_ACC_102(self):
 		# Step 1: Create a tax rule for a supplier with a sales tax template
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		if frappe.db.exists("Purchase Taxes and Charges Template", "GST 1 - _TC"):
 			existing_templates = "GST 1 - _TC"
 		else:

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -4137,6 +4137,8 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(sle.qty_after_transaction, 2)
 
 	def test_create_po_pr_return_pr_TC_SCK_178(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_company()
 		get_or_create_fiscal_year('_Test Company PO')
 		supplier = create_supplier(supplier_name="_Test Supplier PO")

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -4788,6 +4788,8 @@ class TestMaterialRequest(FrappeTestCase):
 			self.assertEqual(creditors_credit, 1000)
 
 	def test_create_material_req_to_2po_to_pi_serial_TC_SCK_096(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_company()
 		create_fiscal_year()
 		supplier = create_supplier(supplier_name="_Test Supplier MR")
@@ -5023,6 +5025,8 @@ class TestMaterialRequest(FrappeTestCase):
 		self.assertEqual(gl_stock_debit, 100)
 
 	def test_create_mr_to_2po_to_1pi_serial_cancel_TC_SCK_099(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_company()
 		create_fiscal_year()
 		supplier = create_supplier(supplier_name="_Test Supplier MR")
@@ -5308,6 +5312,8 @@ class TestMaterialRequest(FrappeTestCase):
 		self.assertEqual(gl_stock_debit, 100)
 
 	def test_create_mr_to_2po_to_1pi_serial_return_TC_SCK_111(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_company()
 		create_fiscal_year()
 		supplier = create_supplier(supplier_name="_Test Supplier MR")
@@ -5573,6 +5579,8 @@ class TestMaterialRequest(FrappeTestCase):
 		self.assertEqual(gl_stock_debit, 100)
 
 	def test_create_mr_to_2po_to_1pi_sr_prtl_ret_TC_SCK_115(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		get_or_create_fiscal_year("_Test Company")
 		create_company()
 		create_fiscal_year()
 		supplier = create_supplier(supplier_name="_Test Supplier MR")

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -5500,7 +5500,7 @@ class TestMaterialRequest(FrappeTestCase):
 	def test_mr_to_2po_to_2pi_sr_partail_return_TC_SCK_114(self):
 		create_company()
 		create_fiscal_year()
-		supplier = create_supplier(supplier_name="_Test Supplier MR")
+		supplier = create_supplier(supplier_name="_Test Supplier MR",default_currency="INR")
 		warehouse = create_warehouse("_Test warehouse PO", company="_Test Company MR")
 		item = item_create("_Test MR")
 		cost_center = frappe.db.get_value("Company","_Test Company MR","cost_center")

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -444,6 +444,15 @@ class TestStockEntry(FrappeTestCase):
 		self.assertFalse(gl_entries)
 
 	def test_repack_with_additional_costs(self):
+		from erpnext.stock.doctype.item.test_item import create_item
+		create_item("_Test Item")
+		create_item("_Test Item Home Desktop 100")
+		test_records = frappe.get_test_records("Company")
+		test_records = test_records[2:]
+		for rec in test_records:
+			if not frappe.db.exists("Company", rec.get("company_name")):
+				rec["doctype"] = "Company"
+				frappe.get_doc(rec).insert()
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
 		create_fiscal_with_company(company)
 		make_stock_entry(


### PR DESCRIPTION
For fixing issue adding get_or_create_ficcal_year function for each test cases for avoid validation issue. the function added below test cases:
test cases name:-
test_multi_payment_request_for_purchase_invoice_TC_ACC_036
test_over_billing_allowance_TC_ACC_119
test_partly_paid_of_pi_to_pr_to_pe_TC_B_081
test_partly_paid_of_pi_to_pr_to_pe_with_gst_TC_B_083
test_payment_term_discount_for_pi_at_fully_paid_TC_ACC_098
test_payment_term_discount_for_pi_at_partially_paid_TC_ACC_100
test_pi_standalone_pi_with_deferred_expense_TC_B_095
test_pi_with_additional_discount_TC_B_054
test_pi_with_additional_discount_TC_B_060
test_purchase_invoice_payment_and_cancel_invoice_TC_ACC_019
test_repost_account_ledger_for_pi_TC_ACC_117
test_single_payment_request_for_purchase_invoice_TC_ACC_035
test_standalone_pi_is_fully_paid_TC_B_088
test_standalone_pi_is_partly_paid_TC_B_090
test_stop_pi_creation_when_value_exceeds_budget_TC_ACC_133
test_supplier_invoice_number_uniqueness_validation_TC_ACC_136
test_tax_withholding_with_supplier_TC_ACC_023
test_warn_pi_creation_when_value_exceeds_budget_TC_ACC_145
test_calculate_commission_for_sales_partner_TC_ACC_143
test_create_sales_invoice_for_common_party_TC_ACC_124
test_create_sales_invoice_for_interstate_branch_transfer_TC_ACC_123
test_deferred_revenue_invoice_line_item_TC_ACC_039
test_deferred_revenue_invoice_multiple_item_TC_ACC_040
test_direct_sales_invoice_via_update_stock_TC_SCK_132
test_jv_records_creation_diff_ex_rate_TC_ACC_029
test_jv_records_creation_diff_ex_rate_TC_ACC_030
test_multiple_payment_request_for_purchase_invoice_TC_ACC_038
test_payment_term_discount_for_si_at_fully_paid_TC_ACC_097
test_payment_term_discount_for_si_at_partially_paid_TC_ACC_099
test_prevent_sale_below_purchase_rate_TC_ACC_125
test_repost_account_ledger_for_si_TC_ACC_118
test_sales_invoice_and_delivery_note_with_shipping_rule_TC_S_026
test_sales_invoice_creating_dunning_from_si_TC_S_154
test_sales_invoice_dont_reserve_sales_order_qty_on_sales_return_TC_S_158
test_sales_invoice_ignoring_pricing_rule_TC_S_156
test_sales_invoice_to_allow_item_multiple_times_TC_S_159
test_sales_invoice_with_SR_and_CRN_TC_S_038
test_sales_invoice_with_child_item_rates_of_product_bundle_TC_S_152
test_sales_invoice_with_sr_crn_and_payment_TC_S_039
test_sales_invoice_with_update_stock_and_SR_TC_S_027
test_sales_invoice_with_update_stock_checked_TC_S_007
test_sales_invoice_without_sales_order_TC_S_006
test_si_cancel_amend_with_customer_change_TC_S_129
test_si_cancel_amend_with_item_details_change_TC_S_128
test_si_cancel_amend_with_payment_terms_change_TC_S_130
test_si_credit_note_cancel_amend_with_payment_terms_change_TC_S_131
test_si_with_deferred_revenue_item_TC_S_135
test_si_with_sr_calculate_with_fixed_TC_S_139
test_si_with_sr_calculate_with_net_total_TC_S_140
test_si_with_sr_calculate_with_net_weight_TC_S_141
test_single_payment_request_for_purchase_invoice_TC_ACC_037
test_tax_with_holding_with_si_TC_ACC_109
test_test_unlink_payment_on_invoice_cancellation_TC_ACC_126
test_subscription_plan_with_template_for_pi_TC_ACC_086
test_subscription_plan_with_template_for_si_TC_ACC_087
test_create_tax_rule_and_apply_to_purchase_invoice_TC_ACC_102
test_create_tax_rule_and_apply_to_sales_invoice_TC_ACC_101
test_create_po_pr_return_pr_TC_SCK_178
test_create_material_req_to_2po_to_pi_serial_TC_SCK_096
test_create_mr_to_2po_to_1pi_serial_cancel_TC_SCK_099
test_create_mr_to_2po_to_1pi_serial_return_TC_SCK_111
test_create_mr_to_2po_to_1pi_sr_prtl_ret_TC_SCK_115