### PR TITLE
Fix: Make stock enrty data are already used in creation of stock entr…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -3697,7 +3697,6 @@ class TestWorkOrder(FrappeTestCase):
 			raw_materials=[item_raw],
 			rm_qty=10
 		)
-		make_stock_entry(item_code="Test raw material", qty=200, rate=500, target="Stores - _TC")
 
 		# Create a work order
 		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10,do_not_submit=1)


### PR DESCRIPTION
Fix: As we are already used this part of creation in below code on stock entry creation so this part of code is not required ,
mentioned the screenshot for the refernce where it has already been used 
![image](https://github.com/user-attachments/assets/27dbbb44-5e40-4b8a-b460-f9647e9c027e)
