### PR TITLE
FIx:PartialPaymentValidationError: Partial Payment in POS Invoice is …

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -1030,7 +1030,7 @@ class TestPOSInvoice(unittest.TestCase):
 		before_lp_details = get_loyalty_program_details_with_points(
 			"_Test Customer", loyalty_program="Test Single Loyalty"
 		)
-		inv = create_pos_invoice(rate=10000, do_not_save=1)
+		inv = create_pos_invoice(rate=9000, do_not_save=1)
 		inv.redeem_loyalty_points = 1
 		inv.loyalty_points = before_lp_details.loyalty_points
 		inv.loyalty_redemption_account ="Cash - _TC"


### PR DESCRIPTION
Fix: Paid amount was greater than invoice total,the partail amount should be less than paid amount
TC_S_103 : test_pos_invoice_with_loyalty_point_TC_S_103