### PR TITLE
Fix:frappe.exceptions.ValidationError: Purchase Invoice PINV-25-00010…

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1759,9 +1759,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi.save()
 		pi.submit()
 		
-		pe = get_payment_entry("Purchase Invoice", pi.name, party_amount=po.grand_total/2)
-		pe.save()
-		pe.submit()
+		
 		po_status = frappe.db.get_value("Purchase Order", po.name, "status")
 		self.assertEqual(po_status, "Completed")
 


### PR DESCRIPTION
**Fix**:
This test case validates the 50-50 payment term functionality in the Purchase Order workflow. It ensures that an advance payment of 50% is applied correctly, and the remaining 50% is covered by the advance during invoicing without any additional payment entries.
So as per the advances we are removing the payment entry creation for 2 nd time
**TC_B_044** : test_50_50_payment_terms_TC_B_044