### PR TITLE
Fixed: fiscal year

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -4575,7 +4575,7 @@ def create_fiscal_with_company(company):
 	if existing_fiscal_years != []:
 		for fiscal_years in existing_fiscal_years:
 			fy_doc = frappe.get_doc("Fiscal Year",fiscal_years.get("name"))
-			if not frappe.db.exists("Fiscal Year Company", {"company": company}):
+			if not frappe.db.exists("Fiscal Year Company", {"company": company, "parent":fy_doc.name}):
 				fy_doc.append("companies", {"company": company})
 				fy_doc.save()
 	else:


### PR DESCRIPTION
Error -
test case name = test_repack_with_additional_costs
FiscalYearError: Date 22-04-2025 is not in any active Fiscal Year for _Test Company with perpetual inventory

Solution - updated filters to add companies