### PR TITLE
fix: negative stock error in sales_invoice test_case

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4233,8 +4233,11 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_sales_invoice_without_sales_order_TC_S_006(self):
 		from erpnext.stock.doctype.item.test_item import create_item
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
-		item = create_item("_Test Item 1")
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		get_or_create_fiscal_year("_Test Company")
+		create_customer(customer_name="_Test Customer",company="_Test Company")
+		item = create_item(item_code="_Test Item 1", valuation_rate=100)
+		make_stock_entry(item_code="_Test Item 1", target="_Test Warehouse - _TC", qty=50, basic_rate=100)
 		setting = frappe.get_doc("Selling Settings")
 		setting.so_required = 'No'
 		setting.save()
@@ -4268,14 +4271,16 @@ class TestSalesInvoice(FrappeTestCase):
 	def test_sales_invoice_with_update_stock_checked_TC_S_007(self):
 		from erpnext.stock.doctype.item.test_item import create_item
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		get_or_create_fiscal_year("_Test Company")
-		item = create_item("_Test Item 1")
+		create_customer(customer_name="_Test Customer",company="_Test Company")
+		item = create_item(item_code="_Test Item 1", valuation_rate=100)
+		make_stock_entry(item_code="_Test Item 1", target="_Test Warehouse - _TC", qty=50, basic_rate=100)
 		si = create_sales_invoice(cost_center='Main - _TC',item_code=item.name, selling_price_list='Standard Selling', income_account='Sales - _TC', expense_account='Cost of Goods Sold - _TC',
 							debit_to='Debtors - _TC', qty=5, rate=3000, do_not_save=True)
 		si.update_stock = 1
 		si.save()
 		si.submit()
-  
 		self.assertEqual(si.status, 'Unpaid', 'Sales Invoice not submitted')
   
 		qty_change = frappe.get_all('Stock Ledger Entry', {'item_code': '_Test Item 1', 'voucher_no': si.name, 'warehouse': '_Test Warehouse - _TC'}, ['actual_qty', 'valuation_rate'])
@@ -7127,19 +7132,25 @@ def get_taxes_and_charges():
 
 def create_internal_parties():
 	from erpnext.selling.doctype.customer.test_customer import create_internal_customer
-    
+
+	create_customer_group("_Test Customer Group")
+	create_territory("_Test Territory")
+
+	create_company(company_name="_Test Company 1", country="India", currency="INR", abbr="_TC1")
 	create_internal_customer(
 		customer_name="_Test Internal Customer",
 		represents_company="_Test Company 1",
 		allowed_to_interact_with="Wind Power LLC",
 	)
 
+	create_company(company_name="_Test Company with perpetual inventory", country="India", currency="INR", abbr="_TCPI")
 	create_internal_customer(
 		customer_name="_Test Internal Customer 2",
 		represents_company="_Test Company with perpetual inventory",
 		allowed_to_interact_with="_Test Company with perpetual inventory",
 	)
 
+	create_company(company_name="_Test Company", country="India", currency="INR", abbr="_TC")
 	create_internal_customer(
 		customer_name="_Test Internal Customer 3",
 		represents_company="_Test Company",
@@ -7168,6 +7179,7 @@ def create_internal_parties():
 
 
 def create_internal_supplier(supplier_name, represents_company, allowed_to_interact_with):
+	create_supplier_group("_Test Supplier Group")
 	if not frappe.db.exists("Supplier", supplier_name):
 		supplier = frappe.get_doc(
 			{
@@ -7192,14 +7204,13 @@ def setup_accounts():
 	## Create internal transfer account
 	account = create_account(
 		account_name="Unrealized Profit",
-		parent_account="Current Liabilities - TCP1",
+		parent_account="Current Liabilities - _TCPI",
 		company="_Test Company with perpetual inventory",
 	)
 
 	frappe.db.set_value(
 		"Company", "_Test Company with perpetual inventory", "unrealized_profit_loss_account", account
 	)
-
 
 def add_taxes(doc):
 	doc.append(
@@ -7621,4 +7632,40 @@ def create_registered_company():
 			"abbr":"_TIRC"
 		}).insert(ignore_permissions=True)
 
+def create_company(
+    company_name=None, 
+    country=None, 
+    currency=None,
+    abbr=None
+    ):
+	if not frappe.db.exists("Company", company_name):
+		frappe.get_doc({
+			"doctype": "Company",
+			"company_name": company_name,
+			"company_type": "Company",
+			"default_currency": currency,
+			"country": country,
+			"company_email": "test@example.com",
+			"abbr": abbr
+		}).insert()
 
+def create_customer_group(customer_group):
+	if not frappe.db.exists("Customer Group", {"customer_group_name": customer_group}):
+		frappe.get_doc({"doctype": "Customer Group", "customer_group_name": customer_group}).insert(
+			ignore_permissions=True
+		)
+
+def create_supplier_group(supplier_group):
+	if not frappe.db.exists("Supplier Group", {"supplier_group_name": supplier_group}):
+		frappe.get_doc({"doctype": "Supplier Group", "supplier_group_name": supplier_group}).insert(
+			ignore_permissions=True
+		)
+
+def create_territory(territory):
+	if not frappe.db.exists("Territory", {"territory_name": territory}):
+		frappe.get_doc(
+			{
+				"doctype": "Territory",
+				"territory_name": territory,
+			}
+		).insert(ignore_permissions=True)


### PR DESCRIPTION
**test_sales_invoice_without_sales_order_TC_S_006** - _raise_exception raise excerpnext.stock.stock_ledger.NegativeStockError: 5.0 units of [Item _Test Item 1](https://github.com/app/Form/Item/_Test%20Item%201) needed in [Warehouse](https://github.com/app/Form/Warehouse/_Test%20Warehouse%20-%20_TC)


**test_sales_invoice_with_update_stock_checked_TC_S_007** - _raise_exception raise excerpnext.stock.stock_ledger.NegativeStockError: 5.0 units of [Item _Test Item 1](https://github.com/app/Form/Item/_Test%20Item%201) needed in [Warehouse](https://github.com/app/Form/Warehouse/_Test%20Warehouse%20-%20_TC)