### PR TITLE
Fix: frappe.exceptions.ValidationError: Party Account <strong>Credito…

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -6987,6 +6987,7 @@ class TestPurchaseOrder(FrappeTestCase):
 			"company": company,
 			"schedule_date": today(),
 			"set_warehouse": warehouse,
+			"currency": "INR",
 			"items": [
 				{
 					"item_code": item.item_code,
@@ -7012,6 +7013,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi_1.bill_no =  f"test_bill_{bill_no}"
 		pi_1.items[0].qty = 3
 		pi_1.update_stock = 1
+		pi_1.currency = "INR"
 		pi_1.insert()
 		pi_1.submit()
 
@@ -7037,6 +7039,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi_2 = make_pi_from_po(po.name)
 		pi_2.update_stock = 1
 		pi_2.bill_no = "test_bill - 1122"
+		pi_2.currency = "INR"
 		pi_2.save()
 		pi_2.submit()
 


### PR DESCRIPTION
**Fix**:
Miss matching of the currency in the purchase order and purchase invoice ,there was a differnce between INR and USD among the Creditors - TC-3</strong> currency (INR) and document currency (USD)
**TC_B_130**
test_po_with_partial_pi_and_update_items_TC_B_130