### PR TITLE
test: new test cases created to improve code coverage progres

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -895,7 +895,7 @@ def is_po_fully_subcontracted(po_name):
 	query = (
 		frappe.qb.from_(table)
 		.select(table.name)
-		.where((table.parent == po_name) & (table.qty != table.sco_qty))
+		.where((table.parent == po_name) & (table.qty != table.subcontracted_quantity))
 	)
 	return not query.run(as_dict=True)
 


### PR DESCRIPTION
**below are the test cases written for the purchase order core functions, for which test cases are not written before,**

**TC_B_159** - this test case verifies the closing the purchase orders and re-opening the closed purchase order
**TC_B_160** - this test case verify and validates the available budget before saving the purchase order
**TC_B_161** - this test case verify and validates the committed overall budget while submitting the purchase order 
**TC_B_162** - this test case verify and validates if the work break down structure is locked it will not allow to proceed further transaction
**TC_B_163** - this test case verify and validates if the work break down structure is locked it will not allow to proceed further transaction it will create material request and mr to it will create purchase order and validates the po is wbs is locked
**TC_B_164** - this test case verifies the subcontracting_items if is  subcontrating check box is checked in the purchase order
**TC_B_165** - this test case prevent the purchase order while saving the purchase order, based on the supplier scorecard status
**TC_B_166** - this test case will verify and checks the warn message while saving while saving the purchase order, based on the supplier scorecard status
**TC_B_167** -  this test will checks for the each throw message if the items in the child tables are subcontrated items and validates while saving purchase order
**TC_B_168** -  this test case will checks the purchase invoice is getting creating or not from portal
**TC_B_169**, **TC_B_170** -  this test case will checks for the last purchase rate for the existin and new item
