### PR TITLE
fix: added a condition to resolve the overlapping fiscal year issue

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -7684,6 +7684,17 @@ def create_fiscal_year(company=None):
 		company = "_Test Company MR"
 
 	today = date.today()
+ 
+	existing_fy = frappe.get_all(
+		"Fiscal Year",
+		fields=["year_start_date", "year_end_date"],
+		filters={"company": company}
+	)
+
+	for fy in existing_fy:
+		if fy.year_start_date <= today <= fy.year_end_date:
+			return
+
 	if today.month >= 4:  # Fiscal year starts in April
 		start_date = date(today.year, 4, 1)
 		end_date = date(today.year + 1, 3, 31)


### PR DESCRIPTION
TC_B_156 failed - NameError: Year start date or end date is overlapping with _Test Fiscal Year 2026. To avoid please set company
TC_B_157 failed - NameError: Year start date or end date is overlapping with _Test Fiscal Year 2026. To avoid please set company
TC_B_158 failed - NameError: Year start date or end date is overlapping with _Test Fiscal Year 2026. To avoid please set company
TC_SCK_193 failed - NameError: Year start date or end date is overlapping with _Test Fiscal Year 2026. To avoid please set company