### PR TITLE
fix: parent account error in sales_invoice test case

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -7277,7 +7277,7 @@ def setup_accounts():
 	## Create internal transfer account
 	account = create_account(
 		account_name="Unrealized Profit",
-		parent_account="Current Liabilities - _TCPI",
+		parent_account="Current Liabilities - TCP1",
 		company="_Test Company with perpetual inventory",
 	)
 


### PR DESCRIPTION
LinkValidationError: Could not find Parent Account: Current Liabilities - _TCPI