### PR TITLE
fix: issue 1953 'SalesInvoice' object has no attribute 'get_finished_…

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -554,13 +554,14 @@ class SellingController(StockController):
 
 	def update_stock_ledger(self, allow_negative_stock=False):
 		sl_entries = []
-		finished_item_row = self.get_finished_item_row()
+		if self.doctype != "Sales Invoice":
+			finished_item_row = self.get_finished_item_row()
 
-		# make sl entries for source warehouse first
-		self.get_sle_for_source_warehouse(sl_entries, finished_item_row)
+			# make sl entries for source warehouse first
+			self.get_sle_for_source_warehouse(sl_entries, finished_item_row)
 
-		# SLE for target warehouse
-		self.get_sle_for_target_warehouse(sl_entries, finished_item_row)
+			# SLE for target warehouse
+			self.get_sle_for_target_warehouse(sl_entries, finished_item_row)
 
 		# reverse sl entries if cancel
 		if self.docstatus == 2:


### PR DESCRIPTION
Company | test_demo_data | psycopg2.errors.UndefinedTable: missing FROM-clause entry for table "tabPurchase Invoice" LINE 1: ...D "tabPurchase Invoice Item"."docstatus"= '1' AND "tabPurcha... #1953

AttributeError: 'SalesInvoice' object has no attribute 'get_finished_item_row'
