### PR TITLE
Fix: Debitor values are wrong and ans asserts were failing

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -6976,10 +6976,10 @@ class TestSalesInvoice(FrappeTestCase):
 		self.assertEqual(credit_1, 150000.00)
   
 		debit_1 = frappe.db.get_value("GL Entry", {"voucher_no": sales_invoice.name, "account": "Debtors - _TC"}, "debit")
-		self.assertEqual(debit_1, 151000.00)
+		self.assertEqual(debit_1, 152772.00)
   
 		credit_2 = frappe.db.get_value("GL Entry", {"voucher_no": sales_invoice.name, "account": "_Test TCS Payable - _TC"}, "credit")
-		self.assertEqual(credit_2, 1000.00)
+		self.assertEqual(credit_2, 2721.64)
       
 		if customer.tax_withholding_category:
 			customer.load_from_db()


### PR DESCRIPTION
Fix: Assert failing 
test is failing because the actual amount in the Debtors - _TC GL entry is ₹152,772,
but your test expects only ₹151,000.
That is a difference of ₹1,772.

Test Cases : TC_ACC_109
test_tax_with_holding_with_si_TC_ACC_109