### PR TITLE
fix: fix issue no 2353

### DIFF
--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -9,7 +9,7 @@ from frappe.query_builder.functions import IfNull, Round
 from erpnext import get_default_currency
 
 
-def get_ordered_to_be_billed_data(args):
+def get_ordered_to_be_billed_data(args,filters):
 	doctype, party = args.get("doctype"), args.get("party")
 	child_tab = doctype + " Item"
 	precision = (


### PR DESCRIPTION
**_Received Items To Be Billed Report Issue._** 
------------------
File "apps/erpnext/erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py", line 13, in execute
    data = get_ordered_to_be_billed_data(args, filters)
TypeError: get_ordered_to_be_billed_data() takes 1 positional argument but 2 were given