### PR TITLE
Fixed: code coverage test cases

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -5388,7 +5388,6 @@ class TestMaterialRequest(FrappeTestCase):
 		doc_pi.load_from_db()
 		from erpnext.controllers.sales_and_purchase_return import make_return_doc
 		return_pi = make_return_doc("Purchase Invoice", doc_pi.name)
-		print(f"\n\n\n return_pi.posting_date={return_pi.posting_date}\n\n\n\n")
 		return_pi.submit()
 
 		gl_temp_credit = frappe.db.get_value('GL Entry',{'voucher_no':return_pi.name, 'account': return_pi.items[0].expense_account},'credit')


### PR DESCRIPTION
Error: Getting SerialNoDuplicateError & data issue in below test cases.
Solution: Added '_Test Company' (default) , added validation & rollback.

1. tc_sck_211
2. tc_sck_212
3. tc_sck_213
4. TC_B_157
5. TC_B_156
6. TC_SCK_193

 And added 'frappe.db.rollback' where mentioned 'serial_numbers' to reduce the 'SerialNoDuplicateError' error.
    
