### PR TITLE
fix: NegativeStockError,units of Item  needed in Warehouse to complet…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -3587,6 +3587,26 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.bom_no, bom_doc.name)
 		self.assertEqual(wo_doc.status, "Not Started")
 
+		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
+		stock_entry = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"stock_entry_type": "Material Receipt",
+			"company": wo_doc.company,
+			"posting_date": frappe.utils.nowdate(),
+			"posting_time": frappe.utils.nowtime(),
+			"items": [
+				{
+					"item_code": item_raw.name,
+					"qty": 100,
+					"uom": "Nos",
+					"stock_uom": "Nos",
+					"t_warehouse": "Stores - _TC",
+					"basic_rate": 50
+				}
+			]
+		})
+		stock_entry.insert()
+		stock_entry.submit()
 		# Create a stock entry to consumption the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
 		for row in ste_doc.items:
@@ -3646,8 +3666,28 @@ class TestWorkOrder(FrappeTestCase):
 				item_code=row.item_code, target="Stores - _TC", qty=row.qty, basic_rate=100
 			)
 		ste_doc.save()
-		ste_doc.submit()
+		ste_doc.submit()	
 		
+		stock_entry = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"stock_entry_type": "Material Receipt",
+			"company": wo_doc.company,
+			"posting_date": frappe.utils.nowdate(),
+			"posting_time": frappe.utils.nowtime(),
+			"items": [
+				{
+					"item_code": item_raw.name,
+					"qty": 100,
+					"uom": "Nos",
+					"stock_uom": "Nos",
+					"t_warehouse": "Stores - _TC",
+					"basic_rate": 50
+				}
+			]
+		})
+		stock_entry.insert()
+		stock_entry.submit()
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -3762,6 +3802,26 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.bom_no, bom_doc.name)
 		self.assertEqual(wo_doc.status, "Not Started")
 
+		stock_entry = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"stock_entry_type": "Material Receipt",
+			"company": wo_doc.company,
+			"posting_date": frappe.utils.nowdate(),
+			"posting_time": frappe.utils.nowtime(),
+			"items": [
+				{
+					"item_code": item_raw.name,
+					"qty": 100,
+					"uom": "Nos",
+					"stock_uom": "Nos",
+					"t_warehouse": "Stores - _TC",
+					"basic_rate": 50
+				}
+			]
+		})
+		stock_entry.insert()
+		stock_entry.submit()
+
 		# Create a stock entry to consumption the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
 		for row in ste_doc.items:
@@ -3818,6 +3878,26 @@ class TestWorkOrder(FrappeTestCase):
 		wo_doc.submit()
 		self.assertEqual(wo_doc.bom_no, bom_doc.name)
 		self.assertEqual(wo_doc.status, "Not Started")
+
+		stock_entry = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"stock_entry_type": "Material Receipt",
+			"company": wo_doc.company,
+			"posting_date": frappe.utils.nowdate(),
+			"posting_time": frappe.utils.nowtime(),
+			"items": [
+				{
+					"item_code": item_raw.name,
+					"qty": 100,
+					"uom": "Nos",
+					"stock_uom": "Nos",
+					"t_warehouse": "Stores - _TC",
+					"basic_rate": 50
+				}
+			]
+		})
+		stock_entry.insert()
+		stock_entry.submit()
 
 		# Create a stock entry to consumption the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
@@ -3879,6 +3959,26 @@ class TestWorkOrder(FrappeTestCase):
 		wo_doc.submit()
 		self.assertEqual(wo_doc.bom_no, bom_doc.name)
 		self.assertEqual(wo_doc.status, "Not Started")
+
+		stock_entry = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"stock_entry_type": "Material Receipt",
+			"company": wo_doc.company,
+			"posting_date": frappe.utils.nowdate(),
+			"posting_time": frappe.utils.nowtime(),
+			"items": [
+				{
+					"item_code": item_raw.name,
+					"qty": 100,
+					"uom": "Nos",
+					"stock_uom": "Nos",
+					"t_warehouse": "Stores - _TC",
+					"basic_rate": 50
+				}
+			]
+		})
+		stock_entry.insert()
+		stock_entry.submit()
 
 		# Create a stock entry to consumption the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))


### PR DESCRIPTION
Fix: 
**Test case**: 
tc_sck_214 : test_mafac_wo_wth_consum_skp_transf_tc_sck_214
tc_sck_215: test_mafac_wo_wth_consum_skp_transf_btch_tc_sck_215
tc_sck_217: test_wo_wth_consum_skp_transf_scp_tc_sck_217
tc_sck_218: test_wo_wth_consum_skp_transf_scp_btch_tc_sck_218
tc_sck_219: test_wo_wth_consum_skp_transf_scp_btch_srl_tc_sck_219

**Issue**
This error occurs when ERPNext tries to create a stock transaction that consumes more stock than what is currently available in the specified warehouse (Stores - _TC) and "Allow Negative Stock" is disabled in the system settings.

* The system attempted to consume 100 units of the item "Test raw material".
* However, there was no stock available in the warehouse Stores - _TC for this item.

 **What Was Done to Fix It**
To solve this, you pre-loaded stock into the warehouse before attempting consumption. Here's what was done:

Created stock_entry with purpose="Material Receipt":

This created a stock entry that added 100 units of Test raw material to the warehouse Stores - _TC.

Then performed Material Consumption for Manufacture:

This successfully consumed stock because it was now available in the warehouse.

This ensured that raw materials were available before any consumption, preventing the NegativeStockError