### PR TITLE
test:Add Multiple Test Cases for Purchase Receipt - (CodeCoverage)

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -27,7 +27,7 @@ class PurchaseReceipt(BuyingController):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from erpnext.accounts.doctype.pricing_rule_detail.pricing_rule_detail import PricingRuleDetail
 		from erpnext.accounts.doctype.purchase_taxes_and_charges.purchase_taxes_and_charges import PurchaseTaxesandCharges
 		from erpnext.buying.doctype.purchase_receipt_item_supplied.purchase_receipt_item_supplied import PurchaseReceiptItemSupplied


### PR DESCRIPTION
#### Test Case ID:  test_po_required_TC_SCK_260
**- Test Summary:**
Added test case to verify the Purchase Order (PO) required validation in Purchase Receipt when “PO Required” setting is enabled in Buying Settings. The test ensures the system properly validates and raises an error when creating a Purchase Receipt without a linked Purchase Order.
**- Scenarios Covered**
Input Validations
Validates that Purchase Receipt requires a PO reference when “PO Required” setting is enabled
**- Edge Cases**
Tests the behavior when PO field is manually cleared
**- API Response Handling**
(N/A for this test)
**- Technology**
Python unittest framework
Frappe/ERPNext testing utilities
**- Linked Feature/Bug**
Related to enforcement of PO Required setting in Purchase Receipt workflow
**- Issue ID**
NA

---
#### Test Case ID:  test_validate_items_quality_inspection_TC_SCK_261
**- Test Summary**
Added test case to validate Quality Inspection (QI) linkage in Purchase Receipt (PR) items. Ensures the system correctly:
Validates QI item codes match PR item codes.
Raises ValidationError when mismatched.
Works with Stock Setting allow_to_make_quality_inspection_after_purchase_or_delivery.
**- Scenarios Covered**
Input Validation
Checks if QI item code matches PR item code.
Validates error when QI references a wrong item.
**- Edge Case**
Tests correction flow (fixing QI item code re-validation).
**- API Response Handling** 
(N/A for this test)
**- Technology**
Framework: Python unittest
Tools: Frappe/ERPNext test utilities (make_purchase_receipt, create_supplier, etc.)
**- Linked Feature/Bug**
Related to Quality Inspection enforcement in Purchase Receipt workflows.
**- Issue ID**
NA

---
#### Test Case ID:  test_get_po_qty_and_warehouse_TC_SCK_262
**- Test Summary**
Added test case to verify correct retrieval of Purchase Order (PO) details (quantity and warehouse) in Purchase Receipt (PR). Ensures:
PR accurately fetches PO-linked item quantity.
PR correctly identifies PO-specified warehouse.
**- Scenarios Covered**
Data Consistency
Validates PR fetches PO item qty (10) and warehouse
Checks end-to-end flow: PO → PR data synchronization.
**- API Response Handling** 
(N/A for this test)
**- Technology**
Framework: Python unittest
Tools: create_purchase_order (PO test utility) and make_purchase_receipt (PR test utility)
**- Linked Feature/Bug**
Related to PO-PR data integrity during stock receipt.
**- Issue ID**
NA

---
#### Test Case ID:  test_make_item_gl_entries_TC_SCK_263
**- Test Summary**
Added comprehensive test cases to validate General Ledger (GL) entries generation in Purchase Receipt (PR) for:
Stock items with purchase invoices
Non-stock items with expense accounts
Warehouses without account mapping
Landed cost voucher integration
**- Scenarios Covered**
**Stock Item Accounting:** Validates GL entries for standard stock items with valuation rates
**Non-Stock Item Handling:** Ensures proper expense account posting for non-stock items
**- Edge Case**
Tests warehouse account mapping fallbacks
Validates landed cost voucher amount distribution
**Integration Tests:**
Purchase Invoice → Purchase Receipt → GL entry flow
Landed Cost Voucher → Purchase Receipt GL impact
**- Technology**
Framework: Python unittest
**Key Utilities:**
make_purchase_receipt
make_purchase_invoice
create_landed_cost_voucher
Custom account/warehouse setup
**- Linked Feature/Bug**
Related to:
Accurate GL posting for inventory transactions
Landed cost accounting integration
**- Issue ID**
NA

---
#### Test Case ID:  test_get_billed_qty_against_purchase_receipt_TC_SCK_264
**- Test Summary**
Added test case to validate:
Billed quantity tracking against Purchase Receipt items
Billing percentage update when linked to Purchase Invoice
Accuracy of get_billed_qty_against_purchase_receipt utility
**- Scenarios Covered**
**Integration Test**
Purchase Receipt → Purchase Invoice linkage
**Data Validation**
Verifies billed quantity matches PI qty (3/5 in test)
**- Edge Case**
Partial billing scenario (3 billed out of 5 received)
**- Technology**
**Framework:** Python unittest
**Key Utilities:**
make_purchase_receipt
make_purchase_invoice
get_billed_qty_against_purchase_receipt
update_billing_percentage
**- Linked Feature/Bug**
Related to:
Accurate tracking of billed vs received quantities
Purchase Receipt billing status updates
**- Issue ID**
NA

---
#### Test Case ID:  test_adjust_incoming_rate_for_pr_TC_SCK_265
**- Test Summary**
Added test case to validate the incoming rate adjustment functionality for Purchase Receipt items, ensuring:
Correct handling of valuation rate updates
Proper persistence of rate changes in the system
**- Scenarios Covered**
**Rate Adjustment Validation**
Verifies adjust_incoming_rate_for_pr updates valuation rate correctly
**Data Integrity**
Confirms rate changes are saved and reloaded accurately
**Document Type Safety**
Ensures operation only affects Purchase Receipt doctype
**- Technology**
**Framework:** Python unittest
**Key Utilities:**
make_purchase_receipt
adjust_incoming_rate_for_pr
Frappe's DB utilities
**- Linked Feature/Bug**
Related to:
Accurate inventory valuation rate maintenance
Purchase Receipt rate adjustment workflows
**- Issue ID**
NA

---
#### Test Case ID:  test_update_billed_amount_based_on_po_TC_SCK_266
**- Test Summary**
Added comprehensive test case to validate:
Billed amount calculation across multiple Purchase Receipts linked to a Purchase Order
Proportional billing distribution when partial invoices are created
Targeted updates using pr_doc parameter
**- Scenarios Covered**
**Multi-Document Integration**
PO → 2 PRs (6+4 qty) → 2 PIs (3+5 qty)
**Proportional Billing Logic**
Validates 600/200 split of 800 total billed amount
**Precision Updates**
Tests targeted PR updates using pr_doc parameter
**- Edge Case**
Mixed billing (direct PR-linked + PO-only invoices)
**- Technology**
**Framework:** Python unittest
**Key Utilities:**
create_purchase_order
make_purchase_receipt
make_purchase_invoice
update_billed_amount_based_on_po
**- Linked Feature/Bug**
Related to:
Accurate cost allocation across partial deliveries
PO-PR-PI amount reconciliation
**- Issue ID**
NA

---
#### Test Case ID:  test_make_stock_entry_TC_SCK_267
**- Test Summary**
Added test case to validate Stock Entry generation from Purchase Receipt, verifying:
Correct automatic creation of Material Transfer entries
Accurate item quantity and warehouse mapping
Proper document linking between PR and Stock Entry
**- Scenarios Covered**
**Basic Functionality**
Stock Entry creation with correct type/purpose ("Material Transfer")
**Data Integrity**
Validates item code, quantity (10), and source warehouse
**Document Linking**
Checks Purchase Receipt reference in Stock Entry
**Workflow State**
Confirms Stock Entry is created in Draft (docstatus=0)
**- Technology**
**Framework:** Python unittest
**Key Utilities:**
make_stock_entry
create_purchase_order
make_purchase_receipt
**- Linked Feature/Bug**
Related to inventory transfer workflows initiated from Purchase Receipts
**- Issue ID**
NA

---
#### Test Case ID:  test_make_stock_entry_TC_SCK_267
**- Test Summary**
Added test case to validate invoiced quantity mapping for Purchase Receipt items, verifying:
Accurate aggregation of billed quantities across multiple Purchase Invoices
Correct mapping between PR items and their corresponding invoices
Proper handling of partial billing scenarios
**- Scenarios Covered**
**Multi-Invoice Aggregation**
Validates qty summation (4 + 6 = 10) from two PIs
**Document Linking**
Checks PR-PI reference integrity via pr_detail field
**- Edge Case**
Tests complete billing scenario (100% of PR quantity invoiced)
**- Technology**
**Framework:** Python unittest
**Key Utilities:**
get_invoiced_qty_map
create_purchase_order
make_purchase_invoice
**- Linked Feature/Bug**
Related to accurate tracking of billed quantities in inventory receipt workflows
**- Issue ID**
NA



