### PR TITLE
fix: ValidationError for missing Tax Withholding data on posting date…

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -2275,6 +2275,7 @@ def create_records(supplier):
  
 	create_account()
 	today = frappe.utils.getdate()
+	fiscal_year = get_fiscal_year(today, company="_Test Company", as_dict=True)
 
 	create_tax_withholding_category(
 			category_name="Test - TDS - 194C - Company",


### PR DESCRIPTION
### Bug Description
When trying to save a Purchase Invoice in test case test_advance_payment_TC_ACC_028, the system throws a Validation error ValidationError: No Tax Withholding data found for the current posting date. This error prevents invoice creation where Tax Withholding is enabled, even when the user might not expect such strict validation or the Tax Withholding setup is only missing for that specific date.

### Root Cause
The method get_tax_withholding_rates enforces that a Tax Withholding record must exist for the exact posting date. If it doesn't, it throws an error without fallback or a check to ensure that withholding should even apply for the given date range.

### Fix Summary
In the test case, modified the setup to align the Tax Withholding Category's from_date and to_date with the current fiscal year. This ensures the posting_date is always within a valid range.

### Affected Module
Accounts

Automated Test: test_purchase_invoice.py

### Test Cases Covered
test_advance_payment_TC_ACC_028

### Linked Issue
Fixes https://github.com/8848digital/erpnext/issues/2347