### PR TITLE
fix: ValidationError: A template with tax category _Test Tax Category…

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -3558,22 +3558,36 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		frappe.set_user("Administrator")
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
 
-		purchase_tax = frappe.new_doc("Purchase Taxes and Charges Template")
-		purchase_tax.title = "TEST"
-		purchase_tax.company = "_Test Company"
-		purchase_tax.tax_category = "_Test Tax Category 1"
+		template = frappe.get_all(
+			"Purchase Taxes and Charges Template",
+			filters={
+				"company": "_Test Company",
+				"tax_category": "_Test Tax Category 1",
+				"disabled": 0,
+			},
+			fields=["name"],
+			limit=1
+		)
 
-		purchase_tax.append("taxes",{
-			"category":"Total",
-			"add_deduct_tax":"Add",
-			"charge_type":"On Net Total",
-			"account_head":"_Test Account Excise Duty - _TC",
-			"_Test Account Excise Duty":"_Test Account Excise Duty",
-			"rate":100,
-			"description":"GST"
-		})
+		if not template:
+			purchase_tax = frappe.new_doc("Purchase Taxes and Charges Template")
+			purchase_tax.title = "TEST"
+			purchase_tax.company = "_Test Company"
+			purchase_tax.tax_category = "_Test Tax Category 1"
 
-		purchase_tax.save()
+			purchase_tax.append("taxes", {
+				"category": "Total",
+				"add_deduct_tax": "Add",
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account Excise Duty - _TC",
+				"rate": 100,
+				"description": "GST"
+			})
+
+			purchase_tax.insert()
+		else:
+			purchase_tax = frappe.get_doc("Purchase Taxes and Charges Template", template[0].name)
+
 		pi = make_purchase_invoice(
 			qty=1,
 			item_code="_Test Item",


### PR DESCRIPTION
### Bug Description
During automated testing of Purchase Invoices (`test_fully_paid_of_pi_to_pr_to_pe_with_gst_TC_B_084`), a `ValidationError` was raised due to attempting to insert a duplicate `Purchase Taxes and Charges Template` with the same `tax_category`.

### Root Cause
ERPNext enforces a unique constraint on `tax_category` per company for tax templates. The test tried to create a new template with `tax_category = _Test Tax Category 1`, which already existed in the system.

**Steps to Reproduce:**
1. Run the test `test_fully_paid_of_pi_to_pr_to_pe_with_gst_TC_B_084`.
2. Observe the error when attempting to create a second template with the same tax category.

**Actual Result:**  
ValidationError: A template with tax category _Test Tax Category 1 already exists.

**Expected Result:**  
Test should reuse the existing template or conditionally create one only if not already present.

### Fix Summary
Before inserting a new template, the code now checks if one already exists using `frappe.get_all(...)`. If found, it reuses the existing one; otherwise, it creates a new template.

### Affected Module
- Accounts
- Automated Test: `test_purchase_invoice.py`

### Test Cases Covered
- `test_fully_paid_of_pi_to_pr_to_pe_with_gst_TC_B_084`

### Linked Issue
Fixes #2348 