### PR TITLE
fix: ValidationError: GST Rate cannot be zero for Taxable GST Treatme…

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -4265,6 +4265,7 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 					"doctype":"Item Tax Template",
 					"title": gst.get("template"),
 					"company":"_Test Company",
+					"gst_rate": gst.get("rate"),
 					"taxes":[
 						{
 							"tax_type":"Marketing Expenses - _TC",
@@ -4272,7 +4273,7 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 						}
 					]}
 					
-					).insert(ignore_permissions=True)
+					).insert(ignore_permissions=True, ignore_if_duplicate=True)
 		purchase_taxes_template = create_or_get_purchase_taxes_template("_Test Company")
 
 		gst_rates = [


### PR DESCRIPTION
### Bug Description
During automated testing of Purchase Invoices (test_generate_purchase_invoice_with_items_different_gst_rates_TC_ACC_130), a ValidationError was raised due to missing gst_rate in the Item Tax Template for taxable GST treatments.

### Root Cause
The validation logic in the india_compliance app enforces that taxable GST treatments must have a non-zero gst_rate. The test was creating Item Tax Template records without setting the gst_rate field, leading to the following error:

Error: ValidationError: GST Rate cannot be zero for Taxable GST Treatment Steps to Reproduce:

Run the test test_generate_purchase_invoice_with_items_different_gst_rates_TC_ACC_130.
Observe the error when the Item Tax Template is inserted without gst_rate.

### Actual/Observed Result:
Validation error raised due to missing GST Rate.

### Expected Result:
Test should create the Item Tax Template with a valid gst_rate.

### Fix Summary
The test now sets the gst_rate field while creating the Item Tax Template. Also used ignore_if_duplicate=True to ensure safe re-runs of tests.

### Affected Module
Accounts

### Test Cases Covered
None

### Linked Issue
#2349 
