### PR TITLE
Fix: AssertionError: 'CWIP Account - _TC' != 'Creditors - _TC'- CWIP Account - _TC+ Creditors - _TC  

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -4241,12 +4241,13 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			{"rate": 18, "template": "GST 18%", "range": (10001, 100000)}
 		]
 		for gst in gst_rates:
-			if not frappe.db.exists("Item Tax Template",{"name":gst.get("template")}):
+			if not frappe.db.exists("Item Tax Template",{"title":gst.get("template")}):
 				frappe.get_doc(
 					{
 					"doctype":"Item Tax Template",
 					"title": gst.get("template"),
 					"company":"_Test Company",
+					"gst_rate":gst.get("rate"),
 					"taxes":[
 						{
 							"tax_type":"Marketing Expenses - _TC",

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -4611,9 +4611,9 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		lvc.save()
 		lvc.submit()
   
-		expected_gle =[
-			['CWIP Account - _TC',pi.grand_total, 0.0, pi.posting_date],
+		expected_gle = [
 			['Creditors - _TC', 0.0, 1000.0, pi.posting_date],
+			['CWIP Account - _TC', 1300.0, 0.0, pi.posting_date],  # 1000 + 300
 			['Expenses Included In Valuation - _TC', 0.0, 300.0, pi.posting_date],
 		]
 		

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -4864,6 +4864,7 @@ class TestMaterialRequest(FrappeTestCase):
 		self.assertEqual(serial_cnt, 1)
 		serial_cnt = frappe.db.count('Serial No',{'purchase_document_no':pr1.name})
 		self.assertEqual(serial_cnt, 1)
+
 	def test_create_material_req_to_2po_to_pi_TC_SCK_095(self):
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 		create_company()
@@ -4888,6 +4889,7 @@ class TestMaterialRequest(FrappeTestCase):
 		po1.supplier = "_Test Supplier"
 		po1.items[0].qty = 5
 		po1.items[0].rate = rate
+		po1.currency = "INR"
 		po1.insert()
 		po1.submit()
 		self.assertEqual(po1.docstatus, 1)
@@ -4896,6 +4898,7 @@ class TestMaterialRequest(FrappeTestCase):
 		po2.supplier = "_Test Supplier"
 		po2.items[0].qty = 5
 		po2.items[0].rate = rate
+		po2.currency = "INR"
 		po2.insert()
 		po2.submit()
 		self.assertEqual(po2.docstatus, 1)
@@ -4904,6 +4907,7 @@ class TestMaterialRequest(FrappeTestCase):
 		pi = create_purchase_invoice(po2.name, target_doc=pi)
 		pi.set_warehouse = warehouse
 		pi.update_stock = 1
+		pi.currency = "INR"
 		serial_numbers1 = ["SN001", "SN002","SN003", "SN004","SN005"]
 		serial_numbers2 = ["SN006", "SN007","SN008", "SN009","SN010"]
 		pi.items[0].serial_no = "\n".join(serial_numbers1)


### PR DESCRIPTION
### Bug Description
  In the automated test case test_lcv_with_purchase_invoice_for_fixed_asset_item_TC_ACC_113, the expected General Ledger (GL) Entry for the CWIP Account was incorrectly set to reflect only the base Purchase Invoice (PI) amount, not accounting for the additional cost introduced by the Landed Cost Voucher (LCV). This caused the test to fail when the actual CWIP debit included both PI and LCV values.

### Root Cause
  The test case expected a GL entry of 1000.0 debit in the CWIP Account, which is the base item cost from the Purchase Invoice. However, in ERPNext, when a Landed Cost Voucher is applied to an asset item, the landed cost is capitalized along with the base item value. As a result, the GL Entry for the CWIP Account correctly showed a debit of 1300.0 (1000 base + 300 landed cost), leading to a mismatch in the test assertion.

### Expected Result
  The test should expect the CWIP Account to be debited by the total cost of the asset, i.e., base PI cost + LCV charges:

Actual Result
  1. The test expected the CWIP Account to have only the base PI amount:
        CWIP Account - _TC: 1000.0 debit
    but The actual system behavior was:
       CWIP Account - _TC: 1300.0 debit

### Fix Summary
  The test case was updated to reflect the correct business logic of ERPNext, where landed costs are capitalized into the fixed asset. The expected GL Entry for the CWIP Account was changed to include the additional 300.0 from the LCV.

### Affected Module
  ERPNext > Accounts > Landed Cost Voucher
  
  ERPNext > Buying > Purchase Invoice
  
  ERPNext > Assets > Asset Capitalization


### Test case Resolved: 
  1.TC_ACC_022
  2.TC_ACC_113


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 3. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 4. All tests pass locally, UI and Unit tests
 5. All business logic and validations must be on the server-side
 6. Update necessary Documentation
 7. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes



Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
