### PR TITLE
test: Add Test Cases for Request for Quotation Functionalities

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -19,6 +19,23 @@ from erpnext.templates.pages.rfq import check_supplier_has_docname_access
 
 
 class TestRequestforQuotation(FrappeTestCase):
+	def setUp(self):
+		# Create dummy supplier
+		self.supplier = frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Test",
+			"supplier_type": "Company"
+		}).insert(ignore_if_duplicate=True)
+
+		item = make_item("Test", {"stock_uom": "Nos"})
+		self.rfq = make_request_for_quotation(item_code=item.name, supplier_data=[
+				{
+					"supplier": self.supplier.name,
+					"supplier_name": self.supplier.supplier_name,
+					"email_id": "123_testrfquser@example.com",
+				}
+			],)
+		
 	def test_quote_status(self):
 		rfq = make_request_for_quotation()
 
@@ -161,6 +178,216 @@ class TestRequestforQuotation(FrappeTestCase):
 
 		supplier_doc.reload()
 		self.assertTrue(supplier_doc.portal_users[0].user)
+
+	def test_send_supplier_emails_runs_TC_B_193(self):
+		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import send_supplier_emails
+		send_supplier_emails(self.rfq.name)
+
+		communications = frappe.get_all("Communication", filters={
+			"reference_doctype": "Request for Quotation",
+			"reference_name": self.rfq.name
+		})
+		print('rfq_name', self.rfq.name)
+		self.assertGreaterEqual(len(communications), 1)
+
+	def test_get_supplier_email_preview_TC_B_194(self):
+		item_code = "_Test Item"
+		if not frappe.db.exists("Item", item_code):
+			item = make_item(item_code, {"stock_uom": "Nos"})
+		supplier_doc = frappe.get_doc(
+			{
+				"doctype": "Supplier",
+				"supplier_name": "Test Supplier for RFQ",
+				"supplier_group": "_Test Supplier Group",
+			}
+		).insert()
+		rfq = make_request_for_quotation(item_code = item_code, supplier_data=[
+				{
+					"supplier": supplier_doc.name,
+					"supplier_name": supplier_doc.supplier_name,
+					"email_id": "testrfquser@example.com",
+				}
+			])
+		preview = rfq.get_supplier_email_preview(supplier_doc.name)
+        
+		self.assertIn("Dear", preview)
+		self.assertIn("testrfquser@example.com", preview)
+
+	def test_get_supplier_tag_TC_B_195(self):
+		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import get_supplier_tag
+		tags = get_supplier_tag()
+		self.assertIsInstance(tags, list)
+
+	def test_get_rfq_containing_supplier_TC_B_196(self):
+		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import get_rfq_containing_supplier
+
+		filters = {
+			"company": self.rfq.company,
+			"supplier": self.supplier.name,
+			"transaction_date": self.rfq.transaction_date
+		}
+
+		rfqs = get_rfq_containing_supplier("Request for Quotation", "", "name", 0, 10, filters)
+
+		self.assertTrue(any(r["name"] == self.rfq.name for r in rfqs))
+
+	def test_get_list_context_coverage_TC_B_197(self):
+		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import get_list_context
+
+		context = get_list_context()
+		self.assertEqual(context["title"], "Request for Quotation")
+		self.assertTrue(context["show_sidebar"])
+		self.assertTrue(context["no_breadcrumbs"])
+
+	def test_supplier_rfq_mail_TC_B_198(self):
+		item_code = "_Test Item"
+		if not frappe.db.exists("Item", item_code):
+			item = make_item(item_code, {"stock_uom": "Nos"})
+		supplier_doc = frappe.get_doc(
+			{
+				"doctype": "Supplier",
+				"supplier_name": "Test Supplier1",
+			}
+		).insert()
+		rfq = make_request_for_quotation(item_code = item_code, supplier_data=[
+				{
+					"supplier": supplier_doc.name,
+					"supplier_name": supplier_doc.supplier_name,
+					"email_id": "testrfquser@example.com",
+				}
+			], do_not_submit=True)
+		rfq.email_template = "Dispatch Notification"
+
+		data = {
+			"supplier": "Test Supplier",
+			"supplier_name": "Test Supplier1",
+			"contact": None
+		}
+
+		update_password_link = "http://example.com/set-password"
+		rfq_link = "http://example.com/submit-quotation"
+
+		preview = rfq.supplier_rfq_mail(data, update_password_link, rfq_link, preview=True)
+
+		self.assertIn("Test Supplier1", preview["message"])
+		self.assertIn("Set Password", preview["message"])
+		self.assertIn("Test Supplier Name", preview["subject"])
+		
+	def test_on_cancel_TC_B_199(self):
+		rfq = make_request_for_quotation()
+		rfq.cancel()
+		cancelled_rfq = frappe.get_doc("Request for Quotation", rfq.name)
+		self.assertEqual(cancelled_rfq.status, "Cancelled")
+
+	def test_get_attachments_TC_B_200(self):
+		rfq = make_request_for_quotation()
+
+		file = frappe.get_doc({
+			"doctype": "File",
+			"file_name": "test.txt",
+			"attached_to_doctype": "Request for Quotation",
+			"attached_to_name": rfq.name,
+			"content": "Hello, world!"
+		}).insert(ignore_permissions=True)
+
+		rfq.reload()
+		attachment_names = rfq.get_attachments()
+
+		self.assertIn(file.name, attachment_names)
+
+	def test_get_item_from_material_requests_based_on_supplier_TC_B_201(self):
+		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
+			get_item_from_material_requests_based_on_supplier
+		)
+
+		supplier = frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Test Supplier"
+		}).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		gst_hsn_code = frappe.get_doc({
+			"doctype": "GST HSN Code",
+			"hsn_code": "110011"
+		}).insert(ignore_if_duplicate=True, ignore_permissions=True).name
+
+		item_code = "_Test Item Supplier Coverage"
+		item = frappe.get_doc({
+			"doctype": "Item",
+			"item_code": item_code,
+			"item_name": item_code,
+			"stock_uom": "Nos",
+			"item_group": "All Item Groups",
+			"gst_hsn_code": gst_hsn_code,
+			"is_stock_item": 1
+		}).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		item = frappe.get_doc("Item", item.name)
+		if not any(row.supplier == supplier.name for row in item.supplier_items):
+			item.append("supplier_items", {"supplier": supplier.name})
+			item.save()
+
+		warehouse = frappe.get_doc({
+			"doctype": "Warehouse",
+			"warehouse_name": "_Test Stores"
+		}).insert(ignore_if_duplicate=True)
+
+		mr = frappe.get_doc({
+			"doctype": "Material Request",
+			"material_request_type": "Purchase",
+			"schedule_date": frappe.utils.add_days(frappe.utils.nowdate(), 5),
+			"items": [{
+				"item_code": item.name,
+				"qty": 10,
+				"schedule_date": frappe.utils.add_days(frappe.utils.nowdate(), 5),
+				"warehouse": warehouse.name,
+			}]
+		}).insert(ignore_permissions=True)
+		mr.submit()
+
+		rfq_doc = get_item_from_material_requests_based_on_supplier(supplier.name)
+
+		self.assertIsNotNone(rfq_doc)
+		self.assertEqual(rfq_doc.doctype, "Request for Quotation")
+		self.assertEqual(len(rfq_doc.items), 1)
+		self.assertEqual(rfq_doc.items[0].item_code, item.name)
+		self.assertEqual(rfq_doc.items[0].material_request, mr.name)
+
+	def test_send_email_TC_B_202(self):
+		from unittest.mock import patch
+		item_code = "_Test Item"
+		if not frappe.db.exists("Item", item_code):
+			make_item(item_code, {"stock_uom": "Nos"})
+
+		supplier = frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Email Test Supplier"
+		}).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		rfq = make_request_for_quotation(item_code=item_code, supplier_data=[{
+			"supplier": supplier.name,
+			"supplier_name": supplier.supplier_name,
+			"email_id": "testrfquser@example.com"
+		}], do_not_submit=True)
+		rfq.email_template = "Dispatch Notification"
+
+		data = frappe._dict({
+			"supplier": supplier.name,
+			"supplier_name": supplier.supplier_name,
+			"email_id": "testrfquser@example.com",
+			"contact": None
+		})
+
+		update_password_link = "http://example.com/set-password"
+		rfq_link = "http://example.com/submit-quotation"
+
+		with patch("erpnext.buying.doctype.request_for_quotation.request_for_quotation.make") as mock_make:
+			rfq.supplier_rfq_mail(data, update_password_link, rfq_link, preview=False)
+
+			mock_make.assert_called_once()
+			args, kwargs = mock_make.call_args
+			self.assertIn("subject", kwargs)
+			self.assertIn("recipients", kwargs)
+			self.assertEqual(kwargs["recipients"], data.email_id)
 
 
 def make_request_for_quotation(**args) -> "RequestforQuotation":

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -187,7 +187,6 @@ class TestRequestforQuotation(FrappeTestCase):
 			"reference_doctype": "Request for Quotation",
 			"reference_name": self.rfq.name
 		})
-		print('rfq_name', self.rfq.name)
 		self.assertGreaterEqual(len(communications), 1)
 
 	def test_get_supplier_email_preview_TC_B_194(self):


### PR DESCRIPTION
### Test Summary
This test suite verifies multiple functionalities related to the Request for Quotation (RFQ) doctype, including email communication, supplier tagging, RFQ previews, list context, attachment handling, supplier-item relationships, and item fetching from Material Requests. The purpose is to ensure robustness and correctness across various use cases and interactions with related doctypes.

### Scenarios Covered
 TC_B_193 – test_send_supplier_emails_runs
Verifies that the send_supplier_emails function sends communication for the given RFQ. It asserts that at least one communication is logged against the RFQ.

TC_B_194 – test_get_supplier_email_preview
Checks if get_supplier_email_preview generates a correctly formatted email preview for a supplier. It asserts the presence of proper greeting and recipient email in the preview.

TC_B_195 – test_get_supplier_tag
Tests the utility function get_supplier_tag and ensures it returns a list of tags (used for supplier filtering/tagging). Verifies return type is list.

TC_B_196 – test_get_rfq_containing_supplier
Verifies that get_rfq_containing_supplier correctly returns RFQs containing a specific supplier and matching filter criteria (like company and transaction date).

TC_B_197 – test_get_list_context_coverage
Tests the web context returned by get_list_context, ensuring UI elements like title, sidebar, and breadcrumbs are correctly configured for the RFQ list page.

TC_B_198 – test_supplier_rfq_mail
Tests the supplier_rfq_mail method of the RFQ doctype. Ensures it generates a complete message with supplier name, password setup link, and a subject containing supplier info.

TC_B_199 – test_on_cancel
Verifies that cancelling an RFQ sets its status to "Cancelled". Helps ensure the cancel operation correctly updates the document state.

TC_B_200 – test_get_attachments
Checks whether attachments linked to the RFQ are correctly retrieved using the get_attachments method.

TC_B_201 – test_get_item_from_material_requests_based_on_supplier Tests the function that fetches items from Material Requests based on the linked supplier. Ensures that:

An RFQ is generated,

The correct item is included,

It’s tied to the proper Material Request.

TC_B_202 – test_send_email
Uses unittest.mock.patch to mock the make function responsible for sending an email. It verifies that an email is triggered and that the correct recipients and subject are passed.

### Technology
Tests are written using FrappeTestCase

### Linked Feature/Bug
None
