### PR TITLE
fix: ignoring type_checking condition to improve code coverage

### DIFF
--- a/erpnext/buying/doctype/remittance_of_tds_certificate/remittance_of_tds_certificate.py
+++ b/erpnext/buying/doctype/remittance_of_tds_certificate/remittance_of_tds_certificate.py
@@ -12,7 +12,7 @@ class RemittanceofTDScertificate(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from erpnext.buying.doctype.logs.logs import logs
 		from frappe.types import DF
 

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -27,7 +27,7 @@ class RequestforQuotation(BuyingController):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from erpnext.buying.doctype.request_for_quotation_item.request_for_quotation_item import RequestforQuotationItem
 		from erpnext.buying.doctype.request_for_quotation_supplier.request_for_quotation_supplier import RequestforQuotationSupplier
 		from frappe.types import DF

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -25,7 +25,7 @@ class Supplier(TransactionBase):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from erpnext.accounts.doctype.allowed_to_transact_with.allowed_to_transact_with import AllowedToTransactWith
 		from erpnext.accounts.doctype.party_account.party_account import PartyAccount
 		from erpnext.utilities.doctype.portal_user.portal_user import PortalUser

--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -21,7 +21,7 @@ class SupplierScorecard(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.buying.doctype.supplier_scorecard_scoring_criteria.supplier_scorecard_scoring_criteria import (

--- a/erpnext/buying/doctype/supplier_scorecard_period/supplier_scorecard_period.py
+++ b/erpnext/buying/doctype/supplier_scorecard_period/supplier_scorecard_period.py
@@ -19,7 +19,7 @@ class SupplierScorecardPeriod(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.buying.doctype.supplier_scorecard_scoring_criteria.supplier_scorecard_scoring_criteria import (

--- a/erpnext/buying/doctype/supplier_scorecard_scoring_criteria/supplier_scorecard_scoring_criteria.py
+++ b/erpnext/buying/doctype/supplier_scorecard_scoring_criteria/supplier_scorecard_scoring_criteria.py
@@ -11,7 +11,7 @@ class SupplierScorecardScoringCriteria(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		criteria_name: DF.Link

--- a/erpnext/buying/doctype/supplier_scorecard_scoring_standing/supplier_scorecard_scoring_standing.py
+++ b/erpnext/buying/doctype/supplier_scorecard_scoring_standing/supplier_scorecard_scoring_standing.py
@@ -11,7 +11,7 @@ class SupplierScorecardScoringStanding(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		employee_link: DF.Link | None


### PR DESCRIPTION
### Bug Description
The test coverage report included lines that are not meant to be executed at runtime (like if TYPE_CHECKING blocks), leading to misleading coverage metrics. This caused confusion during CI analysis and reduced the effectiveness of coverage tools in identifying real test gaps.

### Root Cause
Python type hints and conditional imports guarded by if TYPE_CHECKING: were being included in coverage reports. Since these lines are never run, they were incorrectly marked as uncovered.

Steps to Reproduce:

Add a type-only import inside an if TYPE_CHECKING: block.

Run coverage analysis using coverage.py.

Observe that these lines are shown as uncovered.

Actual/Observed Result:
Type-check-only imports are reported as missing in code coverage.

Expected Result:
Type-check-only imports should be excluded from coverage to avoid false negatives.

### Fix Summary
Added # pragma: no cover to the if TYPE_CHECKING: lines and similar blocks to instruct the coverage tool to skip them.

### Affected Module
All modules using TYPE_CHECKING conditional imports 

### Test Cases Covered
Static typing and import resolution validated manually

Coverage report validated for accuracy post-change

### Linked Issue
None

### PR Reference
https://github.com/8848digital/erpnext/pull/2396