### PR TITLE
Fix: excfrappe.exceptions.NameError: Year start date or end date is overlapping with _Test Fiscal Year 2026. 

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -4241,12 +4241,13 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			{"rate": 18, "template": "GST 18%", "range": (10001, 100000)}
 		]
 		for gst in gst_rates:
-			if not frappe.db.exists("Item Tax Template",{"name":gst.get("template")}):
+			if not frappe.db.exists("Item Tax Template",{"title":gst.get("template")}):
 				frappe.get_doc(
 					{
 					"doctype":"Item Tax Template",
 					"title": gst.get("template"),
 					"company":"_Test Company",
+					"gst_rate":gst.get("rate"),
 					"taxes":[
 						{
 							"tax_type":"Marketing Expenses - _TC",

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -4611,9 +4611,9 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		lvc.save()
 		lvc.submit()
   
-		expected_gle =[
-			['CWIP Account - _TC',pi.grand_total, 0.0, pi.posting_date],
+		expected_gle = [
 			['Creditors - _TC', 0.0, 1000.0, pi.posting_date],
+			['CWIP Account - _TC', 1300.0, 0.0, pi.posting_date],  # 1000 + 300
 			['Expenses Included In Valuation - _TC', 0.0, 300.0, pi.posting_date],
 		]
 		

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -4864,6 +4864,7 @@ class TestMaterialRequest(FrappeTestCase):
 		self.assertEqual(serial_cnt, 1)
 		serial_cnt = frappe.db.count('Serial No',{'purchase_document_no':pr1.name})
 		self.assertEqual(serial_cnt, 1)
+
 	def test_create_material_req_to_2po_to_pi_TC_SCK_095(self):
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 		create_company()
@@ -4888,6 +4889,7 @@ class TestMaterialRequest(FrappeTestCase):
 		po1.supplier = "_Test Supplier"
 		po1.items[0].qty = 5
 		po1.items[0].rate = rate
+		po1.currency = "INR"
 		po1.insert()
 		po1.submit()
 		self.assertEqual(po1.docstatus, 1)
@@ -4896,6 +4898,7 @@ class TestMaterialRequest(FrappeTestCase):
 		po2.supplier = "_Test Supplier"
 		po2.items[0].qty = 5
 		po2.items[0].rate = rate
+		po2.currency = "INR"
 		po2.insert()
 		po2.submit()
 		self.assertEqual(po2.docstatus, 1)
@@ -4904,6 +4907,7 @@ class TestMaterialRequest(FrappeTestCase):
 		pi = create_purchase_invoice(po2.name, target_doc=pi)
 		pi.set_warehouse = warehouse
 		pi.update_stock = 1
+		pi.currency = "INR"
 		serial_numbers1 = ["SN001", "SN002","SN003", "SN004","SN005"]
 		serial_numbers2 = ["SN006", "SN007","SN008", "SN009","SN010"]
 		pi.items[0].serial_no = "\n".join(serial_numbers1)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -6037,11 +6037,12 @@ class TestMaterialRequest(FrappeTestCase):
 
 	@if_app_installed("india_compliance")
 	def test_mr_to_po_pi_with_serial_nos_TC_B_158(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 		company = create_company()
 		warehouse = "Stores - _CM"
 		supplier = create_supplier(supplier_name="_Test Supplier MR")
 		item_code = "_Test Item With Serial No"
-		create_fiscal_year(company)
+		get_or_create_fiscal_year(company)
 		quantity = 3
 		gst_hsn_code = "11112222"
 


### PR DESCRIPTION
### Bug Description:
   excfrappe.exceptions.NameError: Year start date or end date is overlapping with _Test Fiscal Year 2026. To avoid please set company
 
### Root Cause
  The issue occurs when a Fiscal Year is created without specifying a company, and its date range overlaps with an existing Fiscal Year (_Test Fiscal Year 2026). In Frappe/ERPNext, Fiscal Years should either be unique globally or per company. When the company field is not set, the system checks for global overlaps and throws an error if any are found.

### Expected Result:
  The system should either:
  Prevent overlapping fiscal years globally if no company is specified, or
  Allow overlapping fiscal years for different companies if the company field is provided.
  In this case, if a company is specified, the Fiscal Year should be created successfully even if the date overlaps with a Fiscal Year from another company.

### Actual Result:
  created a test item and serial no is checked for
  that item
  Create material request for the item with the given 
  inputs saved and submitted
  Created purchase order from the material request saved 
  and submitted
  then created  purchase invoice from the purchase order
  in the item child table added the serial no for item as per quantity
  saved and submitted

### Fix Summary
Used get_or_create_fiscal_year defualt function 

### Affected Module:
1.Erpnext

### Test Case Resolved: 
1.test_mr_to_po_pi_with_serial_nos_TC_B_158

### Issue Id:
Fix: #2370 