### PR TITLE
Test Cases for Buying Module Reports with Proper Test Data Coverage

### DIFF
--- a/erpnext/buying/report/item_wise_purchase_history/test_item_wise_purchase_history.py
+++ b/erpnext/buying/report/item_wise_purchase_history/test_item_wise_purchase_history.py
@@ -1,0 +1,55 @@
+import frappe
+from frappe.utils import today, add_days
+from frappe.tests.utils import FrappeTestCase
+
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+from erpnext.buying.report.item_wise_purchase_history.item_wise_purchase_history import execute
+
+class TestItemWisePurchaseHistory(FrappeTestCase):
+	def setUp(self):
+		self.item = make_test_item("test_report_item")
+		po = self.create_purchase_order()
+		po.submit()
+
+		self.filters = frappe._dict(
+			company = po.company,
+			from_date = add_days(today(), -30),
+			to_date = today(),
+			item_code = self.item.item_name
+		)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_item_wise_purchase_history_TC_B_214(self):
+		data = execute(self.filters)
+		report_data = data[1][0]
+		if report_data.get("item_code") == self.item.item_code:
+			self.assertEqual(report_data.get("item_code"), "test_report_item")
+			self.assertEqual(report_data.get("item_group"), "Products")
+			self.assertEqual(report_data.get("quantity"), 10)
+			self.assertEqual(report_data.get("uom"), "_Test UOM")
+			self.assertEqual(report_data.get("rate"), 500)
+			self.assertEqual(report_data.get("amount"), 5000)
+			self.assertEqual(report_data.get("supplier"), "_Test Supplier")
+			self.assertEqual(report_data.get("company"), "_Test Company")
+
+	def test_validate_filters_TC_B_215(self):
+		self.filters.update({"from_date": today(),"to_date": add_days(today(), -1)})
+
+		with self.assertRaises(frappe.ValidationError):
+			execute(self.filters)
+
+
+	def create_purchase_order(self):
+		po = frappe.copy_doc(test_records[0]).insert()
+		po = frappe.get_doc("Purchase Order", po.name)
+		po.transaction_date = today()
+		po.schedule_date = today()
+		po.items[0].item_code = self.item.item_code
+		po.items[0].schedule_date = today()
+		po.save()
+
+		return po
+
+test_records = frappe.get_test_records("Purchase Order")

--- a/erpnext/buying/report/procurement_tracker/test_procurement_tracker.py
+++ b/erpnext/buying/report/procurement_tracker/test_procurement_tracker.py
@@ -1,9 +1,54 @@
 # Copyright (c) 2013, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import frappe
 
+from frappe.utils import today, add_days
 from frappe.tests.utils import FrappeTestCase
 
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+from erpnext.stock.doctype.material_request.material_request import make_purchase_order
+from erpnext.stock.doctype.material_request.test_material_request import make_material_request
+from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+from erpnext.buying.report.procurement_tracker.procurement_tracker import execute
 
 class TestProcurementTracker(FrappeTestCase):
-	pass
+	def setUp(self):
+		self.item = make_test_item("test_procurement_item")
+		self.supplier = create_supplier(supplier_name="_Test Supplier Procurement")
+		self.filters = frappe._dict(
+			from_date = add_days(today(), -30),
+			to_date = today(),
+		)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_procurement_tracker_report_TC_B_216(self):
+		mr = make_material_request(
+			item_code = self.item.item_code,
+			do_not_submit = True
+		)
+		mr.submit()
+		self.assertEqual(mr.docstatus, 1)
+
+		po = make_purchase_order(mr.name)
+		po.supplier = self.supplier
+		po.insert()
+		po.submit()
+		self.assertEqual(po.docstatus, 1)
+
+		self.filters["company"] = po.company
+
+		data = execute(self.filters)
+		for item in data[1]:
+			if item.get("item_code") == self.item.item_code:
+				self.assertEqual(item.get("item_code"), "test_procurement_item")
+				self.assertEqual(item.get("quantity"), 10)
+				self.assertEqual(item.get("unit_of_measurement"), "Nos")
+				self.assertEqual(item.get("status"), "To Receive and Bill")
+				self.assertEqual(item.get("supplier"), "_Test Supplier Procurement")
+				self.assertEqual(item.get("estimated_cost"), 0)
+				self.assertEqual(item.get("actual_cost"), 0)
+				self.assertEqual(item.get("purchase_order_amt"), 0)
+				self.assertEqual(item.get("purchase_order_amt_in_company_currency"), 0)

--- a/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
+++ b/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
@@ -1,0 +1,55 @@
+import frappe
+from frappe.utils import today, add_days
+from frappe.tests.utils import FrappeTestCase
+
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+from erpnext.buying.report.purchase_analytics.purchase_analytics import execute
+
+class TestPurchaseAnalytics(FrappeTestCase):
+	def setUp(self):
+		self.item = make_test_item("test_purchase_item")
+		po = self.create_purchase_order()
+		po.submit()
+
+		self.filters = frappe._dict(
+			company = po.company,
+			from_date = add_days(today(), -30),
+			to_date = today(),
+			tree_type = "Item",
+			value_quantity = "Value",
+			range = "Monthly",
+			doc_type = "Purchase Order"
+		)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_purchase_analytics_report_TC_B_217(self):
+		data = execute(self.filters)
+		for item in data[1]:
+			if item.get("entity") == self.item.item_code:
+				self.assertEqual(item.get("entity"), "test_purchase_item")
+				self.assertEqual(item.get("entity_name"), "_Test Item")
+				self.assertEqual(item.get("total"), 5000)
+
+		# based on quantity
+		self.filters.update({"value_quantity": "Quantity"})
+		data_quantity = execute(self.filters)
+		for row in data_quantity[1]:
+			if row.get("entity") == self.item.item_code:
+				self.assertEqual(row.get("entity"), "test_purchase_item")
+				self.assertEqual(row.get("entity_name"), "_Test Item")
+				self.assertEqual(row.get("total"), 10)
+
+	def create_purchase_order(self):
+		po = frappe.copy_doc(test_records[0]).insert()
+		po = frappe.get_doc("Purchase Order", po.name)
+		po.transaction_date = today()
+		po.schedule_date = today()
+		po.items[0].item_code = self.item.item_code
+		po.items[0].schedule_date = today()
+		po.save()
+
+		return po
+
+test_records = frappe.get_test_records("Purchase Order")

--- a/erpnext/buying/report/purchase_order_analysis/test_purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/test_purchase_order_analysis.py
@@ -1,0 +1,72 @@
+import frappe
+from frappe.utils import today, add_days
+from frappe.tests.utils import FrappeTestCase
+
+from erpnext.buying.report.purchase_order_analysis.purchase_order_analysis import execute
+
+class TestPurchaseOrderAnalysis(FrappeTestCase):
+	def setUp(self):
+		po = create_purchase_order()
+		po.submit()
+
+		self.filters = frappe._dict(
+			company = po.company,
+			from_date = add_days(today(), -30),
+			to_date = today(),
+		)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_purchase_order_analysis_report_TC_B_218(self):
+		self.filters.update(
+			{
+				"status": ["To Receive and Bill"],
+				"group_by_po": 1
+			}
+		)
+
+		data = execute(self.filters)
+		report_data = data[1][0]
+
+		self.assertEqual(report_data.get("status"), "To Receive and Bill")
+		self.assertEqual(report_data.get("supplier"), "_Test Supplier")
+		self.assertEqual(report_data.get("item_code"), "_Test Item")
+		self.assertEqual(report_data.get("qty"), 10)
+		self.assertEqual(report_data.get("received_qty"), 0)
+		self.assertEqual(report_data.get("pending_qty"), 10)
+		self.assertEqual(report_data.get("billed_qty"), 0)
+		self.assertEqual(report_data.get("amount"), 5000)
+		self.assertEqual(report_data.get("billed_amount"), 0)
+		self.assertEqual(report_data.get("pending_amount"), 5000)
+		self.assertEqual(report_data.get("company"), "_Test Company")
+		self.assertEqual(report_data.get("received_qty_amount"), 0)
+		self.assertEqual(report_data.get("qty_to_bill"), 10)
+
+	def test_validate_filters_TC_B_219(self):
+		self.filters.update({"from_date": ""})
+
+		with self.assertRaises(frappe.ValidationError):
+			execute(self.filters)
+
+		self.filters.update({"from_date": today(),"to_date": add_days(today(), -1)})
+
+		with self.assertRaises(frappe.ValidationError):
+			execute(self.filters)
+
+		self.filters = {}
+		data = execute(self.filters)
+		self.assertEqual(len(data[1]), 0)
+
+
+def create_purchase_order():
+	po = frappe.copy_doc(test_records[0]).insert()
+	po = frappe.get_doc("Purchase Order", po.name)
+	po.transaction_date = today()
+	po.schedule_date = today()
+	po.items[0].schedule_date = today()
+	po.save()
+
+	return po
+
+test_records = frappe.get_test_records("Purchase Order")

--- a/erpnext/buying/report/purchase_order_trends/test_purchase_order_trends.py
+++ b/erpnext/buying/report/purchase_order_trends/test_purchase_order_trends.py
@@ -1,0 +1,69 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import get_active_fiscal_year
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+from .purchase_order_trends import execute
+
+class TestPurchaseOrderTrends(FrappeTestCase):
+	def setUp(self):
+		self.item = make_test_item("test_trends_item")
+		po = create_purchase_order(item_code = self.item.item_code)
+		self.filters = frappe._dict(
+			company = "_Test Company",
+			period = "Monthly",
+			fiscal_year = get_active_fiscal_year(),
+			period_based_on = "Posting Date",
+			based_on = "Item"
+		)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_purchase_order_trends_report_TC_B_220(self):
+		# based on item
+		data = execute(self.filters)
+		for row in data[1]:
+			if row[0] == "test_trends_item":
+				self.assertEqual(row[0], "test_trends_item")
+
+		# based on supplier
+		self.filters.update(
+			{
+				"based_on": "Supplier"
+			}
+		)
+		s_data = execute(self.filters)
+		for row_1 in s_data[1]:
+			if row_1[0] == "_Test Supplier":
+				self.assertEqual(row_1[1], "_Test Supplier Group")
+
+		# based on supplier group
+		self.filters.update(
+			{
+				"based_on": "Supplier Group"
+			}
+		)
+		sg_data = execute(self.filters)
+		for row_2 in sg_data[1]:
+			if row_2[0] == "_Test Supplier Group":
+				self.assertEqual(row_2[0], "_Test Supplier Group")
+
+		# based on item group
+		self.filters.update(
+			{
+				"based_on": "Item Group"
+			}
+		)
+		ig_data = execute(self.filters)
+		for row_3 in ig_data[1]:
+			if row_3[0] == "_Test Item Group":
+				self.assertEqual(row_3[0], "_Test Item Group")
+
+		# based on group by item
+		self.filters["group_by"] = "Item"
+		g_data = execute(self.filters)
+		for row_4 in g_data[1]:
+			print(row_4[0])
+			if row_4[0] == "_Test Item Group":
+				self.assertEqual(row_4[0],  "_Test Item Group")

--- a/erpnext/buying/report/requested_items_to_order_and_receive/test_requested_items_to_order_and_receive.py
+++ b/erpnext/buying/report/requested_items_to_order_and_receive/test_requested_items_to_order_and_receive.py
@@ -7,7 +7,7 @@ from frappe.utils import add_days, today
 
 from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
 from erpnext.buying.report.requested_items_to_order_and_receive.requested_items_to_order_and_receive import (
-	get_data,
+	get_data, execute
 )
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.material_request.material_request import make_purchase_order
@@ -44,6 +44,40 @@ class TestRequestedItemsToOrderAndReceive(FrappeTestCase):
 		self.assertEqual(len(data), 2)
 		self.assertEqual(data[0].ordered_qty, 0.0)
 		self.assertEqual(data[1].ordered_qty, 57.0)
+
+	def test_requested_items_TC_B_221(self):
+		data = execute(self.filters)
+
+		self.assertEqual(len(data[1]), 2)
+		self.assertEqual(data[1][0].ordered_qty, 0.0)
+		self.assertEqual(data[1][1].ordered_qty, 57.0)
+
+		values_dict = {
+			dataset['name']: dataset['values'][0]
+			for dataset in data[3]['data']['datasets']
+		}
+		self.assertEqual(values_dict.get("Qty to Order"), 57)
+		self.assertEqual(values_dict.get("Ordered Qty"), 57)
+		self.assertEqual(values_dict.get("Received Qty"), 0)
+		self.assertEqual(values_dict.get("Qty to Receive"), 114)
+
+		self.filters.update({"group_by_mr": 1})
+		data_1 = execute(self.filters)
+
+	def test_validate_filters_TC_B_222(self):
+		self.filters.update({"from_date": ""})
+
+		with self.assertRaises(frappe.ValidationError):
+			execute(self.filters)
+
+		self.filters.update({"from_date": today(),"to_date": add_days(today(), -1)})
+
+		with self.assertRaises(frappe.ValidationError):
+			execute(self.filters)
+
+		self.filters = {}
+		data = execute(self.filters)
+		self.assertEqual(len(data[1]), 0)
 
 	def setup_material_request(self, order=False, receive=False, days=0):
 		po = None

--- a/erpnext/buying/report/subcontract_order_summary/test_subcontract_order_summary.py
+++ b/erpnext/buying/report/subcontract_order_summary/test_subcontract_order_summary.py
@@ -1,0 +1,77 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today, add_days
+
+from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import create_subcontracting_order
+from erpnext.controllers.tests.test_subcontracting_controller import (
+	make_bom_for_subcontracted_items,
+	make_raw_materials,
+	make_service_items,
+	make_subcontracted_items,
+)
+
+class TestSubcontractOrderSummery(FrappeTestCase):
+	def setUp(self):
+		make_subcontracted_items()
+		make_raw_materials()
+		make_service_items()
+		make_bom_for_subcontracted_items()
+		self.setup_for_subcontracting_order()
+
+		self.filters = frappe._dict(
+			company="_Test Company",
+			from_date=add_days(today(), -30),
+			to_date=today(),
+			order_type="Subcontracting Order"
+		)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_subcontract_order_summary_TC_B_223(self):
+		from .subcontract_order_summary import execute
+		data = execute(self.filters)
+		for row in data[1]:
+			if row.get("item_code") == "Subcontracted Item SA8":
+				self.assertEqual(row.get("item_name"), "Subcontracted Item SA8")
+				self.assertEqual(row.get("qty"), 10)
+				self.assertEqual(row.get("received_qty"), 0)
+				self.assertEqual(row.get("status"), "Open")
+				self.assertEqual(row.get("main_item_code"), "Subcontracted Item SA8")
+				self.assertEqual(row.get("rm_item_code"), "Subcontracted SRM Item 8")
+				self.assertEqual(row.get("required_qty"), 10)
+				self.assertEqual(row.get("supplied_qty"), 0)
+				self.assertEqual(row.get("returned_qty"), 0)
+				self.assertEqual(row.get("total_supplied_qty"), 0)
+				self.assertEqual(row.get("consumed_qty"), 0)
+
+	def setup_for_subcontracting_order(self):
+		from erpnext.stock.doctype.material_request.material_request import make_purchase_order
+		from erpnext.stock.doctype.material_request.test_material_request import make_material_request
+
+		mr = make_material_request(
+			item_code="Subcontracted Item SA8",
+			material_request_type="Purchase",
+			qty=10,
+		)
+
+		self.assertTrue(mr.docstatus == 1)
+
+		po = make_purchase_order(mr.name)
+		po.is_subcontracted = 1
+		po.supplier = "_Test Supplier"
+		po.items[0].fg_item = "Subcontracted Item SA8"
+		po.items[0].fg_item_qty = 10
+		po.items[0].item_code = "Subcontracted Service Item 8"
+		po.items[0].item_name = "Subcontracted Service Item 8"
+		po.items[0].qty = 10
+		po.supplier_warehouse = "_Test Warehouse 1 - _TC"
+		po.save()
+		po.submit()
+
+		self.assertTrue(po.items[0].material_request)
+		self.assertTrue(po.items[0].material_request_item)
+
+		sco = create_subcontracting_order(po_name=po.name)
+		self.assertTrue(sco.items[0].material_request)
+		self.assertTrue(sco.items[0].material_request_item)

--- a/erpnext/buying/report/supplier_quotation_comparison/test_supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/test_supplier_quotation_comparison.py
@@ -1,0 +1,63 @@
+import frappe
+
+from frappe.utils import today, add_days
+from frappe.tests.utils import FrappeTestCase
+
+from erpnext.buying.report.supplier_quotation_comparison.supplier_quotation_comparison import execute
+
+class TestSupplierQuotationComparison(FrappeTestCase):
+	def setUp(self):
+		sq = create_supplier_quotation()
+		sq.transaction_date = today()
+		sq.insert()
+		sq.submit()
+
+		self.filters = {
+			"company": sq.company,
+			"from_date": add_days(today(), -1),
+			"to_date": today()
+		}
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_supplier_quotation_data_TC_B_224(self):
+		data = execute(self.filters)
+		item_data = data[1][0]
+		self.assertEqual(item_data.get("item_code"), "_Test FG Item")
+		self.assertEqual(item_data.get("supplier_name"), "_Test Supplier")
+
+		# based on group by Item
+		self.filters["group_by"] = "Group by Item"
+		group_data = execute(self.filters)
+		item_group_data = group_data[1][0]
+		self.assertEqual(item_group_data.get("item_code"), "_Test FG Item")
+		self.assertEqual(item_group_data.get("supplier_name"), "_Test Supplier")
+
+		# based on group by supplier
+		self.filters["group_by"] = "Group by Supplier"
+		s_data = execute(self.filters)
+		supplier_group_data = s_data[1][0]
+		self.assertEqual(supplier_group_data.get("item_code"), "_Test FG Item")
+		self.assertEqual(supplier_group_data.get("supplier_name"), "_Test Supplier")
+
+		self.filters["include_expired"] = 1
+		e_data = execute(self.filters)
+		expired_data = e_data[1][0]
+		self.assertEqual(expired_data.get("item_code"), "_Test FG Item")
+		self.assertEqual(expired_data.get("supplier_name"), "_Test Supplier")
+
+		# based on item_code
+		self.filters["item_code"] = "_Test FG Item"
+		i_data = execute(self.filters)
+		based_on_item = i_data[1][0]
+		self.assertEqual(based_on_item.get("item_code"), "_Test FG Item")
+		self.assertEqual(based_on_item.get("supplier_name"), "_Test Supplier")
+
+def create_supplier_quotation():
+	sq = frappe.copy_doc(test_records[0]).insert()
+	sq = frappe.get_doc("Supplier Quotation", sq.name)
+
+	return sq
+
+test_records = frappe.get_test_records("Supplier Quotation")


### PR DESCRIPTION
### Title: Test Cases for Buying Module Reports with Proper Test Data Coverage

# Description:
### Test Summary
- A comprehensive suite of automated test cases was missing for various standard reports in the Buying module. This made it difficult to ensure correctness of key reports like Item Wise Purchase History, Procurement Tracker, Purchase Analytics, etc.
The new test cases include realistic test data creation (Item, Material Request, Purchase Orders, etc.) and simulate business flows to verify report accuracy.
**Report: Item Wise Purchase History**
 - TC_B_214: Validates accurate purchase data retrieval post Purchase Order submission.
- TC_B_215: Ensures proper date filter validation by raising frappe.ValidationError on incorrect date range
**Report: Procurement Tracker**
- TC_B_216: Validates correct data retrieval by linking a submitted Material Request with a Purchase Order. Ensures report returns correct procurement values.
 **Report: Purchase Analytics**
- TC_B_217: Verifies Purchase Analytics report with filters for Value and Quantity.
**Report: Purchase Order Analysis**
 - TC_B_218: Ensures accurate data grouping by Purchase Order.
 - TC_B_219: Validates error handling for missing filters and invalid date ranges.
 **Report: Purchase Order Trends**
 - TC_B_220: Validates grouped data for filters like Item, Supplier, Supplier Group, Item Group, and Group by Item.
**Report: Requested Items To Order and Receive**
 - TC_B_221: Validates chart and table output for different MR states.
 - TC_B_222: Validates required filter enforcement and proper handling of empty or invalid filters.
**Report: Subcontract Order Summary**
- TC_B_223: Validates correct report output for a subcontracted item with associated BOM, Material Request, and Purchase Order.
**Report: Supplier Quotation Comparison**
- **TC_B_224**: Ensures correctness for grouping options and filter combinations.

### Scenarios Covered
**Input Validations**
 - **TC_B_214** - Created a test Item, Created a Purchase Order with test data, once purchase order is submitted, the report will shows the data
 - **TC_B_215** - validating the dates
 - **TC_B_216** - Create a Material Request (MR) with the test item and submit it, Create a Purchase Order (PO) against the MR and assign the test supplier, Submit the PO, Set the company filter to match the PO’s company, Verify that the report contains a row matching the item and the expected procurement details
 - **TC_B_217** - Run the Purchase Analytics report with value_quantity = "Value", Update the filter to use value_quantity = "Quantity".
 - **TC_B_218** - validates the data, checks the data came as expected or not
 - **TC_B_219** - Remove from_date from filters. Expect: frappe.ValidationError, Set from_date = today() and to_date = yesterday. Expect: frappe.ValidationError (invalid date range), Pass empty filters (self.filters = {}). Expect: no error, but empty result set.
 - **TC_B_220** - data Based on Item, Based on Supplier, Based on Supplier Group, Based on Item Group, Group by Item
 - **TC_B_221** - Verify that 2 records are returned (since 1 MR was already fully received), Verify assert checks
 - **TC_B_222** - Missing from_date - Expect frappe.ValidationError, Invalid date range - Expect frappe.ValidationError, Empty filters - Assert that 0 rows are returned
 - **TC_B_223** - Subcontracted item (Subcontracted Item SA8), raw material (Subcontracted SRM Item 8), and service item (Subcontracted Service Item 8) are created, BOM for the subcontracted item is configured, A Material Request of type "Purchase" is submitted for Subcontracted Item SA8, A Purchase Order is generated from the MR, Marked as subcontracted (is_subcontracted = 1), Set with relevant item and raw material details, A Subcontracting Order (SCO) is created from the PO.
 - **TC_B_224** - Base Case – No grouping, Group by Item, Group by Supplier, Include Expired Quotations, Filter by Item Code
 

**Edges Covered**
- **TC_B_214** - verify that the report returns accurate purchase data for the given item
- **TC_B_216** - To validate that the Procurement Tracker report correctly displays data based on a submitted Material Request and its linked Purchase Order
- **TC_B_217** - validate that the Purchase Analytics report returns accurate data when filtered by item and viewed by both Value and Quantity
- **TC_B_218** - Purchase Order Analysis report returns correct data grouped by Purchase Order
- **TC_B_220** - Purchase Order Trends report correctly returns grouped data based on various grouping filters (Item, Supplier, Supplier Group, Item Group, Group by Item)
- **TC_B_221** - Requested Items To Order and Receive report accurately reflects the ordered and received quantities based on Material Requests (MRs), and generates correct chart dataset summaries
- **TC_B_223** - verify that the Subcontract Order Summary report correctly returns data for a given subcontracted item, showing accurate quantities, status, and related fields.
- **TC_B_224** - Supplier Quotation Comparison report displays the correct item and supplier details under different filter conditions such as grouping and inclusion of expired quotations

**API Response Handling**
N/A

### Technology
 - Python unittest framework
 - Frappe/ERPNext testing utilities

### Linked Feature/Bug
N/A

### Issue ID
N/A