### PR TITLE
AttributeError: 'NoneType' object has no attribute 'coupon_code_based' #2378

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -4822,7 +4822,7 @@ class TestPurchaseOrder(FrappeTestCase):
 			tax_category.title = tax_category_1
 			tax_category.save()
 
-		frappe.db.set_value('Company', company, 'stock_received_but_not_billed', "Stock Received But Not Billed - _TC")
+		frappe.db.set_value("Company", company, {"enable_perpetual_inventory":1, "stock_received_but_not_billed": "Stock Received But Not Billed - _TC"})
 		item_tax_template = frappe.db.get_value("Purchase Taxes and Charges Template",{"company": company,"tax_category":tax_category_1}, "name")
 		if frappe.db.exists("DocType", "GST HSN Code") and not frappe.db.exists("GST HSN Code", gst_hsn_code):
 			frappe.get_doc({

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -7140,24 +7140,27 @@ def make_item_price():
         return ip_doc
 
 def make_pricing_rule():
-    if not frappe.db.exists('Pricing Rule', {'title': 'Test Offer'}):
-        pricing_rule_doc = frappe.new_doc('Pricing Rule')
-        pricing_rule_data = {
-            "title": 'Test Offer',
-            "apply_on": 'Item Code',
-            "price_or_product_discount": 'Price',
-            "selling": 1,
-            "min_qty": 10,
-            "company": '_Test Company',
-            "margin_type": 'Percentage',
-            "discount_percentage": 10,
-            "for_price_list": 'Standard Selling',
+	if not frappe.db.exists('Pricing Rule', {'title': 'Test Offer'}):
+		pricing_rule_doc = frappe.new_doc('Pricing Rule')
+		pricing_rule_data = {
+			"title": 'Test Offer',
+			"apply_on": 'Item Code',
+			"price_or_product_discount": 'Price',
+			"selling": 1,
+			"min_qty": 10,
+			"company": '_Test Company',
+			"margin_type": 'Percentage',
+			"discount_percentage": 10,
+			"for_price_list": 'Standard Selling',
 			"items":[ {"item_code": "_Test Item", "uom": '_Test UOM'}]
-        }
-        
-        pricing_rule_doc.update(pricing_rule_data)
-        pricing_rule_doc.save()
-        return pricing_rule_doc
+		}
+		
+		pricing_rule_doc.update(pricing_rule_data)
+		pricing_rule_doc.save()
+		return pricing_rule_doc
+	else:
+		pricing_rule_doc = frappe.get_doc('Pricing Rule', {'title': 'Test Offer'})
+		return pricing_rule_doc
 
 
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -3325,7 +3325,7 @@ class TestStockEntry(FrappeTestCase):
 		company = "_Test Company"
 		get_or_create_fiscal_year('_Test Company')
 		create_customer(name = '_Test Customer')
-		frappe.db.set_value("Company", company, "stock_adjustment_account", 'Stock Adjustment - _TC')
+		frappe.db.set_value("Company", company, {"enable_perpetual_inventory":1, "stock_adjustment_account": "Stock Adjustment - _TC"})
 		fields = {
 			"shelf_life_in_days": 365,
 			"end_of_life": "2099-12-31",
@@ -3413,7 +3413,7 @@ class TestStockEntry(FrappeTestCase):
 		company = "_Test Company"
 		get_or_create_fiscal_year('_Test Company')
 		create_customer(name = '_Test Customer' )
-		frappe.db.set_value("Company", company, "stock_adjustment_account", 'Stock Adjustment - _TC')
+		frappe.db.set_value("Company", company, {"enable_perpetual_inventory":1, "stock_adjustment_account": "Stock Adjustment - _TC"})
 		fields = {
 			"shelf_life_in_days": 365,
 			"end_of_life": "2099-12-31",
@@ -3693,7 +3693,7 @@ class TestStockEntry(FrappeTestCase):
 		company = "_Test Company"
 		get_or_create_fiscal_year('_Test Company')
 		create_customer(name = '_Test Customer' )
-		frappe.db.set_value("Company", company, "stock_adjustment_account", 'Stock Adjustment - _TC')
+		frappe.db.set_value("Company", company, {"enable_perpetual_inventory":1, "stock_adjustment_account": "Stock Adjustment - _TC"})
 		fields = {
 			"shelf_life_in_days": 365,
 			"end_of_life": "2099-12-31",


### PR DESCRIPTION
**Bug Description:**

1. AttributeError: 'NoneType' object has no attribute 'coupon_code_based' – Raised in scenario #2378 when make_pricing_rule returned None.
2. AssertionError: [] is not true – Raised in scenario #2379 during check_gl_entry, specifically at self.assertTrue(gl_entries).

**Root Cause:**

1. The make_pricing_rule function did not handle the case where the pricing rule already existed, resulting in it returning None.
2. GL Entries were not being created because the company was not configured to use perpetual inventory, hence the assertion failure.

**Expected Result:**

1. The make_pricing_rule function should always return a valid Pricing Rule document.
2. GL Entries should be created when expected during stock transactions.

**Actual Result:**

1. make_pricing_rule returned None when a rule already existed, leading to an AttributeError.
2. GL Entries list was empty due to missing configuration, causing the test to fail with an AssertionError.

**Fix Summary:**

1. Added an else block in make_pricing_rule to fetch and return the existing Pricing Rule if it already exists.
2. Updated the test setup to include "enable_perpetual_inventory": 1 in the Company settings to ensure GL Entries are generated.

**Affected Module:**

Selling -> Sales Order
Buying -> Purchase Order
Stock -> Stock Entry

**Test case Resolved:**

1. test_update_coupon_code_count_on_cancel_TC_S_173
2. test_create_2pr_with_item_fifo_and_sr_TC_SCK_14
3. test_create_2pr_with_item_mov_avg_and_sr_TC_SCK_15
4. test_default_uom_with_po_pr_pi_TC_B_105

**Linked Issue**
1. #2378 
2. #2379 