### PR TITLE
test : Add Test Cases for Remittance of TDS Certificate Utilities

### DIFF
--- a/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
+++ b/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
@@ -48,3 +48,98 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		self.assertIn("fcontent", result)
 		self.assertEqual(result["fname"], "test_attachment.txt")
 		self.assertEqual(result["fcontent"], b"Dummy content")
+
+	def test_get_emails_and_unrecored_pan_list_TC_B_189(self):
+		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_emails_and_unrecored_pan_list
+
+		frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Supplier With Email",
+			"pan": "ABCDE1234F",
+			"email_id": "supplier@example.com"
+		}).insert(ignore_if_duplicate=True)
+
+		frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Supplier Without Email",
+			"pan": "DGAPK9160G",
+			"email_id": ""
+		}).insert(ignore_if_duplicate=True)
+
+		test_data = [
+			{"pan": "ABCDE1234F", "file_name": "file1.pdf"}, 
+			{"pan": "DGAPK9160G", "file_name": "file2.pdf"},
+			{"pan": "DGAPK9160T", "file_name": "file3.pdf"}   
+			]
+
+
+		unrecorded_pan, emails_and_pan_list, pan_without_emails = get_emails_and_unrecored_pan_list(test_data)
+
+		self.assertEqual(len(emails_and_pan_list), 1)
+		self.assertEqual(emails_and_pan_list[0]["pan"], "ABCDE1234F")
+		self.assertEqual(emails_and_pan_list[0]["status"], "Success")
+
+		self.assertEqual(len(pan_without_emails), 1)
+		self.assertEqual(pan_without_emails[0]["pan"], "DGAPK9160G")
+		self.assertEqual(pan_without_emails[0]["status"], "Failure")
+
+		self.assertEqual(len(unrecorded_pan), 1)
+		self.assertEqual(unrecorded_pan[0]["pan"], "DGAPK9160T")
+		self.assertEqual(unrecorded_pan[0]["status"], "Failure")
+
+	def test_get_email_list_TC_B_225(self):
+		frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Supplier With Email",
+			"pan": "ABCDE1234F",
+			"email_id": "email@domain.com"
+		}).insert(ignore_if_duplicate=True)
+
+		frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Supplier Without Email",
+			"pan": "DGAPK9160G",
+			"email_id": ""
+		}).insert(ignore_if_duplicate=True)
+
+		doc = frappe.get_doc({
+			"doctype": "Your Custom Doctype",
+			"some_field": "Some Value"
+		}).insert()
+
+		filenames = ["PAN123_certificate.pdf", "PAN456_certificate.pdf", "PAN789_certificate.pdf"]
+		for fname in filenames:
+			frappe.get_doc({
+				"doctype": "File",
+				"file_name": fname,
+				"attached_to_doctype": doc.doctype,
+				"attached_to_name": doc.name,
+				"is_private": 1
+			}).insert()
+
+		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_email_list, get_pan_list
+		import erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate
+
+		def mock_get_pan_list(certificate_name_list):
+			return [
+				{"pan": "ABCDE1234F", "file_name": "PAN123_certificate.pdf"},
+				{"pan": "DGAPK9160G", "file_name": "PAN456_certificate.pdf"},
+				{"pan": "DGAPK9160T", "file_name": "PAN789_certificate.pdf"},
+			]
+
+		erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_pan_list = mock_get_pan_list
+
+		emails_and_pan_list = get_email_list(doc)
+
+		self.assertEqual(len(emails_and_pan_list), 1)
+		self.assertEqual(emails_and_pan_list[0]["pan"], "PAN123")
+
+		error_logs = doc.error_logs
+		self.assertEqual(len(error_logs), 3)
+
+		statuses = [log.status for log in error_logs]
+		self.assertIn("Success", statuses)
+		self.assertIn("Failure", statuses)
+
+
+

--- a/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
+++ b/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
@@ -88,58 +88,13 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		self.assertEqual(unrecorded_pan[0]["status"], "Failure")
 
 	def test_get_email_list_TC_B_225(self):
-		frappe.get_doc({
-			"doctype": "Supplier",
-			"supplier_name": "Supplier With Email",
-			"pan": "ABCDE1234F",
-			"email_id": "email@domain.com"
-		}).insert(ignore_if_duplicate=True)
-
-		frappe.get_doc({
-			"doctype": "Supplier",
-			"supplier_name": "Supplier Without Email",
-			"pan": "DGAPK9160G",
-			"email_id": ""
-		}).insert(ignore_if_duplicate=True)
-
-		doc = frappe.get_doc({
-			"doctype": "Your Custom Doctype",
-			"some_field": "Some Value"
-		}).insert()
-
-		filenames = ["PAN123_certificate.pdf", "PAN456_certificate.pdf", "PAN789_certificate.pdf"]
-		for fname in filenames:
-			frappe.get_doc({
-				"doctype": "File",
-				"file_name": fname,
-				"attached_to_doctype": doc.doctype,
-				"attached_to_name": doc.name,
-				"is_private": 1
-			}).insert()
-
-		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_email_list, get_pan_list
-		import erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate
-
-		def mock_get_pan_list(certificate_name_list):
-			return [
-				{"pan": "ABCDE1234F", "file_name": "PAN123_certificate.pdf"},
-				{"pan": "DGAPK9160G", "file_name": "PAN456_certificate.pdf"},
-				{"pan": "DGAPK9160T", "file_name": "PAN789_certificate.pdf"},
+		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_email_list, get_pan_list, get_emails_and_unrecored_pan_list
+		test_data = [
+			{"pan": "ABCDE1234F", "file_name": "file1.pdf"}, 
+			{"pan": "DGAPK9160G", "file_name": "file2.pdf"},
+			{"pan": "DGAPK9160T", "file_name": "file3.pdf"}   
 			]
-
-		erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_pan_list = mock_get_pan_list
-
-		emails_and_pan_list = get_email_list(doc)
-
+		pan_list_with_file_name = get_pan_list(test_data)
+		unrecorded_pan_list,emails_and_pan_list,pan_without_emails = get_emails_and_unrecored_pan_list(pan_list_with_file_name)
 		self.assertEqual(len(emails_and_pan_list), 1)
-		self.assertEqual(emails_and_pan_list[0]["pan"], "PAN123")
-
-		error_logs = doc.error_logs
-		self.assertEqual(len(error_logs), 3)
-
-		statuses = [log.status for log in error_logs]
-		self.assertIn("Success", statuses)
-		self.assertIn("Failure", statuses)
-
-
-
+		self.assertEqual(emails_and_pan_list[0]["pan"], "ABCDE1234F")


### PR DESCRIPTION
### Test Summary
This PR introduces unit tests to validate the behavior of the remittance certificate feature in ERPNext. The tests verify the functionality of PAN-to-email mapping and ensure that proper logs are created when PANs are missing or emails are unavailable. The test cases also simulate real conditions by inserting supplier records and file attachments.

### Scenarios Covered
TC_B_189 – test_get_emails_and_unrecored_pan_list_TC_B_189 Validates that the system accurately categorizes PANs into:

Suppliers with email (success list)

Suppliers without email (failure list)

PANs not recorded in the system (unrecorded list)

TC_B_225 – test_get_email_list_TC_B_225
Mocks get_pan_list() to test get_email_list() and ensure:

Correct mapping of PAN to email where applicable

Proper error logging for failures and unrecorded PANs

Consistency of log entries and result structure

### Technology
Tests are written using the built-in FrappeTestCase test framework.

### Linked Feature/Bug
Null
