### PR TITLE
fix: corrected the account name for 2323 | frappe.exceptions.DoesNotExistError: Account Test TDS Payable - _TC not found

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2777,7 +2777,7 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 		records_for_pi('_Test Supplier USD')
 		supplier = frappe.get_doc('Supplier', '_Test Supplier USD')
-		tds_account = frappe.get_doc("Account", "Test TDS Payable - _TC")
+		tds_account = frappe.get_doc("Account", "_Test TDS Payable - _TC")
 		if tds_account.account_currency != "INR":
 			tds_account.account_currency = "INR"
 			tds_account.save()


### PR DESCRIPTION
### Bug Description
The unit test test_advance_payment_TC_ACC_028 in the Purchase Invoice Doctype was failing with the following error:
frappe.exceptions.DoesNotExistError: Account Test TDS Payable - _TC not found.
This prevented the test from proceeding with validating TDS deductions and advance allocations, impacting test coverage for advance payment reconciliation scenarios.

### Root Cause
The test was referencing a non-existent account "Test TDS Payable - _TC" which was not part of the test chart of accounts.

Steps to Reproduce:
Run bench run-tests --doctype "Purchase Invoice" --test test_advance_payment_TC_ACC_028

Observe the error about missing account.

Actual/Observed Result:
Test fails with a DoesNotExistError due to an invalid account name.

Expected Result:
Test should pass, validating TDS deductions and exchange gain/loss journal entries correctly.

### Fix Summary
Replaced the incorrect account name "Test TDS Payable - _TC" with the correct predefined test account "_Test TDS Payable - _TC" which exists in the test company chart of accounts.

### Affected Module
Accounts

### Test Cases Covered
test_advance_payment_TC_ACC_028

### Linked Issue
Fixes #2323