### PR TITLE
Fixed: Missing 'Payment Term' and 'Item' caused test failure in test_mr_to_pi_with_PE_TC_B_076

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -6151,6 +6151,10 @@ class TestMaterialRequest(FrappeTestCase):
 
 	def test_mr_to_pi_with_PE_TC_B_076(self):
 		# MR =>  PO => PE => PR => PI
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
+		create_payment_term("Basic Amount Receivable for Selling")
+		item = make_test_item("Testing-31")
+
 		mr_dict_list = {
 				"company" : "_Test Company",
 				"item_code" : "Testing-31",


### PR DESCRIPTION
1.. **Bug Description**
The automated test case test_mr_to_pi_with_PE_TC_B_076 was failing due to missing dependencies:

"Testing-31" Item not found.

Payment Term "Basic Amount Receivable for Selling" not defined.

This resulted in errors during test execution, blocking validation of the full MR → PO → PE → PR → PI transaction workflow.

3. **Root Cause**
The test was relying on the existence of test data (Item and Payment Term) that were not created or available in the test environment.


Observe errors related to missing "Testing-31" and "Basic Amount Receivable for Selling".

4. **Actual/Observed Result:**
Test fails with:

Could not find "Testing-31"

Could not find Row #1: Payment Term: Basic Amount Receivable for Selling.

5. **Expected Result:**
Test should successfully create and validate the full purchasing and invoicing workflow.

6. **Fix Summary**
Added the following lines before executing the test steps to ensure required data exists:

from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
create_payment_term("Basic Amount Receivable for Selling")
item = make_test_item("Testing-31")

7. **Affected Module**
ERPNext Accounts → Payment Entry Tests

Test Workflow: Material Request → Purchase Order → Payment Entry → Purchase Receipt → Purchase Invoice

Test Cases Covered
Validate MR → PO → PE → PR → PI flow works end-to-end with payment terms.

Assert item quantity and totals match across documents.

Ensure PO status updates to "Completed" and PI status updates to "Paid".

8. **Linked Issue**
https://github.com/8848digital/erpnext/issues/2364
