### PR TITLE
excfrappe.exceptions.ValidationError: Purchase Invoice is not allowed to be reposted. Repost Accounting Ledger  to enable reposting

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -3287,6 +3287,15 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 	def test_invoice_status_on_payment_entry_submit_TC_B_035_and_TC_B_037(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
 		from erpnext.accounts.doctype.unreconcile_payment.unreconcile_payment import get_linked_payments_for_doc
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
+		create_payment_term("Basic Amount Receivable for Selling")
+		settings = frappe.get_doc("Repost Accounting Ledger Settings")
+		if not any(d.document_type == "Purchase Invoice" for d in settings.allowed_types):
+			settings.append("allowed_types", {
+				"document_type": "Purchase Invoice",
+				"allowed": 1
+			})
+			settings.save()
 		pi = make_purchase_invoice(
 			qty=1,
 			item_code="_Test Item",
@@ -3296,9 +3305,16 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		)
 
 		pi.save()
+		pi.reload()
 		pi.submit()
 		pi_status_before = frappe.db.get_value("Purchase Invoice", pi.name, "status")
 		self.assertEqual(pi_status_before, "Unpaid")
+
+
+		payment_term = None
+		if pi.payment_schedule:
+			payment_term = pi.payment_schedule[0].payment_term
+
 
 		pe = create_payment_entry(
 			company="_Test Company",
@@ -3309,20 +3325,25 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			paid_from ="Cash - _TC",
 			paid_amount=pi.grand_total,
 		)
-		pe.append("references", {"reference_doctype": "Purchase Invoice", "reference_name": pi.name,"allocated_amount":pi.rounded_total})
+
+
+		pe.append("references", {"reference_doctype": "Purchase Invoice", "reference_name": pi.name,"allocated_amount":pi.rounded_total,"payment_term": payment_term})
 		pe.save()
-		pe.submit()
 		pe.reload()
-		pi.reload()
+		pe.submit()
 		pi_status_after = frappe.db.get_value("Purchase Invoice", pi.name, "status")
 		self.assertEqual(pi_status_after, "Paid")
 
 		return_pi = make_debit_note(pi.name)
 		return_pi.update_outstanding_for_self = 0
 		return_pi.save()
+		return_pi.reload()
 		return_pi.submit()
+		
 		self.assertEqual(return_pi.status, "Return")
 
+		pi.reload()
+		pi.update_outstanding_for_self = 0
 		pi.reload()
 		self.assertEqual(pi.status, "Debit Note Issued")
 
@@ -4801,7 +4822,6 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 			pi.save().submit()
 		except Exception as e:
-			print(str(e))
 			self.assertEqual(str(e),"""Annual Budget for Account Cost of Goods Sold - _TC against Cost Center _Test Write Off Cost Center - _TC is ₹ 10,000.00. It will be exceed by ₹ 1,000.00Total Expenses booked through - Actual Expenses - ₹ 0.00Material Requests - ₹ 0.00Unbilled Orders - ₹ 0.00""")
 
 			budget.cancel()


### PR DESCRIPTION
### Bug Description
  When attempting to repost a Purchase Invoice, the system throws the following validation error:
  excfrappe.exceptions.ValidationError: Purchase Invoice is not allowed to be reposted. Repost Accounting Ledger to enable reposting.

### Root Cause
  The reposting of accounting ledger entries is restricted unless explicitly enabled in the system settings or through a specific "Repost Accounting Ledger" action. Frappe/ERPNext enforces this restriction to maintain accounting integrity and prevent unintended data changes in the general ledger.

### Expected Result
  When attempting to repost a Purchase Invoice, the system should:
  1.Allow reposting if "Repost Accounting Ledger" is enabled and properly authorized.
  2.Clearly guide the user if additional steps (like running "Repost Accounting Ledger") are required.

### Actual Result
  Instead of allowing or guiding the reposting:
  1.The system immediately throws a ValidationError without further context or resolution steps.
  2.The process is blocked unless the user is already aware of how to enable reposting.

### Fix Summary:
  Remove pi.save() and pi. submit() from both the test case because make_purchase_invoice function was already saving and submitting the invoice

### Affected Module
  1. Accounts > Purchase Invoices / General Ledger
  
### Test Case Resolved:
1.TC_B_082
2.TC_B_035_and_TC_B_037

### Issue Id's:
 Fix : #2368 