### PR TITLE
Fix: DuplicateEntryError: ('Supplier', 'Test Supplier', UniqueViolati…

### DIFF
--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -182,17 +182,19 @@ class TestSupplier(FrappeTestCase):
 		self.assertIn(self.contact.name, results[0])
 
 	def test_create_primary_contact_TC_B_182(self):
-		supplier = frappe.get_doc({
-            "doctype": "Supplier",
-            "supplier_name": "Test Supplier",
-            "supplier_group": "All Supplier Groups",
-            "mobile_no": "1234567890",
-            "email_id": "test@example.com"
-        })
-		supplier.insert(ignore_permissions=True)
+		if not frappe.db.exists("Supplier", "Test Supplier"):
+			supplier = frappe.get_doc({
+				"doctype": "Supplier",
+				"supplier_name": "Test Supplier",
+				"supplier_group": "All Supplier Groups",
+				"mobile_no": "1234567890",
+				"email_id": "test@example.com"
+			})
+			supplier.insert(ignore_permissions=True)
+		else:
+			supplier = frappe.get_doc("Supplier", "Test Supplier")  # ✅ fetch doc properly
 
 		supplier.create_primary_contact()
-
 		supplier.reload()
 
 		self.assertIsNotNone(supplier.supplier_primary_contact)


### PR DESCRIPTION
### Bug Description
The test was failing with an UnboundLocalError because the supplier variable was not defined in all execution paths.

### Root Cause
if condition was missing from the function to check whether the supplier exist or not

### Expected Result
The test should either create or fetch a Supplier named "Test Supplier".
It should create a primary contact based on the supplier's mobile and email.
Assertions should pass verifying that the contact was created and correctly linked.

### Actual Result
The test should either create or fetch a Supplier named "Test Supplier".
It should create a primary contact based on the supplier's mobile and email.


### Fix Summary
Ensure that the supplier variable is defined in both the if and else blocks.
The corrected if else block now properly fetches the Supplier document:

### Affected Module
Module: ERPNext

### Test Case Solved:
1.test_create_primary_contact_TC_B_182

### Issue ID:
Fix #2416 