### PR TITLE
Fix: Missing item "Testing-31" causing DoesNotExistError in test cases

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -3081,6 +3081,7 @@ class TestMaterialRequest(FrappeTestCase):
 	def test_mr_to_pe_flow_TC_B_080(self):
 		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import get_sl_entries, get_gl_entries
 		# Scenario : MR=>PO=> Partial PE=>PR=>PI=>Rm PE (With GST)
+		make_item(item_code="Testing-31")
 		mr_dict_list = {
 				"company" : "_Test Company",
 				"purpose":"Purchase",
@@ -4602,7 +4603,7 @@ class TestMaterialRequest(FrappeTestCase):
 
 	def test_purchase_flow_TC_B_068(self):
 		#Scenario : MR=>PO=>PR=>PI [With Shipping Rule]
-		
+		make_item(item_code="Testing-31")
 		args = {
 					"calculate_based_on" : "Fixed",
 					"shipping_amount" : 200
@@ -4636,7 +4637,7 @@ class TestMaterialRequest(FrappeTestCase):
 
 	def test_purchase_flow_TC_B_069(self):
 		#Scenario: MR=>SQ=>PO=>PR=>PI [With SQ and Shipping Rule]
-		
+		make_item(item_code="Testing-31")
 		args = {
 					"calculate_based_on" : "Fixed",
 					"shipping_amount" : 200
@@ -6155,7 +6156,7 @@ class TestMaterialRequest(FrappeTestCase):
 		# MR =>  PO => PE => PR => PI
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
 		create_payment_term("Basic Amount Receivable for Selling")
-		item = make_test_item("Testing-31")
+		make_item(item_code="Testing-31")
 
 		mr_dict_list = {
 				"company" : "_Test Company",
@@ -6246,7 +6247,7 @@ class TestMaterialRequest(FrappeTestCase):
 
 	def test_mr_to_pi_TC_B_078(self):
 		#Scenario: MR=>SQ=>PO=>PE=>PR=>PI [With SQ, Shipping Rule and Shipping Rule]
-		
+		make_item(item_code="Testing-31")
 		args = {
 					"calculate_based_on" : "Fixed",
 					"shipping_amount" : 200


### PR DESCRIPTION
**Bug Description**
The test cases were failing due to a missing item with code Testing-31. This raised a DoesNotExistError during test execution, halting the test flow.

**Root Cause**
The item "Testing-31" was being referenced in multiple test cases without being created beforehand.
Steps to Reproduce:

Run the affected test cases without pre-existing "Testing-31" item.
Actual/Observed Result:
Tests raise frappe.exceptions.DoesNotExistError: Item Testing-31 not found
Expected Result:
Tests should run successfully without item-related exceptions.

**Fix Summary**
Added make_item(item_code="Testing-31") at the beginning of each affected test case to ensure the item is created before being referenced.

**Affected Module**
Item tests

**Test Cases Covered**
TC_B_068
TC_B_078
TC_B_069
TC_B_080
TC_B_076

**Linked Issue**
https://github.com/8848digital/erpnext/issues/2131