### PR TITLE
fix: ignoring type_checking condition to improve code coverage

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -16,7 +16,7 @@ class MaintenanceSchedule(TransactionBase):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.maintenance.doctype.maintenance_schedule_detail.maintenance_schedule_detail import (

--- a/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
@@ -11,7 +11,7 @@ class MaintenanceScheduleDetail(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		actual_date: DF.Date | None

--- a/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
@@ -11,7 +11,7 @@ class MaintenanceScheduleItem(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		description: DF.TextEditor | None

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
@@ -14,7 +14,7 @@ class MaintenanceVisit(TransactionBase):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.maintenance.doctype.maintenance_visit_purpose.maintenance_visit_purpose import (

--- a/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.py
+++ b/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.py
@@ -11,7 +11,7 @@ class MaintenanceVisitPurpose(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		description: DF.TextEditor | None


### PR DESCRIPTION
### Bug Description
The test coverage report included lines that are not meant to be executed at runtime (like if TYPE_CHECKING blocks), leading to misleading coverage metrics. This caused confusion during CI analysis and reduced the effectiveness of coverage tools in identifying real test gaps.

### Root Cause
Python type hints and conditional imports guarded by if TYPE_CHECKING: were being included in coverage reports. Since these lines are never run, they were incorrectly marked as uncovered.

Steps to Reproduce:

Add a type-only import inside an if TYPE_CHECKING: block.

Run coverage analysis using coverage.py.

Observe that these lines are shown as uncovered.

Actual/Observed Result:
Type-check-only imports are reported as missing in code coverage.

Expected Result:
Type-check-only imports should be excluded from coverage to avoid false negatives.

### Fix Summary
Added # pragma: no cover to the if TYPE_CHECKING: lines and similar blocks to instruct the coverage tool to skip them.

### Affected Module
All modules using TYPE_CHECKING conditional imports

### Test Cases Covered
Static typing and import resolution validated manually

Coverage report validated for accuracy post-change

### Linked Issue
None

### PR Reference
None
