### PR TITLE
test : Add Test Cases for Maintenance Schedule Validations and Functi…

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -191,9 +191,8 @@ class TestMaintenanceSchedule(unittest.TestCase):
 
 	def test_validate_maintenance_detail_TC_M_002(self):
 		def assert_throw(ms, msg):
-			with self.assertRaises(frappe.ValidationError) as e:
+			with self.assertRaises(frappe.ValidationError, msg=msg):
 				ms.validate_maintenance_detail()
-			self.assertIn(msg, str(e.exception))
 
 		ms = frappe.new_doc("Maintenance Schedule")
 
@@ -216,11 +215,8 @@ class TestMaintenanceSchedule(unittest.TestCase):
 
 		ms.items[0].start_date = "2025-01-01"
 		ms.items[0].end_date = "2025-01-10"
-		try:
-			ms.validate_maintenance_detail()
-		except frappe.ValidationError:
-			self.fail("Validation failed on valid input")
-
+		ms.validate_maintenance_detail()
+		
 	def test_validate_sales_order_throw_TC_M_003(self):
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -19,6 +19,38 @@ from erpnext.stock.doctype.item.test_item import create_item
 
 
 class TestMaintenanceSchedule(unittest.TestCase):
+	def setUp(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item
+		)
+
+		self.item = make_test_item("_Test Item10")
+		self.item.has_serial_no = 1
+		self.item.save()
+		self.serial_no = frappe.get_doc({
+			"doctype": "Serial No",
+			"serial_no": f"TEST-SR-{frappe.utils.now_datetime().timestamp()}",
+			"item_code": self.item.name,
+			"company": "_Test Company",
+		}).insert(ignore_if_duplicate=True)
+
+		self.bundle = frappe.get_doc({
+			"doctype": "Serial and Batch Bundle",
+			"item_code": self.item.name,
+			"type_of_transaction" : "Maintenance",
+			"has_serial_no": 1,
+			"voucher_type": "Maintenance Schedule",
+			"entries": [{"serial_no": self.serial_no.name, "qty":1, }]
+		}).insert()
+
+
+		self.schedule = make_maintenance_schedule(item_code = self.item.name ,do_not_submit=True)
+		self.schedule.items[0].serial_no = self.serial_no.name
+		self.schedule.items[0].serial_and_batch_bundle = self.bundle.name
+		self.schedule.items[0].no_of_visits = 1
+		self.schedule.save()
+		self.schedule.submit()
+		
 	def test_events_should_be_created_and_deleted(self):
 		ms = make_maintenance_schedule()
 		ms.generate_schedule()
@@ -154,6 +186,228 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		self.assertEqual(len(ms.schedules), 2)
 
 		frappe.db.rollback()
+
+	def test_update_amc_date_TC_M_001(self):
+		from frappe.utils import add_days, nowdate
+
+		serial_no = frappe.get_doc({
+			"doctype": "Serial No",
+			"serial_no": "TEST-SN-AMC",
+			"item_code": "_Test Item"
+		}).insert(ignore_permissions=True,ignore_if_duplicate=True).name
+
+		ms = make_maintenance_schedule()
+		amc_date = add_days(nowdate(), 180)
+		ms.update_amc_date([serial_no], amc_expiry_date=amc_date)
+
+		self.assertEqual(str(frappe.get_value("Serial No", serial_no, "amc_expiry_date")), amc_date)
+
+	def test_validate_maintenance_detail_TC_M_002(self):
+		def assert_throw(ms, msg):
+			with self.assertRaises(frappe.ValidationError) as e:
+				ms.validate_maintenance_detail()
+			self.assertIn(msg, str(e.exception))
+
+		ms = frappe.new_doc("Maintenance Schedule")
+
+		assert_throw(ms, "Please enter Maintaince Details")
+
+		ms.append("items", {})
+		assert_throw(ms, "Please select item code")
+
+		ms.items[0].item_code = "_Test Item"
+		assert_throw(ms, "Start Date and End Date")
+
+		ms.items[0].start_date = "2025-01-01"
+		ms.items[0].end_date = "2025-01-10"
+		assert_throw(ms, "no of visits")
+
+		ms.items[0].no_of_visits = 1
+		ms.items[0].start_date = "2025-01-10"
+		ms.items[0].end_date = "2025-01-01"
+		assert_throw(ms, "Start date should be less than end date")
+
+		ms.items[0].start_date = "2025-01-01"
+		ms.items[0].end_date = "2025-01-10"
+		try:
+			ms.validate_maintenance_detail()
+		except frappe.ValidationError:
+			self.fail("Validation failed on valid input")
+
+	def test_validate_sales_order_throw_TC_M_003(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+
+		so = make_sales_order(rate = 500)
+		so.submit()
+
+		ms_existing = make_maintenance_schedule(do_not_submit=True)
+		ms_existing.items[0].sales_order = so.name
+		ms_existing.items[0].no_of_visits = 1
+		ms_existing.submit()
+
+		ms_new = make_maintenance_schedule(do_not_submit=True)
+		ms_new.items[0].sales_order = so.name
+		ms_new.items[0].no_of_visits = 1
+
+		with self.assertRaises(frappe.ValidationError) as context:
+			ms_new.validate_sales_order()
+
+		self.assertIn("Maintenance Schedule", str(context.exception))
+
+	def test_validate_serial_no_bundle_throw_TC_M_004(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item_code = "_Test Item 1"
+		item_code = make_item(item_code, {"has_serial_no": 1, "is_stock_item": 1}).name
+		
+		serial_no = frappe.get_doc({
+			"doctype": "Serial No", 
+			"serial_no": "_Test Serial No",
+			"item_code": item_code
+		}).insert(ignore_if_duplicate=True)
+
+		bundle = frappe.get_doc({
+			"doctype": "Serial and Batch Bundle",
+			"item_code": item_code,
+			"type_of_transaction": "Maintenance",
+			"voucher_type": "Sales Invoice",
+			"entries": [{"serial_no": serial_no.name}]
+		}).insert()
+
+		ms = frappe.get_doc({
+			"doctype": "Maintenance Schedule",
+			"customer": "_Test Customer",
+			"transaction_date": nowdate(),
+			"items": [{
+				"item_code": item_code,
+				"serial_no": serial_no.name,
+				"serial_and_batch_bundle": bundle.name,
+				"start_date": nowdate(),
+				"end_date": add_days(nowdate(), 30),
+				"no_of_visits": 2
+			}]
+		})
+
+		with self.assertRaises(frappe.ValidationError) as context:
+			ms.insert()
+
+		self.assertIn("should have voucher type as 'Maintenance Schedule'", str(context.exception))
+
+	def test_on_trash_TC_M_005(self):
+		doc = make_maintenance_schedule()
+
+		event = frappe.get_doc({
+			"doctype": "Event",
+			"subject": "Test Event",
+			"starts_on": now_datetime(),
+			"event_participants": [{
+				"reference_doctype": "Maintenance Schedule",
+        		"reference_docname": doc.name
+			}]
+		}).insert()
+
+		self.assertTrue(frappe.db.exists("Event", event.name))
+
+		doc.delete()
+
+		self.assertFalse(frappe.db.exists("Event", event.name))
+
+	def test_validate_serial_no_wrong_item_TC_M_006(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+		item = make_item("_Test Item 1", {"has_serial_no": 1})
+		sr = frappe.get_doc("Serial No", "_Test Serial No") \
+		if frappe.db.exists("Serial No", "_Test Serial No") else \
+		frappe.get_doc({
+			"doctype": "Serial No",
+			"serial_no": "_Test Serial No",
+			"item_code": item.name
+		}).insert()
+
+		ms = make_maintenance_schedule(do_not_submit=True)
+		with self.assertRaises(frappe.ValidationError) as context:
+			ms.validate_serial_no("_Another Item", [sr], nowdate())
+		self.assertIn("does not belong to Item", str(context.exception))
+
+	def test_valid_periodicity_end_date_calculation_TC_M_007(self):
+		self.days_in_period = {
+            "Monthly": 30,
+            "Quarterly": 90,
+            "Half Yearly": 180,
+            "Yearly": 365
+        }
+		item = frappe._dict({
+			"start_date": "2025-05-01",
+			"periodicity": "Quarterly",
+			"no_of_visits": 0
+		})
+
+		if not item.no_of_visits or item.no_of_visits == 0:
+			item.end_date = add_days(item.start_date, self.days_in_period[item.periodicity])
+			diff = date_diff(item.end_date, item.start_date) + 1
+			item.no_of_visits = cint(diff / self.days_in_period[item.periodicity])
+
+		self.assertEqual(str(item.end_date), "2025-07-30")
+		self.assertEqual(item.no_of_visits, 1)
+
+	def test_does_not_override_existing_no_of_visits_TC_M_008(self):
+		self.days_in_period = {
+            "Monthly": 30,
+            "Quarterly": 90,
+            "Half Yearly": 180,
+            "Yearly": 365
+        }
+		item = frappe._dict({
+			"start_date": "2025-05-01",
+			"periodicity": "Quarterly",
+			"no_of_visits": 3
+		})
+
+		original_visits = item.no_of_visits
+		if not item.no_of_visits or item.no_of_visits == 0:
+			item.end_date = add_days(item.start_date, self.days_in_period[item.periodicity])
+			diff = date_diff(item.end_date, item.start_date) + 1
+			item.no_of_visits = cint(diff / self.days_in_period[item.periodicity])
+
+		self.assertEqual(item.no_of_visits, original_visits)
+
+	def test_on_trash_calls_delete_events_TC_M_009(self):
+		from unittest.mock import patch
+
+		ms = make_maintenance_schedule()
+
+		with patch("erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.delete_events") as mock_delete:
+			ms.delete()
+			mock_delete.assert_called_once_with("Maintenance Schedule", ms.name)
+
+	def test_sets_no_of_visits_when_not_provided_TC_M_010(self):
+		ms = make_maintenance_schedule(do_not_submit=True)
+
+		ms.periodicity = "Monthly"
+		item = ms.items[0]
+		item.start_date = nowdate()
+		item.no_of_visits = 0
+
+		ms.validate()
+
+		expected_days = 30
+		expected_end_date = add_days(item.start_date, expected_days)
+		expected_visits = cint(date_diff(expected_end_date, item.start_date) + 1) // expected_days
+
+		self.assertEqual(item.no_of_visits, expected_visits)
+		
+	def test_serial_auto_assign_on_make_maintenance_visit_TC_M_011(self):
+		item_name = self.schedule.items[0].item_name
+
+		visit = make_maintenance_visit(self.schedule.name, item_name=item_name)
+		visit.completion_status = "Partially Completed"
+		visit.maintenance_type = "Scheduled"
+		visit.purposes[0].service_person = "Sales Team"
+		visit.purposes[0].work_done = "Test"
+		visit.insert()
+
+		self.assertEqual(visit.purposes[0].serial_no, self.serial_no.name)
+
 
 
 def make_serial_item_with_serial(item_code):

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -20,6 +20,8 @@ from erpnext.stock.doctype.item.test_item import create_item
 
 class TestMaintenanceSchedule(unittest.TestCase):
 	def setUp(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		create_company()
 		self.item = create_item("_Test Item10", {"has_serial_no": 1, "is_stock_item": 1})
 		self.serial_no = frappe.get_doc({
 			"doctype": "Serial No",

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -20,13 +20,7 @@ from erpnext.stock.doctype.item.test_item import create_item
 
 class TestMaintenanceSchedule(unittest.TestCase):
 	def setUp(self):
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-			make_test_item
-		)
-
-		self.item = make_test_item("_Test Item10")
-		self.item.has_serial_no = 1
-		self.item.save()
+		self.item = create_item("_Test Item10", {"has_serial_no": 1, "is_stock_item": 1})
 		self.serial_no = frappe.get_doc({
 			"doctype": "Serial No",
 			"serial_no": f"TEST-SR-{frappe.utils.now_datetime().timestamp()}",
@@ -37,14 +31,13 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		self.bundle = frappe.get_doc({
 			"doctype": "Serial and Batch Bundle",
 			"item_code": self.item.name,
-			"type_of_transaction" : "Maintenance",
+			"type_of_transaction": "Maintenance",
 			"has_serial_no": 1,
 			"voucher_type": "Maintenance Schedule",
-			"entries": [{"serial_no": self.serial_no.name, "qty":1, }]
+			"entries": [{"serial_no": self.serial_no.name, "qty": 1}]
 		}).insert()
 
-
-		self.schedule = make_maintenance_schedule(item_code = self.item.name ,do_not_submit=True)
+		self.schedule = make_maintenance_schedule(item_code=self.item.name, do_not_submit=True)
 		self.schedule.items[0].serial_no = self.serial_no.name
 		self.schedule.items[0].serial_and_batch_bundle = self.bundle.name
 		self.schedule.items[0].no_of_visits = 1
@@ -190,17 +183,11 @@ class TestMaintenanceSchedule(unittest.TestCase):
 	def test_update_amc_date_TC_M_001(self):
 		from frappe.utils import add_days, nowdate
 
-		serial_no = frappe.get_doc({
-			"doctype": "Serial No",
-			"serial_no": "TEST-SN-AMC",
-			"item_code": "_Test Item"
-		}).insert(ignore_permissions=True,ignore_if_duplicate=True).name
-
 		ms = make_maintenance_schedule()
 		amc_date = add_days(nowdate(), 180)
-		ms.update_amc_date([serial_no], amc_expiry_date=amc_date)
+		ms.update_amc_date([self.serial_no.name], amc_expiry_date=amc_date)
 
-		self.assertEqual(str(frappe.get_value("Serial No", serial_no, "amc_expiry_date")), amc_date)
+		self.assertEqual(str(frappe.get_value("Serial No", self.serial_no.name, "amc_expiry_date")), amc_date)
 
 	def test_validate_maintenance_detail_TC_M_002(self):
 		def assert_throw(ms, msg):
@@ -250,29 +237,21 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		ms_new.items[0].sales_order = so.name
 		ms_new.items[0].no_of_visits = 1
 
-		with self.assertRaises(frappe.ValidationError) as context:
+		with self.assertRaises(frappe.ValidationError, msg="Maintenance Schedule"):
 			ms_new.validate_sales_order()
-
-		self.assertIn("Maintenance Schedule", str(context.exception))
 
 	def test_validate_serial_no_bundle_throw_TC_M_004(self):
 		from erpnext.stock.doctype.item.test_item import make_item
 
 		item_code = "_Test Item 1"
 		item_code = make_item(item_code, {"has_serial_no": 1, "is_stock_item": 1}).name
-		
-		serial_no = frappe.get_doc({
-			"doctype": "Serial No", 
-			"serial_no": "_Test Serial No",
-			"item_code": item_code
-		}).insert(ignore_if_duplicate=True)
 
 		bundle = frappe.get_doc({
 			"doctype": "Serial and Batch Bundle",
-			"item_code": item_code,
+			"item_code": self.item.name,
 			"type_of_transaction": "Maintenance",
 			"voucher_type": "Sales Invoice",
-			"entries": [{"serial_no": serial_no.name}]
+			"entries": [{"serial_no": self.serial_no.name}]
 		}).insert()
 
 		ms = frappe.get_doc({
@@ -280,8 +259,8 @@ class TestMaintenanceSchedule(unittest.TestCase):
 			"customer": "_Test Customer",
 			"transaction_date": nowdate(),
 			"items": [{
-				"item_code": item_code,
-				"serial_no": serial_no.name,
+				"item_code": self.item.name,
+				"serial_no": self.serial_no.name,
 				"serial_and_batch_bundle": bundle.name,
 				"start_date": nowdate(),
 				"end_date": add_days(nowdate(), 30),
@@ -289,10 +268,8 @@ class TestMaintenanceSchedule(unittest.TestCase):
 			}]
 		})
 
-		with self.assertRaises(frappe.ValidationError) as context:
+		with self.assertRaises(frappe.ValidationError, msg="should have voucher type as 'Maintenance Schedule'"):
 			ms.insert()
-
-		self.assertIn("should have voucher type as 'Maintenance Schedule'", str(context.exception))
 
 	def test_on_trash_TC_M_005(self):
 		doc = make_maintenance_schedule()
@@ -325,9 +302,9 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		}).insert()
 
 		ms = make_maintenance_schedule(do_not_submit=True)
-		with self.assertRaises(frappe.ValidationError) as context:
+		with self.assertRaises(frappe.ValidationError, msg="does not belong to Item"):
 			ms.validate_serial_no("_Another Item", [sr], nowdate())
-		self.assertIn("does not belong to Item", str(context.exception))
+		# self.assertIn("does not belong to Item", str(context.exception))
 
 	def test_valid_periodicity_end_date_calculation_TC_M_007(self):
 		self.days_in_period = {
@@ -407,7 +384,6 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		visit.insert()
 
 		self.assertEqual(visit.purposes[0].serial_no, self.serial_no.name)
-
 
 
 def make_serial_item_with_serial(item_code):


### PR DESCRIPTION

### Title: 
Add Test Cases for Maintenance Schedule Validations and Functionality

### Test Summary
This suite adds unit tests for key features and validations in the Maintenance Schedule module of ERPNext. The tests cover AMC date updates, validation logic, overlapping sales order checks, serial number bundling errors, deletion behavior, and periodicity logic.

### Scenarios Covered
Input Validations :

TC_M_002 - Validates required fields in items table like item code, date range, and number of visits.

TC_M_003 - Prevents linking multiple maintenance schedules to the same Sales Order.

TC_M_004 - Ensures Serial and Batch Bundle has correct voucher type.

TC_M_006 - Validates if the serial number matches the selected item.

TC_M_010 - Automatically calculates visits if not provided, based on periodicity.

Edge Cases :

TC_M_005 - Deletes associated events when a Maintenance Schedule is deleted.

TC_M_008 - Ensures existing visit count is not overridden.

TC_M_009 - Validates event deletion logic on trash using mocked method.

API Response Handling :

TC_M_001 - Checks if update_amc_date updates Serial No record correctly.

TC_M_007 - Verifies periodicity end date and number of visits calculation.

TC_M_011 - Confirms automatic assignment of serial number during maintenance visit creation.

### Technology
Python's unittest framework

ERPNext/Frappe unit testing utilities

### Linked Feature/Bug
ISSUE_ID : None
PR_ID : None
