### PR TITLE
Fix: #2418 Test Cleanup for Inventory Dimension Validation

### DIFF
--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -491,6 +491,32 @@ class TestInventoryDimension(FrappeTestCase):
 
 		self.assertEqual(site_name, "Site 1")
 
+		## TearDown
+		if frappe.db.exists("Inventory Dimension", {"dimension_name": "Inv Site"}):
+			frappe.delete_doc("Inventory Dimension", "Inv Site", force=True)
+
+		affected_doctypes = [
+			"Stock Ledger Entry",
+			"Stock Entry Detail",
+			"Purchase Receipt Item",
+			"Delivery Note Item",
+			"Sales Invoice Item",
+		]
+		for doctype in affected_doctypes:
+			# Remove both source and target fields if they exist
+			for fieldname in ["inv_site", "to_inv_site"]:
+				if frappe.db.exists("Custom Field", {"dt": doctype, "fieldname": fieldname}):
+					frappe.delete_doc("Custom Field", f"{doctype}-{fieldname}", force=True)
+
+			# Drop the columns if they exist
+			if fieldname in frappe.db.get_table_columns(doctype):
+				frappe.db.sql(f"ALTER TABLE `tab{doctype}` DROP COLUMN IF EXISTS `{fieldname}`")
+			# Clear inventory dimension cache
+		frappe.local.inventory_dimensions = {}
+		frappe.cache().delete_key("inventory_dimensions")
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 0)
+		frappe.db.commit()
+
 
 def get_voucher_sl_entries(voucher_no, fields):
 	return frappe.get_all(


### PR DESCRIPTION
**Bug Description**
Test cases for inventory dimension negative stock validation were leaving behind test data in the database.

Impact: This caused pollution in subsequent test runs, leading to inconsistent test results and potential false negatives/positives.

**Root Cause**
Steps to Reproduce:
Run test_validate_negative_stock_for_inventory_dimension
Check database for leftover:
Inventory Dimension "Inv Site"
Custom Fields (inv_site, to_inv_site)
Physical columns in transaction tables
Actual Result: Orphaned test data persisted after test completion.
Expected Result: All test artifacts should be cleaned post-execution.

**Fix Summary**
Added comprehensive teardown logic that:
Removes test Inventory Dimension if it exists
Cleans Custom Fields across 5 affected doctypes
Drops physical columns from transaction tables
Resets caches and Stock Settings to default state

**Affected Module**
Stock/Inventory: Dimension validation system
Testing Framework: Test isolation integrity

**Test Cases Covered**
Verifies cleanup of:
Inventory Dimension doctype
Custom Fields in transaction tables
Physical database columns
Cache invalidation

**Linked Issue**
Fixes #2418