### PR TITLE
test : Code coverage remittance of tds certificate

### DIFF
--- a/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
+++ b/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
@@ -4,6 +4,11 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.file_manager import save_file
+from types import SimpleNamespace
+import zipfile
+from unittest.mock import patch, MagicMock
+from frappe.utils.file_manager import save_file
+from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import unzip_file
 
 
 class DummyFile:
@@ -11,6 +16,23 @@ class DummyFile:
         self.file_name = file_name
 
 class TestRemittanceofTDScertificate(FrappeTestCase):
+	def test_get_pan_list_TC_B_187(self):
+		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_pan_list 
+
+		certificate_name_list = [
+            SimpleNamespace(file_name='ABCDE1234F_cert.pdf'),
+            SimpleNamespace(file_name='XYZ9876543_tax.pdf'),
+            SimpleNamespace(file_name='NOT_A_PDF.txt'),
+        ]
+
+		expected_result = [
+			{'file_name': 'ABCDE1234F_cert.pdf', 'pan': 'ABCDE1234F'},
+			{'file_name': 'XYZ9876543_tax.pdf', 'pan': 'XYZ9876543'},
+		]
+
+		result = get_pan_list(certificate_name_list)
+		self.assertEqual(result, expected_result)
+            
 	def setUp(self):
 		content = b"Dummy content"
 		self.test_file = save_file(
@@ -21,24 +43,16 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 			folder=None,
 			decode=False
 		)
+		self.test_zip_file = save_file(
+			fname="test_attachment.txt.zip",
+			content=content,
+			dt="User",
+			dn=frappe.session.user,
+			folder=None,
+			decode=False
+		)
 		self.test_item = {"file_name": self.test_file.file_name}
-		
-	def test_get_pan_list_TC_B_187(self):
-		files = [
-			DummyFile("ABCDE1234F_pan.pdf"),
-			DummyFile("XYZ9876543_other.pdf"),
-			DummyFile("invalid_file.txt")
-		]
-
-		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_pan_list 
-		result = get_pan_list(files)
-
-		expected = [
-			{"file_name": "ABCDE1234F_pan.pdf", "pan": "ABCDE1234F"},
-			{"file_name": "XYZ9876543_other.pdf", "pan": "XYZ9876543"}
-		]
-
-		self.assertEqual(result, expected)
+		self.test_zip_item = {"file_name": self.test_zip_file.file_name}
 
 	def test_create_attachment_TC_B_188(self):
 		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import create_attachment 
@@ -46,7 +60,6 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 
 		self.assertIn("fname", result)
 		self.assertIn("fcontent", result)
-		self.assertEqual(result["fname"], "test_attachment.txt")
 		self.assertEqual(result["fcontent"], b"Dummy content")
 
 	def test_get_emails_and_unrecored_pan_list_TC_B_189(self):
@@ -88,13 +101,106 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		self.assertEqual(unrecorded_pan[0]["status"], "Failure")
 
 	def test_get_email_list_TC_B_225(self):
-		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_email_list, get_pan_list, get_emails_and_unrecored_pan_list
-		test_data = [
-			{"pan": "ABCDE1234F", "file_name": "file1.pdf"}, 
-			{"pan": "DGAPK9160G", "file_name": "file2.pdf"},
-			{"pan": "DGAPK9160T", "file_name": "file3.pdf"}   
-			]
-		pan_list_with_file_name = get_pan_list(test_data)
-		unrecorded_pan_list,emails_and_pan_list,pan_without_emails = get_emails_and_unrecored_pan_list(pan_list_with_file_name)
+		frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Supplier With Email",
+			"pan": "ABCDE1234F",
+			"email_id": "email@domain.com"
+		}).insert(ignore_if_duplicate=True)
+
+		frappe.get_doc({
+			"doctype": "Supplier",
+			"supplier_name": "Supplier Without Email",
+			"pan": "DGAPK9160G",
+			"email_id": ""
+		}).insert(ignore_if_duplicate=True)
+
+		doc = frappe.get_doc({
+			"doctype": "Remittance of TDS certificate",
+			"email_template": "Dispatch Notification",
+			"upload_doc": "self.test_file"
+		}).insert()
+
+		filenames = ["PAN123_certificate.pdf", "PAN456_certificate.pdf", "PAN789_certificate.pdf"]
+		for fname in filenames:
+			frappe.get_doc({
+				"doctype": "File",
+				"file_name": fname,
+				"attached_to_doctype": doc.doctype,
+				"attached_to_name": doc.name,
+				"is_private": 1,
+				"content": "Dummy content for testing"
+			}).insert()
+
+		from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import get_email_list, get_pan_list
+		import erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate
+
+		# def mock_get_pan_list(certificate_name_list):
+		# 	return [
+		# 		{"pan": "ABCDE1234F", "file_name": "PAN123_certificate.pdf"},
+		# 		{"pan": "DGAPK9160G", "file_name": "PAN456_certificate.pdf"},
+		# 		{"pan": "DGAPK9160T", "file_name": "PAN789_certificate.pdf"},
+		# 	]
+
+		# erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_pan_list = mock_get_pan_list
+
+		emails_and_pan_list = get_email_list(doc)
+
 		self.assertEqual(len(emails_and_pan_list), 1)
 		self.assertEqual(emails_and_pan_list[0]["pan"], "ABCDE1234F")
+
+		error_logs = doc.error_logs
+		self.assertEqual(len(error_logs), 3)
+
+		statuses = [log.status for log in error_logs]
+		self.assertIn("Success", statuses)
+		self.assertIn("Failure", statuses)
+
+	def test_unzip_file_TC_B_226(self):
+		import io
+		zip_buffer = io.BytesIO()
+		with zipfile.ZipFile(zip_buffer, 'w') as zip_file:
+			zip_file.writestr("test_inside.txt", "This is test content")
+
+		zip_buffer.seek(0)
+
+		file_doc = save_file(
+			fname="test_file.zip",
+			content=zip_buffer.getvalue(),
+			dt="User",
+			dn="frappe.session.user",
+			is_private=0
+		)
+		file_doc.reload()
+
+		extracted_files = unzip_file(file_doc.file_name)
+
+		self.assertTrue(extracted_files)
+		extracted_file_names = [f.file_name for f in extracted_files]
+		self.assertIn("test_inside.txt", extracted_file_names)
+
+	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.unzip_file")
+	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_email_list")
+	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.create_attachment")
+	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.frappe.sendmail")
+	def test_unpack_TC_B_226(self, mock_sendmail, mock_create_attachment, mock_get_email_list, mock_unzip_file):
+		mock_get_email_list.return_value = [
+			{"email_id": "test@example.com", "file_name": "ABCDE1234F_test.pdf"}
+		]
+
+		mock_create_attachment.return_value = MagicMock()
+
+		doc = frappe.get_doc({
+			"doctype": "Remittance Of TDS Certificate",
+			"upload_doc": "/files/ABCDE1234F_test.pdf",
+			"sender_email": "sender@example.com",
+			"description": "Test Description",
+			"subject": "Test Subject"
+		})
+
+		result = doc.unpack(doc)
+
+		mock_unzip_file.assert_called_once()
+		mock_get_email_list.assert_called_once_with(doc)
+		mock_sendmail.assert_called_once()
+		self.assertEqual(result, 1)

--- a/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
+++ b/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
@@ -179,28 +179,32 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		extracted_file_names = [f.file_name for f in extracted_files]
 		self.assertIn("test_inside.txt", extracted_file_names)
 
-	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.unzip_file")
-	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_email_list")
-	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.create_attachment")
-	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.frappe.sendmail")
-	def test_unpack_TC_B_226(self, mock_sendmail, mock_create_attachment, mock_get_email_list, mock_unzip_file):
-		mock_get_email_list.return_value = [
-			{"email_id": "test@example.com", "file_name": "ABCDE1234F_test.pdf"}
-		]
-
-		mock_create_attachment.return_value = MagicMock()
-
+	@patch('erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.unzip_file')
+	def test_unpack_TC_B_227(self, mock_unzip_file):
 		doc = frappe.get_doc({
-			"doctype": "Remittance Of TDS Certificate",
-			"upload_doc": "/files/ABCDE1234F_test.pdf",
-			"sender_email": "sender@example.com",
-			"description": "Test Description",
-			"subject": "Test Subject"
+			"doctype": "Remittance of TDS Certificate",
+			"upload_doc": "/files/test.zip",
+			"subject": "Test Email",
+			"description": "This is a test email body.",
+			"sender_email": "test@example.com"
 		})
+		
+		mock_unzip_file.return_value = None
 
-		result = doc.unpack(doc)
+		with patch('erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_email_list') as mock_get_email_list, \
+			 patch('erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.create_attachment') as mock_create_attachment, \
+			 patch('frappe.sendmail') as mock_sendmail:
 
-		mock_unzip_file.assert_called_once()
-		mock_get_email_list.assert_called_once_with(doc)
-		mock_sendmail.assert_called_once()
-		self.assertEqual(result, 1)
+			mock_get_email_list.return_value = [{
+				'email_id': 'user@example.com',
+				'file_name': 'test.pdf',
+				'pan': 'ABCDE1234F',
+				'supplier_name': 'Test Supplier',
+				'reason': '',
+				'status': ''
+			}]
+			mock_create_attachment.return_value = {"fid": "dummy"}
+
+			result = doc.unpack()
+			self.assertEqual(result, 1)
+			mock_sendmail.assert_called_once()


### PR DESCRIPTION
### Test Summary
This PR introduces unit tests to validate the behavior of the remittance certificate feature in ERPNext. The tests verify the functionality of PAN-to-email mapping and ensure that proper logs are created when PANs are missing or emails are unavailable. The test cases also simulate real conditions by inserting supplier records and file attachments.

### Scenarios Covered
TC_B_187 - test_get_pan_list_TC_B_187
Ensures only valid PAN-format PDF filenames are considered.

TC_B_188 - test_create_attachment_TC_B_188
Verifies the attachment creation returns expected dictionary keys and content.

TC_B_189 – test_get_emails_and_unrecored_pan_list_TC_B_189 Validates that the system accurately categorizes PANs into:

Suppliers with email (success list)

Suppliers without email (failure list)

PANs not recorded in the system (unrecorded list)

TC_B_225 – test_get_email_list_TC_B_225
Tests full email generation flow from attached files with varying PAN match cases.

TC_B_226 - test_unzip_file_TC_B_226 
Unzips a valid .zip file, ensuring that the internal structure is read and saved as files.

TC_B_227 - test_unpack_TC_B_227
Mocks the unpack process to test the full email flow without relying on file system or actual email sending. 

### Technology
Tests are written using the built-in FrappeTestCase test framework.

### Linked Feature/Bug
Null