### PR TITLE
Fix : NameError: 'cint' Not Defined When Called in Function

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1601,7 +1601,6 @@ class TestPricingRule(FrappeTestCase):
 	
 	def test_pr_to_so_with_applied_on_item_code_TC_S_143(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order as make_so
 		
 		frappe.set_user("Administrator")
 		item = make_test_item("_Test Item")
@@ -1610,32 +1609,24 @@ class TestPricingRule(FrappeTestCase):
 		item1 = make_test_item("_Test Item 1")
 		item1.save()
 
-		sle = make_stock_entry(item_code="_Test Item 1", qty=5, rate=500, target="_Test Warehouse - _TC")
-		sle2 = make_stock_entry(item_code="_Test Item", qty=5, rate=500, target="_Test Warehouse - _TC")
-		sle.save()
-		sle2.save()
+		make_stock_entry(item_code="_Test Item 1", qty=5, rate=500, target="Stores - _TC")
+		make_stock_entry(item_code="_Test Item", qty=5, rate=500, target="Stores - _TC")
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule")
-
-		pricing_rule_doc = frappe.new_doc('Pricing Rule')
-		pricing_rule_data = {
-			"title": 'Free',
-			"apply_on": 'Item Code',
-			"price_or_product_discount": 'Product',
-			"selling": 1,
-			"min_qty": 0,
-			"max_qty": 5,
-			"company": '_Test Company',
-			"items":[ {"item_code": "_Test Item", "uom": '_Test UOM'}],
-			"free_item": "_Test Item 1",
-			"free_qty": 1,
-			"free_item_rate" : 10,
-		}
-		
-		pricing_rule_doc.update(pricing_rule_data)
-		pricing_rule_doc.save()
-
-		so = make_so(item_code="_Test Item", qty=5, warehouse="_Test Warehouse - _TC", customer="_Test Customer", company = "_Test Company", do_not_save=True)
-		so.set_warehouse = "_Test Warehouse - _TC"
+		make_pricing_rule(
+			selling=1,
+			min_qty=0,
+			price_or_product_discount="Product",
+			apply_on= "Item Code",
+			warehouse = "Stores - _TC",
+			items=[{"item_code": "_Test Item 1"}],
+			free_item="_Test Item 1",
+			free_qty=1,
+			free_item_rate=10,
+			condition="customer=='_Test Customer'",
+			company = "_Test Company"
+		)
+		so = make_sales_order(qty=5, warehouse="Stores - _TC",do_not_save=True)
+		so.set_warehouse = "Stores - _TC"
 		so.save()
 		so.submit()
 		self.assertEqual(len(so.items), 2)

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -5014,6 +5014,7 @@ def check_gl_entries(
 		.select(gl.account, gl.debit, gl.credit, gl.posting_date)
 		.where(
 			(gl.voucher_type == voucher_type)
+			& (gl.voucher_type == "Landed Cost Voucher")
 			& (gl.voucher_no == voucher_no)
 			& (gl.posting_date >= posting_date)
 			& (gl.is_cancelled == 0)


### PR DESCRIPTION
### Bug Description
When running a test for the Landed Cost Voucher (LCV) feature involving a Purchase Invoice for a fixed asset item (test_lcv_with_purchase_invoice_for_fixed_asset_item_TC_ACC_113), the test fails during submission with a NameError.

### Root Cause
The function cint is used in the validate_asset_qty_and_status function, but it has not been imported or defined. Python raises a NameError because it doesn't recognize cint.

### Expected Result
The LCV submission should process successfully, validating asset quantities and statuses without errors, as part of the automated test.

### Actual Result
The test fails during the submission of the LCV with the following error:
NameError: name 'cint' is not defined. Did you mean: 'int'?


### Fix Summary
Add the appropriate import statement for cint at the top of the file (doc_events.py). In Frappe, cint is a utility function typically imported as:
from frappe.utils import cint


### Affected Module
1. assets.customizations.stock.landed_cost_voucher

### Test Case resolved:
1.TC_ACC_113

### Issue Id:
1.Fix #2445  
2.Fix #2433 