### PR TITLE
fix: 2377 – ensure validate_selling_price in Selling Settings is properly reset in tests

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -6,6 +6,7 @@ import unittest
 
 import frappe
 from frappe import _
+from frappe.tests.utils import change_settings
 from frappe.utils import cint, flt, getdate, today
 from erpnext.accounts.doctype.pos_invoice.pos_invoice import PartialPaymentValidationError, make_sales_return
 from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
@@ -743,6 +744,7 @@ class TestPOSInvoice(unittest.TestCase):
 		rounded_total = frappe.db.get_value("Sales Invoice", pos_inv.consolidated_invoice, "rounded_total")
 		self.assertEqual(rounded_total, 840)
 
+	@change_settings("Selling Settings",{"validate_selling_price":1})
 	def test_merging_with_validate_selling_price(self):
 		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import (
 			init_user_and_profile,
@@ -750,9 +752,6 @@ class TestPOSInvoice(unittest.TestCase):
 		from erpnext.accounts.doctype.pos_invoice_merge_log.pos_invoice_merge_log import (
 			consolidate_pos_invoices,
 		)
-
-		if not frappe.db.get_single_value("Selling Settings", "validate_selling_price"):
-			frappe.db.set_single_value("Selling Settings", "validate_selling_price", 1)
 
 		item = "Test Selling Price Validation"
 		make_item(item, {"is_stock_item": 1})
@@ -795,7 +794,9 @@ class TestPOSInvoice(unittest.TestCase):
 		pos_inv2.load_from_db()
 		rounded_total = frappe.db.get_value("Sales Invoice", pos_inv2.consolidated_invoice, "rounded_total")
 		self.assertEqual(rounded_total, 400)
+		frappe.clear_cache(doctype="Selling Settings")
 
+	@change_settings("Selling Settings",{"validate_selling_price":0})
 	def test_pos_batch_reservation(self):
 		from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
 			get_auto_batch_nos,
@@ -855,6 +856,7 @@ class TestPOSInvoice(unittest.TestCase):
 		for batch in batches:
 			if batch.batch_no == batch_no and batch.warehouse == "_Test Warehouse - _TC":
 				self.assertEqual(batch.qty, 5)
+		frappe.clear_cache(doctype="Selling Settings")
 
 	def test_pos_batch_item_qty_validation(self):
 		from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -50,6 +50,8 @@ class TestSalesInvoice(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.db.rollback()
+		if frappe.db.get_single_value("Selling Settings", "validate_selling_price"):
+			frappe.db.set_single_value("Selling Settings", "validate_selling_price", 0)
 
 	def make(self):
 		w = frappe.copy_doc(test_records[0])
@@ -5726,6 +5728,7 @@ class TestSalesInvoice(FrappeTestCase):
 		]
 		check_gl_entries(self, jv_doc.name, expected_gl_entries, jv_doc.posting_date, "Journal Entry")
 	
+	@change_settings("Selling Settings",{"validate_selling_price":1})
 	def test_prevent_sale_below_purchase_rate_TC_ACC_125(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			create_purchase_invoice,
@@ -5733,15 +5736,17 @@ class TestSalesInvoice(FrappeTestCase):
 			create_supplier,
 		)
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+		import frappe
+
 		get_or_create_fiscal_year("_Test Company")
-		selling_setting = frappe.get_doc("Selling Settings")
-		selling_setting.validate_selling_price = 1
-		selling_setting.save()
 
+		if not frappe.db.get_value("Company","_Test Company","stock_received_but_not_billed"):
+			frappe.db.set_value("Company","_Test Company","stock_received_but_not_billed","Stock Received But Not Billed - _TC")
 		supplier = create_supplier(supplier_name="_Test Supplier")
-
 		item = make_test_item("_Test Sell Item")
 
+		# Purchase at 100
 		pi = create_purchase_invoice(
 			supplier=supplier.name,
 			company="_Test Company",
@@ -5751,26 +5756,26 @@ class TestSalesInvoice(FrappeTestCase):
 		)
 		pi.save().submit()
 
-		try:
-			si = create_sales_invoice(
-				customer="_Test Customer",
-				company="_Test Company",
-				item_code=item.name,
-				qty=1,
-				rate=99
-			)
-		except Exception as e:
-			error_msg = str(e)
-		self.assertEqual(
-            error_msg,
-            (
-                "Row #1: Selling rate for item _Test Item is lower than its last purchase rate.\n"
-                "\t\t\t\t\tSelling net rate should be atleast 100.0.Alternatively,\n"
-                "\t\t\t\t\tyou can disable selling price validation in Selling Settings to bypass\n"
-                "\t\t\t\t\tthis validation."
-            )
-        )
+		expected_msg = (
+			"Row #1: Selling rate for item _Test Item is lower than its last purchase rate.\n"
+			"\t\t\t\t\tSelling net rate should be atleast 100.0.Alternatively,\n"
+			"\t\t\t\t\tyou can disable selling price validation in Selling Settings to bypass\n"
+			"\t\t\t\t\tthis validation."
+		)
+		si = create_sales_invoice(
+			customer="_Test Customer",
+			company="_Test Company",
+			item_code=item.name,
+			qty=1,
+			rate=99,
+			do_not_save=1
+		)
+		with self.assertRaises(frappe.ValidationError) as context:
+			si.save()
+		self.assertEqual(str(context.exception), expected_msg)
+		frappe.clear_cache(doctype="Selling Settings")
 	
+	@change_settings("Selling Settings",{"validate_selling_price":0})
 	def test_test_unlink_payment_on_invoice_cancellation_TC_ACC_126(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			make_test_item
@@ -5801,6 +5806,8 @@ class TestSalesInvoice(FrappeTestCase):
 		except Exception as e:
 			error_msg = str(e)
 			self.assertEqual(error_msg,f'Cannot delete or cancel because Sales Invoice {si_name} is linked with Payment Entry {pe_name} at Row: 1')
+		finally:
+			frappe.clear_cache(doctype="Selling Settings")
 
 	def test_si_cancel_amend_with_item_details_change_TC_S_128(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (


### PR DESCRIPTION
### Bug Description
Certain test cases were failing due to selling price validations that compare the selling rate against the last purchase rate. This validation was not relevant to the test scenario and caused unintended failures.

### Root Cause
The system enforces a check via the validate_selling_price flag in Selling Settings. Two test cases were enabling this flag to 1, but they did not properly reset the setting afterward. As a result, when running the full test suite at the application level, some other unrelated test cases failed due to triggered selling rate validations—even in controlled test environments.

### Actual/Observed Result:
Test case fails with a ValidationError like:
Row #1: Selling rate for item _Test Item for Drop Shipping is lower than its last purchase rate.

### Expected Result:
The test case should focus on core business logic, not fail due to irrelevant selling price validation.

### Fix Summary
Selling price validation is programmatically disabled after test execution inside the Selling Settings

### Affected Module
[Selling , Accounts]

### Test Cases Covered
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
Test Name
--
test_update_coupon_code_count_on_cancel_TC_S_173
test_quotation_to_po_with_drop_ship_with_GST_TC_S_112
test_quotation_to_si_with_pi_and_drop_ship_TC_S_114
test_quotation_to_si_with_pi_and_drop_ship_with_GST_TC_S_116
test_so_with_qi_flow_TC_S_032
test_so_to_po_with_gst_TC_S_110
test_so_to_si_with_loyalty_point_creating_payment_TC_S_108
test_so_to_si_with_manual_discount_grand_total_TC_S_136
test_so_to_si_with_manual_discount_net_total_TC_S_137
test_so_to_si_with_po_TC_S_113
test_so_to_si_with_po_with_gst_TC_S_115
test_quotation_expired_to_create_sales_order_TC_S_153
test_stock_reservation_from_so_to_dn_TC_SCK_143
test_sales_order_create_si_via_partial_pe_with_pricing_rule_TC_S_047
test_sales_order_create_si_via_pe_dn_with_pricing_rule_TC_S_046
test_make_quotation_and_opportunity_TC_S_185
test_customer_from_prospect_TC_S_180
test_lead_to_quotation_TC_S_171
test_quotation_with_referral_sales_partner_TC_S_172
test_sales_invoice_flow_TC_S_179
test_cannot_cancel_closed_so_TC_S_169
test_check_modified_date_coverage_TC_S_164
test_close_or_unclose_sales_orders_coverage_TC_S_178
test_make_maintenance_schedule_coverage_TC_S_186
test_make_project_coverage_TC_S_190
test_on_recurring_coverage_TC_S_177
test_onload_coverage_TC_S_175
test_sales_order_for_partial_return_TC_S_035
test_sales_order_for_partial_sales_return_via_payment_entry_TC_S_037
test_sales_order_for_sales_return_TC_S_033
test_sales_order_for_sales_return_via_payment_entry_TC_S_036
test_sales_order_for_sales_return_via_si_TC_S_034
test_sales_order_with_advance_payment_TC_S_040
test_so_cancel_amend_with_rate_change_TC_S_127
test_sales_order_to_sales_return_SR_TC_S_049
test_set_delivery_date_coverage_TC_S_192
test_set_indicator_coverage_TC_S_182
test_create_tax_rule_and_apply_to_sales_invoice_TC_ACC_101
test_sales_invoice_dont_reserve_sales_order_qty_on_sales_return_TC_S_158
test_sales_invoice_to_allow_item_multiple_times_TC_S_159
test_si_cancel_amend_with_customer_change_TC_S_129
test_si_cancel_amend_with_item_details_change_TC_S_128
test_si_cancel_amend_with_payment_terms_change_TC_S_130
test_si_credit_note_cancel_amend_with_payment_terms_change_TC_S_131
test_si_with_sr_calculate_with_fixed_TC_S_139
test_si_with_sr_calculate_with_net_weight_TC_S_141
test_si_with_deferred_revenue_item_TC_S_135
test_si_with_sr_calculate_with_net_total_TC_S_140
test_update_status_coverage_TC_S_165
test_validate_supplier_after_submit_coverage_TC_S_176
test_update_picking_status_coverage_TC_S_174

### Linked Issue
Fixes #2377 
