### PR TITLE
Fix :The test case test_pr_to_so_with_applied_on_item_code_TC_S_143 in the Pricing Rule module fails because the generated Sales Order (so) contains 1 item instead of the expected 2 items. - AssertionError: 1 != 2

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1601,6 +1601,7 @@ class TestPricingRule(FrappeTestCase):
 	
 	def test_pr_to_so_with_applied_on_item_code_TC_S_143(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order as make_so
 		
 		frappe.set_user("Administrator")
 		item = make_test_item("_Test Item")
@@ -1609,24 +1610,32 @@ class TestPricingRule(FrappeTestCase):
 		item1 = make_test_item("_Test Item 1")
 		item1.save()
 
-		make_stock_entry(item_code="_Test Item 1", qty=5, rate=500, target="Stores - _TC")
-		make_stock_entry(item_code="_Test Item", qty=5, rate=500, target="Stores - _TC")
+		sle = make_stock_entry(item_code="_Test Item 1", qty=5, rate=500, target="_Test Warehouse - _TC")
+		sle2 = make_stock_entry(item_code="_Test Item", qty=5, rate=500, target="_Test Warehouse - _TC")
+		sle.save()
+		sle2.save()
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule")
-		make_pricing_rule(
-			selling=1,
-			min_qty=0,
-			price_or_product_discount="Product",
-			apply_on= "Item Code",
-			warehouse = "Stores - _TC",
-			items=[{"item_code": "_Test Item 1"}],
-			free_item="_Test Item 1",
-			free_qty=1,
-			free_item_rate=10,
-			condition="customer=='_Test Customer'",
-			company = "_Test Company"
-		)
-		so = make_sales_order(qty=5, warehouse="Stores - _TC",do_not_save=True)
-		so.set_warehouse = "Stores - _TC"
+
+		pricing_rule_doc = frappe.new_doc('Pricing Rule')
+		pricing_rule_data = {
+			"title": 'Free',
+			"apply_on": 'Item Code',
+			"price_or_product_discount": 'Product',
+			"selling": 1,
+			"min_qty": 0,
+			"max_qty": 5,
+			"company": '_Test Company',
+			"items":[ {"item_code": "_Test Item", "uom": '_Test UOM'}],
+			"free_item": "_Test Item 1",
+			"free_qty": 1,
+			"free_item_rate" : 10,
+		}
+		
+		pricing_rule_doc.update(pricing_rule_data)
+		pricing_rule_doc.save()
+
+		so = make_so(item_code="_Test Item", qty=5, warehouse="_Test Warehouse - _TC", customer="_Test Customer", company = "_Test Company", do_not_save=True)
+		so.set_warehouse = "_Test Warehouse - _TC"
 		so.save()
 		so.submit()
 		self.assertEqual(len(so.items), 2)

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -5014,6 +5014,7 @@ def check_gl_entries(
 		.select(gl.account, gl.debit, gl.credit, gl.posting_date)
 		.where(
 			(gl.voucher_type == voucher_type)
+			& (gl.voucher_type == "Landed Cost Voucher")
 			& (gl.voucher_no == voucher_no)
 			& (gl.posting_date >= posting_date)
 			& (gl.is_cancelled == 0)


### PR DESCRIPTION
### Bug Description:
The test case test_pr_to_so_with_applied_on_item_code_TC_S_143 in the Pricing Rule module fails because the generated Sales Order (so) contains 1 item instead of the expected 2 items.

### Root Cause:
The test expects that two items with pricing rules applied at the item code level are mapped from a Purchase Receipt (PR) to a Sales Order (SO). However, only one item is being added to the Sales Order.
This could be due to one or more of the following:
Misconfigured or missing pricing rules for the second item.
The logic in the PR to SO mapping function is filtering out or skipping the second item.
Item filters or conditions in the pricing rule setup may not match all expected items.

### Expected Result:
When converting from Purchase Receipt to Sales Order, the system should map two items as per the pricing rule setup, and len(so.items) should return 2.

### Actual Result:
Only one item is present in the Sales Order after conversion, causing the test to fail with AssertionError: 1 != 2.

### Fix Summary:
Review the pricing rule(s) applied on item code to ensure both items are properly covered.
Check the mapping function (likely using make_mapped_doc) to confirm it's iterating through and including both items.
Fix the condition or logic that might be skipping the second item.
Re-run the test after adjusting configuration or logic.

### Affected Module:
ERPNext > Accounts > Pricing Rule

### Test Case Resolved:
1.test_pr_to_so_with_applied_on_item_code_TC_S_143

### Issue Id:
Fix #2433
