### PR TITLE
test: Fixed a test case for item_query where the test expected data to be saved before reloading, but the steps were in the wrong order.

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -745,7 +745,7 @@ class TestQualityInspection(FrappeTestCase):
 		# Create Item
 		item = create_item(item_code="_Test BOM Item", stock_uom="Nos", is_stock_item=1)
 		item.quality_inspection_template = template_name
-		item.inspection_required_before_purchase =1
+		item.inspection_required_before_purchase = 1
 		item.save()
 
 		# Create BOM for the item and link the QA template
@@ -759,7 +759,11 @@ class TestQualityInspection(FrappeTestCase):
 			bom.submit()
 
 		pr = make_purchase_receipt(
-			item_code=item.name, supplier_warehouse=warehouse, company=company.name, stock_uom="Box", do_not_submit=True
+			item_code=item.name,
+			supplier_warehouse=warehouse,
+			company=company.name,
+			stock_uom="Box",
+			do_not_submit=True,
 		)
 
 		# Create Quality Inspection without template (method will fetch it from BOM)
@@ -910,8 +914,8 @@ class TestQualityInspection(FrappeTestCase):
 		mock_set_value.assert_not_called()
 
 	def test_item_query_TC_SCK_290(self):
-		from erpnext.stock.doctype.quality_inspection.quality_inspection import item_query
 		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.quality_inspection.quality_inspection import item_query
 
 		frappe.set_user("Administrator")
 		frappe.db.rollback()
@@ -930,13 +934,17 @@ class TestQualityInspection(FrappeTestCase):
 
 		# Create purchase receipt with the item
 		pr = make_purchase_receipt(
-			item_code=item.name, company="_Test Company",supplier_warehouse=warehouse, stock_uom="Box", do_not_submit=True
+			item_code=item.name,
+			company="_Test Company",
+			supplier_warehouse=warehouse,
+			stock_uom="Box",
+			do_not_submit=True,
 		)
 
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_customer
 
 		create_customer(name="_Test Customer")
-		dn = create_delivery_note(item_code=item.name,cost_center=cost_center, do_not_submit=True)
+		dn = create_delivery_note(item_code=item.name, cost_center=cost_center, do_not_submit=True)
 		wh = create_warehouse("_Test Warehouse - _TC", company=company.name)
 		se = make_stock_entry(
 			item_code=item.name,
@@ -972,8 +980,8 @@ class TestQualityInspection(FrappeTestCase):
 		# Link to SE item
 		for d in se.items:
 			d.quality_inspection = qi.name
-		se.reload()
 		se.save()
+		se.reload()
 		se.submit()
 
 		from erpnext.buying.doctype.supplier_quotation.supplier_quotation import set_expired_status
@@ -1183,6 +1191,7 @@ def setup_test_company_defaults(company_name="_Test Company", abbreviation="_TC"
 	set_default("company", company_name, "__default")
 
 	return company
+
 
 def setup_fy_gls_cost_center():
 	company = setup_test_company_defaults()


### PR DESCRIPTION
**Test Coverage:**
fix field code coverage test case ID:**TC_SCK_290** for Quality Inspection.

---
**Description:**
While Stock Entry raise in test case correct it order of save and then reload

---
**Scenarios Covered:**
**TC_SCK_290 (test_item_query_TC_SCK_290)**
Improved coverage of item_query() function for multiple parent types.
Created relevant documents (PR, DN, SE, SQ) and validated that item appears in query results.
Ensured logic paths for each document type’s filter conditions were executed.

---
## Technology:
Frappe Framework: v15.65.2 (pre-prod)
ERPNext: v15.58.2

---
## Linked Feature/Bug
*Code Coverage Expansion*

## Reference PR ID:
[PR: 2423](https://github.com/8848digital/erpnext/pull/2423)


