### PR TITLE
test: Test item manufacturer details are properly linked, stored, and validated.

### DIFF
--- a/erpnext/stock/doctype/item_manufacturer/item_manufacturer.py
+++ b/erpnext/stock/doctype/item_manufacturer/item_manufacturer.py
@@ -13,7 +13,7 @@ class ItemManufacturer(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		description: DF.SmallText | None

--- a/erpnext/stock/doctype/item_manufacturer/test_item_manufacturer.py
+++ b/erpnext/stock/doctype/item_manufacturer/test_item_manufacturer.py
@@ -1,9 +1,91 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
 import unittest
+
+import frappe
+
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 
 
 class TestItemManufacturer(unittest.TestCase):
-	pass
+	def tearDown(self):
+		frappe.db.rollback()
+
+	# codecov
+	def test_validate_TC_SCK_313(self):
+		from erpnext.stock.doctype.item_manufacturer.item_manufacturer import get_item_manufacturer_part_no
+
+		item_code = "_Test Item"
+
+		manufacturer_doc = frappe.get_doc(
+			{
+				"doctype": "Manufacturer",
+				"short_name": "Test Item Manufacturer",
+				"full_name": "Test Item manufacturer",
+				"country": "India",
+			}
+		).insert()
+
+		if not frappe.db.exists("Item", item_code):
+			item_create = make_test_item(item_code)
+			item_create.default_item_manufacturer = manufacturer_doc.name
+			item_create.default_manufacturer_part_no = "001"
+			item_create.save()
+		else:
+			item_create = frappe.get_doc("Item", item_code)
+			item_create.default_item_manufacturer = manufacturer_doc.name
+			item_create.default_manufacturer_part_no = "001"
+			item_create.save()
+
+		item_manufacturer_doc = frappe.get_doc(
+			{
+				"doctype": "Item Manufacturer",
+				"item_code": item_code,
+				"manufacturer": manufacturer_doc,
+				"manufacturer_part_no": "001",
+			}
+		).insert()
+		get_item_manufacturer_part_no(item_code, manufacturer_doc.name)
+		self.assertEqual(item_manufacturer_doc.item_code, item_code)
+		self.assertEqual(item_manufacturer_doc.manufacturer, manufacturer_doc.name)
+		self.assertEqual(item_manufacturer_doc.manufacturer_part_no, "001")
+
+	# codecov
+	def test_validate_delete_TC_SCK_314(self):
+		item_code = "_Test Item"
+
+		manufacturer_doc = frappe.get_doc(
+			{
+				"doctype": "Manufacturer",
+				"short_name": "Test Item Manufacturer",
+				"full_name": "Test Item manufacturer",
+				"country": "India",
+			}
+		).insert()
+
+		if not frappe.db.exists("Item", item_code):
+			item_create = make_test_item(item_code)
+			item_create.default_item_manufacturer = manufacturer_doc.name
+			item_create.default_manufacturer_part_no = "001"
+			item_create.save()
+		else:
+			item_create = frappe.get_doc("Item", item_code)
+			item_create.default_item_manufacturer = manufacturer_doc.name
+			item_create.default_manufacturer_part_no = "001"
+			item_create.save()
+
+		item_manufacturer_doc = frappe.get_doc(
+			{
+				"doctype": "Item Manufacturer",
+				"item_code": item_code,
+				"is_default": 1,
+				"manufacturer": manufacturer_doc.name,
+				"manufacturer_part_no": "001",
+			}
+		).insert()
+		item_manufacturer_doc.reload()
+		item_manufacturer_doc.delete()
+		item = frappe.get_doc("Item", item_code)
+		self.assertIsNone(item.default_item_manufacturer)
+		self.assertIsNone(item.default_manufacturer_part_no)

--- a/erpnext/stock/doctype/item_manufacturer/test_item_manufacturer.py
+++ b/erpnext/stock/doctype/item_manufacturer/test_item_manufacturer.py
@@ -27,16 +27,10 @@ class TestItemManufacturer(unittest.TestCase):
 			}
 		).insert()
 
-		if not frappe.db.exists("Item", item_code):
-			item_create = make_test_item(item_code)
-			item_create.default_item_manufacturer = manufacturer_doc.name
-			item_create.default_manufacturer_part_no = "001"
-			item_create.save()
-		else:
-			item_create = frappe.get_doc("Item", item_code)
-			item_create.default_item_manufacturer = manufacturer_doc.name
-			item_create.default_manufacturer_part_no = "001"
-			item_create.save()
+		item_create = make_test_item(item_code)
+		item_create.default_item_manufacturer = manufacturer_doc.name
+		item_create.default_manufacturer_part_no = "001"
+		item_create.save()
 
 		item_manufacturer_doc = frappe.get_doc(
 			{
@@ -64,16 +58,10 @@ class TestItemManufacturer(unittest.TestCase):
 			}
 		).insert()
 
-		if not frappe.db.exists("Item", item_code):
-			item_create = make_test_item(item_code)
-			item_create.default_item_manufacturer = manufacturer_doc.name
-			item_create.default_manufacturer_part_no = "001"
-			item_create.save()
-		else:
-			item_create = frappe.get_doc("Item", item_code)
-			item_create.default_item_manufacturer = manufacturer_doc.name
-			item_create.default_manufacturer_part_no = "001"
-			item_create.save()
+		item_create = make_test_item(item_code)
+		item_create.default_item_manufacturer = manufacturer_doc.name
+		item_create.default_manufacturer_part_no = "001"
+		item_create.save()
 
 		item_manufacturer_doc = frappe.get_doc(
 			{

--- a/erpnext/stock/doctype/manufacturer/manufacturer.py
+++ b/erpnext/stock/doctype/manufacturer/manufacturer.py
@@ -12,7 +12,7 @@ class Manufacturer(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		country: DF.Link | None

--- a/erpnext/stock/doctype/manufacturer/test_manufacturer.py
+++ b/erpnext/stock/doctype/manufacturer/test_manufacturer.py
@@ -1,10 +1,25 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+import frappe
 
 # test_records = frappe.get_test_records('Manufacturer')
 
 
 class TestManufacturer(unittest.TestCase):
-	pass
+	def tearDown(self):
+		frappe.db.rollback()
+
+	# codecov
+	def test_onload_TC_SCK_314(self):
+		manufacturer_doc = frappe.get_doc(
+			{
+				"doctype": "Manufacturer",
+				"short_name": "Test Item Manufacturer",
+				"full_name": "Test Item manufacturer",
+				"country": "India",
+			}
+		).insert()
+		manufacturer_doc.onload()
+		assert hasattr(manufacturer_doc, "__onload"), "__onload should be set after onload()"


### PR DESCRIPTION
Title:
Test item manufacturer details are properly linked, stored, and validated.

Description:
Test Summary
Previously, critical doctypes in the Buying module lacked thorough test coverage, increasing the risk of regression and data inconsistency.
This commit introduces detailed test cases for doctypes such as Item Manufacturer and Manufacturer, ensuring realistic test data is created, key workflows are validated, and data integrity is maintained post-operations.
The addition of a tearDown method ensures test isolation by rolling back database changes after every test.

Doctypes Covered:

Item Manufacturer

Manufacturer

Test Cases Implemented:

TC_SCK_313: test_validate_TC_SCK_313

Validates that Item Manufacturer part numbers are correctly linked.

Ensures manufacturer data is correctly assigned to the item.

Covers creation of manufacturer and item test records.

TC_SCK_314: test_validate_delete_TC_SCK_314

Validates deletion of Item Manufacturer entry.

Ensures that linked fields (default_item_manufacturer, default_manufacturer_part_no) in the Item are reset on deletion.

Uses item.reload() and assertions for validation.

TC_SCK_315: test_onload_TC_SCK_315

Verifies the behavior of the onload() method for the Manufacturer doctype with test data.

Key Enhancements:

Introduced tearDown(self) method with frappe.db.rollback() to ensure that database changes are reverted post each test, maintaining test environment isolation.

Ensures clean state for every test execution and prevents data leakage between tests.

Improved data consistency and realistic test data simulation.

Scenarios Covered:

Item Manufacturer creation and linking

Manufacturer data validation and behavior testing

Onload method behavior verification

Default field assignment and cleanup logic

Deletion and data cleanup testing

Technology Used:

Python unittest framework

Frappe test utilities

Database rollback via frappe.db.rollback() in tearDown

Linked Feature/Bug:
N/A

Issue ID:
N/A