### PR TITLE
test: Test Suite for Maintenance Visit Validations and Functionality

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_visit/test_maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/test_maintenance_visit.py
@@ -1,16 +1,202 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
 from frappe.utils.data import today
 
+from erpnext.stock.doctype.item.test_item import create_item
+
 # test_records = frappe.get_test_records('Maintenance Visit')
 
 
 class TestMaintenanceVisit(unittest.TestCase):
-	pass
+	def setUp(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company, create_customer
+
+		create_company()
+		self.customer = create_customer("_Test Customer", currency="INR")
+		self.item_code = create_item("_Test Item", is_stock_item=1)
+		self.company = "_Test Company"
+		self.sales_person = self.make_sales_person("_Test Sales Person")
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_update_customer_issue_sets_resolution_fields_TC_M_012(self):
+		sales_person = self.sales_person
+		wc = frappe.get_doc(
+			{
+				"doctype": "Warranty Claim",
+				"item_code": "_Test Item",
+				"customer": "_Test Customer",
+				"complaint": "Test",
+				"status": "Open",
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		mv = frappe.get_doc(
+			{
+				"doctype": "Maintenance Visit",
+				"mntc_date": frappe.utils.nowdate(),
+				"company": "_Test Company",
+				"customer": "_Test Customer",
+				"completion_status": "Fully Completed",
+				"purposes": [
+					{
+						"prevdoc_doctype": "Warranty Claim",
+						"prevdoc_docname": wc.name,
+						"work_done": "Test resolution work",
+						"service_person": sales_person.name,
+					}
+				],
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		mv.update_customer_issue(flag=1)
+
+		updated_wc = frappe.get_doc("Warranty Claim", wc.name)
+
+		self.assertEqual(updated_wc.status, "Closed")
+		self.assertEqual(updated_wc.resolution_details, "Test resolution work")
+		self.assertEqual(str(updated_wc.resolution_date.date()), mv.mntc_date)
+
+	def test_update_customer_issue_from_patial_maintenance_visit_TC_M_013(self):
+		wc = frappe.get_doc(
+			{
+				"doctype": "Warranty Claim",
+				"customer": "_Test Customer",
+				"item_code": "_Test Item",
+				"complaint": "Test",
+				"status": "Open",
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		mv = make_maintenance_visit()
+		mv.purposes[0].prevdoc_docname = wc.name
+		mv.completion_status = "Partially Completed"
+		mv.purposes[0].prevdoc_doctype = "Warranty Claim"
+		mv.update_customer_issue(flag=1)
+
+		wc.reload()
+		self.assertEqual(wc.status, "Work In Progress")
+
+	def test_update_customer_issue_from_maintenance_visit_TC_M_014(self):
+		wc = frappe.get_doc(
+			{
+				"doctype": "Warranty Claim",
+				"customer": "_Test Customer",
+				"item_code": "_Test Item",
+				"complaint": "Test",
+				"status": "Open",
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		mv = make_maintenance_visit()
+		mv.purposes[0].prevdoc_docname = wc.name
+		mv.completion_status = "Fully Completed"
+		mv.purposes[0].prevdoc_doctype = "Warranty Claim"
+		mv.update_customer_issue(flag=1)
+
+		wc.reload()
+		self.assertEqual(wc.status, "Closed")
+		mv1 = make_maintenance_visit()
+		mv1.purposes[0].prevdoc_docname = wc.name
+		mv1.completion_status = "Fully Completed"
+		mv1.purposes[0].prevdoc_doctype = "Warranty Claim"
+		mv1.update_customer_issue(flag=0)
+		if "sales_commission" in frappe.get_installed_apps():
+			self.assertNotEqual("service_person_field", "t2.service_person")
+		else:
+			self.assertEqual("service_person_field", "NULL")
+
+	def test_future_maintenance_visit_prevents_cancel_TC_M_015(self):
+		wc = frappe.get_doc(
+			{
+				"doctype": "Warranty Claim",
+				"customer": "_Test Customer",
+				"item_code": "_Test Item",
+				"complaint": "Tests",
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		mv1 = make_maintenance_visit()
+		mv1.purposes[0].prevdoc_docname = wc.name
+		mv1.purposes[0].prevdoc_doctype = "Warranty Claim"
+		mv1.completion_status = "Fully Completed"
+		mv1.update_customer_issue(flag=1)
+		mv1.mntc_date = today()
+		mv1.mntc_time = "10:00:00"
+		mv1.submit()
+
+		mv2 = make_maintenance_visit()
+		mv2.purposes[0].prevdoc_docname = wc.name
+		mv2.completion_status = "Fully Completed"
+		mv2.purposes[0].prevdoc_doctype = "Warranty Claim"
+		mv2.update_customer_issue(flag=1)
+		mv2.mntc_date = today()
+		mv2.mntc_time = "11:00:00"
+		mv2.submit()
+
+		with self.assertRaises(frappe.ValidationError, msg="Cancel Material Visits"):
+			mv1.cancel()
+
+	def test_update_customer_issue_flag_0_with_previous_partial_visit_TC_M_016(self):
+		sales_person = self.sales_person
+
+		wc = frappe.get_doc(
+			{
+				"doctype": "Warranty Claim",
+				"customer": "_Test Customer",
+				"item_code": "_Test Item",
+				"complaint": "Test",
+				"status": "Open",
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		frappe.get_doc(
+			{
+				"doctype": "Maintenance Visit",
+				"mntc_date": frappe.utils.nowdate(),
+				"company": "_Test Company",
+				"customer": "_Test Customer",
+				"completion_status": "Partially Completed",
+				"docstatus": 1,
+				"purposes": [
+					{
+						"prevdoc_doctype": "Warranty Claim",
+						"prevdoc_docname": wc.name,
+						"work_done": "Partial fix done",
+						"service_person": sales_person.name,
+					}
+				],
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		mv2 = frappe.get_doc(
+			{
+				"doctype": "Maintenance Visit",
+				"mntc_date": frappe.utils.nowdate(),
+				"company": "_Test Company",
+				"customer": "_Test Customer",
+				"completion_status": "Fully Completed",
+				"purposes": [
+					{
+						"prevdoc_doctype": "Warranty Claim",
+						"prevdoc_docname": wc.name,
+						"work_done": "Partial fix done",
+						"service_person": sales_person.name,
+					}
+				],
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
+		mv2.update_customer_issue(flag=0)
+
+		wc.reload()
+		self.assertEqual(wc.status, "Work In Progress")
+		self.assertEqual(wc.resolution_details, "Partial fix done")
+		self.assertEqual(wc.resolved_by, sales_person.name)
 
 
 def make_maintenance_visit():


### PR DESCRIPTION
Title:
Add Test Cases for Maintenance Visit Validations and Functionality

Test Summary
These test cases focus on validating the integration between Maintenance Visits and Warranty Claims, including resolution updates, status transitions, cancellation constraints, and partial completion logic.

Scenarios Covered
Input Validations

TC_M_015: Prevents cancellation of a maintenance visit if a future visit exists for the same warranty claim.

TC_M_016: Ensures that flag=0 behavior correctly updates warranty claim to "Work In Progress" and sets resolution details accordingly when a previous partial visit exists.

Edge Cases

TC_M_013: Verifies that a partially completed maintenance visit updates the warranty claim to Work In Progress.

TC_M_014: Handles the case where two fully completed visits are made on the same claim — tests both flag=1 and flag=0 logic.

TC_M_016: Handles edge behavior for flag=0 in the presence of a prior partial fix visit.

API Response Handling

TC_M_012: Validates that update_customer_issue(flag=1) correctly sets the warranty claim to "Closed", sets resolution details, and assigns resolution date.

TC_M_014: Also includes handling of behavior when sales_commission is installed — tests assignment of service person field conditionally.

Technology
Python unittest

Frappe/ERPNext test environment

Mocking and validation utilities within ERPNext

Linked Feature/Bug
ISSUE ID : None
PR_ID : None