### PR TITLE
test: Comprehensive Test Suite for Maintenance Schedule Validations

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -4,21 +4,54 @@
 import unittest
 
 import frappe
-from frappe.utils import format_date
-from frappe.utils.data import add_days, formatdate, today
 from frappe.tests.utils import if_app_installed
+from frappe.utils import cint, date_diff, format_date, now_datetime, nowdate
+from frappe.utils.data import add_days, formatdate, today
 
 from erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule import (
 	get_serial_nos_from_schedule,
 	make_maintenance_visit,
 )
 from erpnext.stock.doctype.item.test_item import create_item
+
 # from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 # test_records = frappe.get_test_records('Maintenance Schedule')
 
 
 class TestMaintenanceSchedule(unittest.TestCase):
+	def setUp(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
+		create_company()
+		self.item = create_item("_Test Item10", {"has_serial_no": 1, "is_stock_item": 1})
+		self.serial_no = frappe.get_doc(
+			{
+				"doctype": "Serial No",
+				"serial_no": f"TEST-SR-{frappe.utils.now_datetime().timestamp()}",
+				"item_code": self.item.name,
+				"company": "_Test Company",
+			}
+		).insert(ignore_if_duplicate=True)
+
+		self.bundle = frappe.get_doc(
+			{
+				"doctype": "Serial and Batch Bundle",
+				"item_code": self.item.name,
+				"type_of_transaction": "Maintenance",
+				"has_serial_no": 1,
+				"voucher_type": "Maintenance Schedule",
+				"entries": [{"serial_no": self.serial_no.name, "qty": 1}],
+			}
+		).insert()
+
+		self.schedule = make_maintenance_schedule(item_code=self.item.name, do_not_submit=True)
+		self.schedule.items[0].serial_no = self.serial_no.name
+		self.schedule.items[0].serial_and_batch_bundle = self.bundle.name
+		self.schedule.items[0].no_of_visits = 1
+		self.schedule.save()
+		self.schedule.submit()
+
 	def test_events_should_be_created_and_deleted(self):
 		ms = make_maintenance_schedule()
 		ms.generate_schedule()
@@ -155,9 +188,205 @@ class TestMaintenanceSchedule(unittest.TestCase):
 
 		frappe.db.rollback()
 
+	def test_update_amc_date_TC_M_001(self):
+		from frappe.utils import add_days, nowdate
+
+		ms = make_maintenance_schedule()
+		amc_date = add_days(nowdate(), 180)
+		ms.update_amc_date([self.serial_no.name], amc_expiry_date=amc_date)
+
+		self.assertEqual(str(frappe.get_value("Serial No", self.serial_no.name, "amc_expiry_date")), amc_date)
+
+	def test_validate_maintenance_detail_TC_M_002(self):
+		def assert_throw(ms, msg):
+			with self.assertRaises(frappe.ValidationError, msg=msg):
+				ms.validate_maintenance_detail()
+
+		ms = frappe.new_doc("Maintenance Schedule")
+
+		assert_throw(ms, "Please enter Maintaince Details")
+
+		ms.append("items", {})
+		assert_throw(ms, "Please select item code")
+
+		ms.items[0].item_code = "_Test Item"
+		assert_throw(ms, "Start Date and End Date")
+
+		ms.items[0].start_date = "2025-01-01"
+		ms.items[0].end_date = "2025-01-10"
+		assert_throw(ms, "no of visits")
+
+		ms.items[0].no_of_visits = 1
+		ms.items[0].start_date = "2025-01-10"
+		ms.items[0].end_date = "2025-01-01"
+		assert_throw(ms, "Start date should be less than end date")
+
+		ms.items[0].start_date = "2025-01-01"
+		ms.items[0].end_date = "2025-01-10"
+		ms.validate_maintenance_detail()
+
+	def test_validate_sales_order_throw_TC_M_003(self):
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		so = make_sales_order(rate=500)
+		so.submit()
+
+		ms_existing = make_maintenance_schedule(do_not_submit=True)
+		ms_existing.items[0].sales_order = so.name
+		ms_existing.items[0].no_of_visits = 1
+		ms_existing.submit()
+
+		ms_new = make_maintenance_schedule(do_not_submit=True)
+		ms_new.items[0].sales_order = so.name
+		ms_new.items[0].no_of_visits = 1
+
+		with self.assertRaises(frappe.ValidationError, msg="Maintenance Schedule"):
+			ms_new.validate_sales_order()
+
+	def test_validate_serial_no_bundle_throw_TC_M_004(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item_code = "_Test Item 1"
+		item_code = make_item(item_code, {"has_serial_no": 1, "is_stock_item": 1}).name
+
+		bundle = frappe.get_doc(
+			{
+				"doctype": "Serial and Batch Bundle",
+				"item_code": self.item.name,
+				"type_of_transaction": "Maintenance",
+				"voucher_type": "Sales Invoice",
+				"entries": [{"serial_no": self.serial_no.name}],
+			}
+		).insert()
+
+		ms = frappe.get_doc(
+			{
+				"doctype": "Maintenance Schedule",
+				"customer": "_Test Customer",
+				"transaction_date": nowdate(),
+				"items": [
+					{
+						"item_code": self.item.name,
+						"serial_no": self.serial_no.name,
+						"serial_and_batch_bundle": bundle.name,
+						"start_date": nowdate(),
+						"end_date": add_days(nowdate(), 30),
+						"no_of_visits": 2,
+					}
+				],
+			}
+		)
+
+		with self.assertRaises(
+			frappe.ValidationError, msg="should have voucher type as 'Maintenance Schedule'"
+		):
+			ms.insert()
+
+	def test_on_trash_TC_M_005(self):
+		doc = make_maintenance_schedule()
+
+		event = frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "Test Event",
+				"starts_on": now_datetime(),
+				"event_participants": [
+					{"reference_doctype": "Maintenance Schedule", "reference_docname": doc.name}
+				],
+			}
+		).insert()
+
+		self.assertTrue(frappe.db.exists("Event", event.name))
+
+		doc.delete()
+
+		self.assertFalse(frappe.db.exists("Event", event.name))
+
+	def test_validate_serial_no_wrong_item_TC_M_006(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item = make_item("_Test Item 1", {"has_serial_no": 1})
+		sr = (
+			frappe.get_doc("Serial No", "_Test Serial No")
+			if frappe.db.exists("Serial No", "_Test Serial No")
+			else frappe.get_doc(
+				{"doctype": "Serial No", "serial_no": "_Test Serial No", "item_code": item.name}
+			).insert()
+		)
+
+		ms = make_maintenance_schedule(do_not_submit=True)
+		with self.assertRaises(frappe.ValidationError, msg="does not belong to Item"):
+			ms.validate_serial_no("_Another Item", [sr], nowdate())
+		# self.assertIn("does not belong to Item", str(context.exception))
+
+	def test_valid_periodicity_end_date_calculation_TC_M_007(self):
+		self.days_in_period = {"Monthly": 30, "Quarterly": 90, "Half Yearly": 180, "Yearly": 365}
+		item = frappe._dict({"start_date": "2025-05-01", "periodicity": "Quarterly", "no_of_visits": 0})
+
+		if not item.no_of_visits or item.no_of_visits == 0:
+			item.end_date = add_days(item.start_date, self.days_in_period[item.periodicity])
+			diff = date_diff(item.end_date, item.start_date) + 1
+			item.no_of_visits = cint(diff / self.days_in_period[item.periodicity])
+
+		self.assertEqual(str(item.end_date), "2025-07-30")
+		self.assertEqual(item.no_of_visits, 1)
+
+	def test_does_not_override_existing_no_of_visits_TC_M_008(self):
+		self.days_in_period = {"Monthly": 30, "Quarterly": 90, "Half Yearly": 180, "Yearly": 365}
+		item = frappe._dict({"start_date": "2025-05-01", "periodicity": "Quarterly", "no_of_visits": 3})
+
+		original_visits = item.no_of_visits
+		if not item.no_of_visits or item.no_of_visits == 0:
+			item.end_date = add_days(item.start_date, self.days_in_period[item.periodicity])
+			diff = date_diff(item.end_date, item.start_date) + 1
+			item.no_of_visits = cint(diff / self.days_in_period[item.periodicity])
+
+		self.assertEqual(item.no_of_visits, original_visits)
+
+	def test_on_trash_calls_delete_events_TC_M_009(self):
+		from unittest.mock import patch
+
+		ms = make_maintenance_schedule()
+
+		with patch(
+			"erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.delete_events"
+		) as mock_delete:
+			ms.delete()
+			mock_delete.assert_called_once_with("Maintenance Schedule", ms.name)
+
+	def test_sets_no_of_visits_when_not_provided_TC_M_010(self):
+		ms = make_maintenance_schedule(do_not_submit=True)
+
+		ms.periodicity = "Monthly"
+		item = ms.items[0]
+		item.start_date = nowdate()
+		item.no_of_visits = 0
+
+		ms.validate()
+
+		expected_days = 30
+		expected_end_date = add_days(item.start_date, expected_days)
+		expected_visits = cint(date_diff(expected_end_date, item.start_date) + 1) // expected_days
+
+		self.assertEqual(item.no_of_visits, expected_visits)
+
+	def test_serial_auto_assign_on_make_maintenance_visit_TC_M_011(self):
+		item_name = self.schedule.items[0].item_name
+
+		visit = make_maintenance_visit(self.schedule.name, item_name=item_name)
+		visit.completion_status = "Partially Completed"
+		visit.maintenance_type = "Scheduled"
+		visit.purposes[0].service_person = "Sales Team"
+		visit.purposes[0].work_done = "Test"
+		visit.insert()
+
+		self.assertEqual(visit.purposes[0].serial_no, self.serial_no.name)
+
 
 def make_serial_item_with_serial(item_code):
 	from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
+
 	serial_item_doc = create_item(item_code, is_stock_item=1)
 	if not serial_item_doc.has_serial_no or not serial_item_doc.serial_no_series:
 		serial_item_doc.has_serial_no = 1

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -21,19 +21,25 @@ from erpnext.stock.doctype.item.test_item import create_item
 
 class TestMaintenanceSchedule(unittest.TestCase):
 	def setUp(self):
+		import random
+		import string
+
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
 
 		create_company()
 		self.item = create_item("_Test Item10", {"has_serial_no": 1, "is_stock_item": 1})
+		suffix = "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
+		self.item.has_serial_no = 1
+		self.item.is_stock_item = 1
+		self.item.save()
 		self.serial_no = frappe.get_doc(
 			{
 				"doctype": "Serial No",
-				"serial_no": f"TEST-SR-{frappe.utils.now_datetime().timestamp()}",
+				"serial_no": f"TEST-SR-{suffix}",
 				"item_code": self.item.name,
 				"company": "_Test Company",
 			}
 		).insert(ignore_if_duplicate=True)
-
 		self.bundle = frappe.get_doc(
 			{
 				"doctype": "Serial and Batch Bundle",
@@ -50,7 +56,6 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		self.schedule.items[0].serial_and_batch_bundle = self.bundle.name
 		self.schedule.items[0].no_of_visits = 1
 		self.schedule.save()
-		self.schedule.submit()
 
 	def test_events_should_be_created_and_deleted(self):
 		ms = make_maintenance_schedule()
@@ -191,7 +196,8 @@ class TestMaintenanceSchedule(unittest.TestCase):
 	def test_update_amc_date_TC_M_001(self):
 		from frappe.utils import add_days, nowdate
 
-		ms = make_maintenance_schedule()
+		ms = self.schedule
+
 		amc_date = add_days(nowdate(), 180)
 		ms.update_amc_date([self.serial_no.name], amc_expiry_date=amc_date)
 
@@ -232,12 +238,12 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		so = make_sales_order(rate=500)
 		so.submit()
 
-		ms_existing = make_maintenance_schedule(do_not_submit=True)
+		ms_existing = self.schedule
 		ms_existing.items[0].sales_order = so.name
 		ms_existing.items[0].no_of_visits = 1
 		ms_existing.submit()
 
-		ms_new = make_maintenance_schedule(do_not_submit=True)
+		ms_new = self.schedule
 		ms_new.items[0].sales_order = so.name
 		ms_new.items[0].no_of_visits = 1
 
@@ -284,7 +290,7 @@ class TestMaintenanceSchedule(unittest.TestCase):
 			ms.insert()
 
 	def test_on_trash_TC_M_005(self):
-		doc = make_maintenance_schedule()
+		doc = self.schedule
 
 		event = frappe.get_doc(
 			{
@@ -315,7 +321,7 @@ class TestMaintenanceSchedule(unittest.TestCase):
 			).insert()
 		)
 
-		ms = make_maintenance_schedule(do_not_submit=True)
+		ms = self.schedule
 		with self.assertRaises(frappe.ValidationError, msg="does not belong to Item"):
 			ms.validate_serial_no("_Another Item", [sr], nowdate())
 		# self.assertIn("does not belong to Item", str(context.exception))
@@ -347,7 +353,7 @@ class TestMaintenanceSchedule(unittest.TestCase):
 	def test_on_trash_calls_delete_events_TC_M_009(self):
 		from unittest.mock import patch
 
-		ms = make_maintenance_schedule()
+		ms = self.schedule
 
 		with patch(
 			"erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.delete_events"
@@ -356,7 +362,7 @@ class TestMaintenanceSchedule(unittest.TestCase):
 			mock_delete.assert_called_once_with("Maintenance Schedule", ms.name)
 
 	def test_sets_no_of_visits_when_not_provided_TC_M_010(self):
-		ms = make_maintenance_schedule(do_not_submit=True)
+		ms = self.schedule
 
 		ms.periodicity = "Monthly"
 		item = ms.items[0]
@@ -373,7 +379,7 @@ class TestMaintenanceSchedule(unittest.TestCase):
 
 	def test_serial_auto_assign_on_make_maintenance_visit_TC_M_011(self):
 		item_name = self.schedule.items[0].item_name
-
+		self.schedule.submit()
 		visit = make_maintenance_visit(self.schedule.name, item_name=item_name)
 		visit.completion_status = "Partially Completed"
 		visit.maintenance_type = "Scheduled"

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -215,7 +215,7 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		ms.append("items", {})
 		assert_throw(ms, "Please select item code")
 
-		ms.items[0].item_code = "_Test Item"
+		ms.items[0].item_code = self.item.name
 		assert_throw(ms, "Start Date and End Date")
 
 		ms.items[0].start_date = "2025-01-01"
@@ -251,11 +251,6 @@ class TestMaintenanceSchedule(unittest.TestCase):
 			ms_new.validate_sales_order()
 
 	def test_validate_serial_no_bundle_throw_TC_M_004(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
-		item_code = "_Test Item 1"
-		item_code = make_item(item_code, {"has_serial_no": 1, "is_stock_item": 1}).name
-
 		bundle = frappe.get_doc(
 			{
 				"doctype": "Serial and Batch Bundle",
@@ -310,14 +305,11 @@ class TestMaintenanceSchedule(unittest.TestCase):
 		self.assertFalse(frappe.db.exists("Event", event.name))
 
 	def test_validate_serial_no_wrong_item_TC_M_006(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-
-		item = make_item("_Test Item 1", {"has_serial_no": 1})
 		sr = (
 			frappe.get_doc("Serial No", "_Test Serial No")
 			if frappe.db.exists("Serial No", "_Test Serial No")
 			else frappe.get_doc(
-				{"doctype": "Serial No", "serial_no": "_Test Serial No", "item_code": item.name}
+				{"doctype": "Serial No", "serial_no": "_Test Serial No", "item_code": self.item.name}
 			).insert()
 		)
 


### PR DESCRIPTION
### Title:
Add Test Cases for Maintenance Schedule Validations and Functionality

### Test Summary
This suite adds unit tests for key features and validations in the Maintenance Schedule module of ERPNext. The tests cover AMC date updates, validation logic, overlapping sales order checks, serial number bundling errors, deletion behavior, and periodicity logic.

### Scenarios Covered
Input Validations :

TC_M_002 - Validates required fields in items table like item code, date range, and number of visits.

TC_M_003 - Prevents linking multiple maintenance schedules to the same Sales Order.

TC_M_004 - Ensures Serial and Batch Bundle has correct voucher type.

TC_M_006 - Validates if the serial number matches the selected item.

TC_M_010 - Automatically calculates visits if not provided, based on periodicity.

Edge Cases :

TC_M_005 - Deletes associated events when a Maintenance Schedule is deleted.

TC_M_008 - Ensures existing visit count is not overridden.

TC_M_009 - Validates event deletion logic on trash using mocked method.

API Response Handling :

TC_M_001 - Checks if update_amc_date updates Serial No record correctly.

TC_M_007 - Verifies periodicity end date and number of visits calculation.

TC_M_011 - Confirms automatic assignment of serial number during maintenance visit creation.

### Technology
Python's unittest framework

ERPNext/Frappe unit testing utilities

### Linked Feature/Bug
ISSUE_ID : None
PR_ID : None