### PR TITLE
test: Added Test Cases for Validating Creation, Hierarchy Rules, Type Constraints and other Validations for Account Doctype

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -28,13 +28,45 @@ class Account(NestedSet):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		account_currency: DF.Link | None
 		account_name: DF.Data
 		account_number: DF.Data | None
-		account_type: DF.Literal["", "Accumulated Depreciation", "Asset Received But Not Billed", "Bank", "Cash", "Chargeable", "Capital Work in Progress", "Cost of Goods Sold", "Current Asset", "Current Liability", "Depreciation", "Direct Expense", "Direct Income", "Equity", "Expense Account", "Expenses Included In Asset Valuation", "Expenses Included In Valuation", "Fixed Asset", "Income Account", "Indirect Expense", "Indirect Income", "Liability", "Payable", "Receivable", "Round Off", "Stock", "Stock Adjustment", "Stock Received But Not Billed", "Service Received But Not Billed", "Tax", "Temporary"]
+		account_type: DF.Literal[
+			"",
+			"Accumulated Depreciation",
+			"Asset Received But Not Billed",
+			"Bank",
+			"Cash",
+			"Chargeable",
+			"Capital Work in Progress",
+			"Cost of Goods Sold",
+			"Current Asset",
+			"Current Liability",
+			"Depreciation",
+			"Direct Expense",
+			"Direct Income",
+			"Equity",
+			"Expense Account",
+			"Expenses Included In Asset Valuation",
+			"Expenses Included In Valuation",
+			"Fixed Asset",
+			"Income Account",
+			"Indirect Expense",
+			"Indirect Income",
+			"Liability",
+			"Payable",
+			"Receivable",
+			"Round Off",
+			"Stock",
+			"Stock Adjustment",
+			"Stock Received But Not Billed",
+			"Service Received But Not Billed",
+			"Tax",
+			"Temporary",
+		]
 		balance_must_be: DF.Literal["", "Debit", "Credit"]
 		company: DF.Link
 		disabled: DF.Check
@@ -72,7 +104,6 @@ class Account(NestedSet):
 		self.name = get_autoname_with_number(self.account_number, self.account_name, self.company)
 
 	def validate(self):
-
 		if frappe.local.flags.allow_unverified_charts:
 			return
 		self.validate_parent()
@@ -420,12 +451,8 @@ def get_account_currency(account):
 		return
 
 	def generator():
-		account_currency = frappe.get_cached_value(
-			"Account", account, "account_currency"
-		)
-		company = frappe.get_cached_value(
-			"Account", account, "company"
-		)
+		account_currency = frappe.get_cached_value("Account", account, "account_currency")
+		company = frappe.get_cached_value("Account", account, "company")
 		if not account_currency:
 			account_currency = frappe.get_cached_value("Company", company, "default_currency")
 

--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -6,10 +6,12 @@ import unittest
 
 import frappe
 from frappe.test_runner import make_test_records
+from frappe.tests.utils import change_settings
 from frappe.utils import nowdate
 
 from erpnext.accounts.doctype.account.account import (
 	InvalidAccountMergeError,
+	RootNotEditable,
 	merge_account,
 	update_account_number,
 )
@@ -19,33 +21,28 @@ test_dependencies = ["Company"]
 
 
 class TestAccount(unittest.TestCase):
+	def tearDown(self):
+		frappe.local.flags.allow_unverified_charts = False
+		frappe.db.rollback()
+
 	def test_delete_account_with_children(self):
-		parent_account = create_account(
+		create_account(
 			account_name="Parent Account",
 			is_group=1,
 			parent_account="Application of Funds (Assets) - _TC",
-			company="_Test Company"
+			company="_Test Company",
 		)
-		
+
 		create_account(
-			account_name="Child Account 1",
-			parent_account="Parent Account - _TC",
-			company="_Test Company"
+			account_name="Child Account 1", parent_account="Parent Account - _TC", company="_Test Company"
 		)
-		
+
 		create_account(
-			account_name="Child Account 2",
-			parent_account="Parent Account - _TC",
-			company="_Test Company"
+			account_name="Child Account 2", parent_account="Parent Account - _TC", company="_Test Company"
 		)
-		
-		self.assertRaises(
-			frappe.ValidationError,
-			frappe.delete_doc,
-			"Account", 
-			"Parent Account - _TC"
-		)
-		
+
+		self.assertRaises(frappe.ValidationError, frappe.delete_doc, "Account", "Parent Account - _TC")
+
 		frappe.delete_doc("Account", "Child Account 1 - _TC")
 		frappe.delete_doc("Account", "Child Account 2 - _TC")
 
@@ -359,6 +356,560 @@ class TestAccount(unittest.TestCase):
 		balance = get_balance_on(account="Test Percent Account %5 - _TC", date=nowdate())
 		self.assertEqual(balance, 0)
 
+	def test_allow_unverified_chart_TC_ACC_167(self):
+		company = make_company(company_name="Test Company")
+		frappe.local.flags.allow_unverified_charts = True
+		if frappe.db.exists("Account", "Test Account - TC"):
+			frappe.delete_doc("Account", "Test Account - TC", force=1)
+		account = frappe.new_doc("Account")
+		account.account_name = "Test Account"
+		account.company = company.name
+		account.parent_account = "Cash In Hand - TC"
+		account.insert(ignore_permissions=True)
+		self.assertEqual(account.parent_account, "Cash In Hand - TC")
+
+	def test_validate_parent_child_account_type_TC_ACC_168(self):
+		make_company(company_name="_Test Company")
+
+		parent_account = create_account(
+			account_name="Expenses Test",
+			is_group=1,
+			parent_account="Expenses - _TC",
+			company="_Test Company",
+			do_not_save=True,
+		)
+		parent_account.account_type = "Direct Expense"
+		parent_account.save(ignore_permissions=True)
+		self.assertEqual(parent_account.account_type, "Direct Expense")
+		acc = frappe.new_doc("Account")
+		acc.account_name = "Test Account"
+		acc.parent_account = parent_account.name
+		acc.company = "_Test Company"
+		acc.account_type = "Direct Expense"
+		with self.assertRaises(frappe.ValidationError, msg=f"Only Parent can be of type {acc.account_type}"):
+			acc.save(ignore_permissions=True)
+
+	def test_validate_parent_account_not_assign_TC_ACC_169(self):
+		make_company(company_name="_Test Company")
+		account = frappe.new_doc("Account")
+		account.account_name = "Cash In Hand"
+		account.parent_account = "Cash In Hand - _TC"
+		account.company = "_Test Company"
+		account.flags.ignore_if_duplicate = True
+		with self.assertRaises(
+			frappe.ValidationError,
+			msg=f"Account {account.parent_account}: You can not assign itself as parent account",
+		):
+			account.save(ignore_permissions=True)
+
+	def test_validate_parent_account_is_group_TC_ACC_170(self):
+		make_company(company_name="_Test Company")
+		account = frappe.new_doc("Account")
+		account.account_name = "Test Account"
+		account.is_group = 0
+		account.parent_account = "Cash - _TC"
+		account.company = "_Test Company"
+		with self.assertRaises(
+			frappe.ValidationError,
+			msg=f"Account Test Account - _TC: Parent account {account.parent_account} can not be a ledger",
+		):
+			account.save(ignore_permissions=True)
+
+	def test_validate_parent_account_for_company_TC_ACC_171(self):
+		make_company(company_name="_Test Company")
+		account = frappe.new_doc("Account")
+		account.account_name = "Test Account"
+		account.is_group = 0
+		account.parent_account = "Current Assets - _TC1"
+		account.company = "_Test Company"
+		with self.assertRaises(
+			frappe.ValidationError,
+			msg=f"Account Test Account - _TC: Parent account {account.parent_account} does not belong to company: _Test Company",
+		):
+			account.save(ignore_permissions=True)
+
+	def test_set_root_and_report_type_TC_ACC_172(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc("Account", "Current Assets - _TC")
+		account.db_set("root_type", "Income")
+		account.db_set("report_type", "Profit and Loss")
+		account.save()
+		account.reload()
+		self.assertEqual(account.root_type, "Asset")
+		self.assertEqual(account.report_type, "Balance Sheet")
+
+	def test_validate_receivable_payable_account_type_TC_ACC_173(self):
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		make_company(company_name="_Test Company")
+		item_code = "_Test Item"
+		supplier = "_Test Supplier"
+
+		create_warehouse(
+			warehouse_name="_Test Warehouse - _TC",
+			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
+			company="_Test Company",
+		)
+		create_supplier(supplier_name=supplier, default_currency="INR")
+		item = create_item(item_code=item_code, valuation_rate=100)
+		pi = frappe.new_doc("Purchase Invoice")
+		pi.supplier = supplier
+		pi.company = "_Test Company"
+		pi.currency = "INR"
+		pi.append("items", {"item_code": item.item_code, "qty": 8, "rate": 100})
+		pi.save()
+		pi.submit()
+		account = frappe.get_doc("Account", "Creditors - _TC")
+		account.account_type = "Cash"
+		account.save()
+
+	def test_validate_root_details_TC_ACC_174(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc("Account", "Application of Funds (Assets) - _TC")
+		account.account_type = "Cash"
+		with self.assertRaises(RootNotEditable, msg="Root cannot be edited."):
+			account.save(ignore_permissions=True)
+
+	def test_validate_root_account_must_be_group_TC_ACC_175(self):
+		make_company(company_name="_Test Company")
+		account = frappe.new_doc("Account")
+		account.account_name = "Test Account"
+		account.company = "_Test Company"
+		account.account_type = "Cash"
+		with self.assertRaises(
+			frappe.ValidationError, msg="The root account Test Account - _TC must be a group"
+		):
+			account.save(ignore_permissions=True)
+
+	def test_with_child_node_convert_group_to_ledger_TC_ACC_176(self):
+		make_company(company_name="_Test Company")
+		create_account(
+			account_name="Test Parent Account",
+			parent_account="Cash In Hand - _TC",
+			company="_Test Company",
+			account_type="Direct Income",
+			is_group=1,
+		)
+		frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test Child",
+				"parent_account": "Test Parent Account - _TC",
+				"company": "_Test Company",
+			}
+		).insert()
+		parent_doc = frappe.get_doc("Account", "Test Parent Account - _TC")
+		with self.assertRaises(
+			frappe.ValidationError, msg="Account with child nodes cannot be converted to ledger"
+		):
+			parent_doc.convert_group_to_ledger()
+
+	def test_convert_group_to_ledger_with_ledger_exists_TC_ACC_177(self):
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		make_company(company_name="_Test Company")
+		item_code = "_Test Item"
+		supplier = "_Test Supplier"
+
+		create_warehouse(
+			warehouse_name="Test Warehouse - _TC",
+			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
+			company="_Test Company",
+		)
+		create_supplier(supplier_name=supplier, default_currency="INR")
+		item = create_item(item_code=item_code, valuation_rate=100)
+		pi = frappe.new_doc("Purchase Invoice")
+		pi.supplier = supplier
+		pi.company = "_Test Company"
+		pi.currency = "INR"
+		pi.append("items", {"item_code": item.item_code, "qty": 8, "rate": 100})
+		pi.save()
+		pi.submit()
+		account = frappe.get_doc("Account", "Creditors - _TC")
+		with self.assertRaises(
+			frappe.ValidationError, msg="Account with existing transaction cannot be converted to ledger"
+		):
+			account.convert_group_to_ledger()
+
+	def test_should_convert_to_ledger_TC_ACC_178(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test Convertible Account",
+				"is_group": 1,
+				"company": "_Test Company",
+				"parent_account": "Accounts Receivable - _TC",
+				"root_type": "Asset",
+			}
+		).insert()
+		account.convert_group_to_ledger()
+		account.reload()
+		self.assertEqual(account.is_group, 0)
+
+	@change_settings(
+		"Accounts Settings",
+		{"delete_linked_ledger_entries": 1},
+	)
+	def test_validate_group_or_ledger_TC_ACC_179(self):
+		make_company(company_name="_Test Company")
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		item_code = "_Test Item"
+		supplier = "_Test Supplier"
+
+		create_warehouse(
+			warehouse_name="Test Warehouse - _TC",
+			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
+			company="_Test Company",
+		)
+		create_supplier(supplier_name=supplier, default_currency="INR")
+		item = create_item(item_code=item_code, valuation_rate=100)
+		pi = frappe.new_doc("Purchase Invoice")
+		pi.supplier = supplier
+		pi.company = "_Test Company"
+		pi.currency = "INR"
+		pi.append("items", {"item_code": item.item_code, "qty": 8, "rate": 100})
+		pi.save()
+		pi.submit()
+		account = frappe.get_doc("Account", "Creditors - _TC")
+		account.is_group = 1
+		with self.assertRaises(
+			frappe.ValidationError, msg="Account with existing transaction cannot be converted to ledger"
+		):
+			account.save(ignore_permissions=True)
+		pi.cancel()
+		pi.delete()
+		gl_1 = frappe.get_all("GL Entry", filters={"account": "Creditors - _TC"}, pluck="name")
+		if len(gl_1) > 0:
+			for gl in gl_1:
+				frappe.delete_doc_if_exists("GL Entry", gl, force=1)
+		account.reload()
+		account.is_group = 1
+		with self.assertRaises(
+			frappe.ValidationError, msg="Cannot covert to Group because Account Type is selected."
+		):
+			account.save(ignore_permissions=True)
+
+	def test_validate_frozen_accounts_modifier_TC_ACC_180(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc("Account", "Current Assets - _TC")
+		account.freeze_account = "Yes"
+		with self.assertRaises(frappe.ValidationError, msg="You are not authorized to set Frozen value"):
+			account.save(ignore_permissions=True)
+
+	def test_validate_balance_must_be_credit_TC_ACC_181(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test Convertible Account",
+				"is_group": 0,
+				"company": "_Test Company",
+				"parent_account": "Accounts Receivable - _TC",
+			}
+		).insert()
+		journal_entry = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"voucher_type": "Journal Entry",
+				"company": "_Test Company",
+				"posting_date": frappe.utils.nowdate(),
+				"accounts": [
+					{"account": account.name, "debit_in_account_currency": 1000},
+					{"account": "Cash - _TC", "credit_in_account_currency": 1000},
+				],
+			}
+		)
+		journal_entry.insert()
+		journal_entry.submit()
+		account.balance_must_be = "Credit"
+		with self.assertRaises(
+			frappe.ValidationError,
+			msg="Account balance already in Debit, you are not allowed to set 'Balance Must Be' as 'Credit'",
+		):
+			account.save(ignore_permissions=True)
+
+	def test_validate_balance_should_be_credit_TC_ACC_182(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test Convertible Account",
+				"is_group": 0,
+				"company": "_Test Company",
+				"parent_account": "Accounts Receivable - _TC",
+			}
+		).insert()
+		journal_entry = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"voucher_type": "Journal Entry",
+				"company": "_Test Company",
+				"posting_date": frappe.utils.nowdate(),
+				"accounts": [
+					{"account": account.name, "credit_in_account_currency": 1000},
+					{"account": "Cash - _TC", "debit_in_account_currency": 1000},
+				],
+			}
+		)
+		journal_entry.insert()
+		journal_entry.submit()
+		account.balance_must_be = "Debit"
+		with self.assertRaises(
+			frappe.ValidationError,
+			msg="Account balance already in Credit, you are not allowed to set 'Balance Must Be' as 'Debit'",
+		):
+			account.save(ignore_permissions=True)
+
+	def test_validate_account_currency_TC_ACC_183(self):
+		make_company(company_name="_Test Company")
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		item_code = "_Test Item"
+		supplier = "_Test Supplier"
+
+		create_warehouse(
+			warehouse_name="Test Warehouse - _TC",
+			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
+			company="_Test Company",
+		)
+		create_supplier(supplier_name=supplier, default_currency="INR")
+		item = create_item(item_code=item_code, valuation_rate=100)
+		pi = frappe.new_doc("Purchase Invoice")
+		pi.supplier = supplier
+		pi.company = "_Test Company"
+		pi.currency = "INR"
+		pi.append("items", {"item_code": item.item_code, "qty": 8, "rate": 100})
+		pi.save()
+		pi.submit()
+		account = frappe.get_doc("Account", pi.credit_to)
+		account.account_currency = "USD"
+		with self.assertRaises(
+			frappe.ValidationError,
+			msg="Currency can not be changed after making entries using some other currency",
+		):
+			account.save(ignore_permissions=True)
+
+	def test_validate_account_number_TC_ACC_184(self):
+		make_company(company_name="_Test Company")
+		create_account(
+			account_name="Test Parent Account",
+			parent_account="Cash In Hand - _TC",
+			company="_Test Company",
+			account_type="Cash",
+		)
+		parent_account = frappe.get_doc("Account", "Test Parent Account - _TC")
+		update_account_number(
+			name=parent_account.name, account_name=parent_account.account_name, account_number="12345"
+		)
+		acc = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test account 89",
+				"is_group": 0,
+				"company": "_Test Company",
+				"parent_account": "Accounts Receivable - _TC",
+				"account_number": "12345",
+			}
+		)
+		with self.assertRaises(
+			frappe.ValidationError,
+			msg="Account Number 12345 already used in account 12345 - Test Parent Account - _TC",
+		):
+			acc.save(ignore_permissions=True)
+
+	def test_convert_ledger_to_group_with_ledger_exists_TC_ACC_185(self):
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		make_company(company_name="_Test Company")
+		item_code = "_Test Item"
+		supplier = "_Test Supplier"
+
+		create_warehouse(
+			warehouse_name="Test Warehouse - _TC",
+			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
+			company="_Test Company",
+		)
+		create_supplier(supplier_name=supplier, default_currency="INR")
+		item = create_item(item_code=item_code, valuation_rate=100)
+		pi = frappe.new_doc("Purchase Invoice")
+		pi.supplier = supplier
+		pi.company = "_Test Company"
+		pi.currency = "INR"
+		pi.append("items", {"item_code": item.item_code, "qty": 8, "rate": 100})
+		pi.save()
+		pi.submit()
+		account = frappe.get_doc("Account", "Creditors - _TC")
+		with self.assertRaises(
+			frappe.ValidationError, msg="Account with existing transaction can not be converted to group"
+		):
+			account.convert_ledger_to_group()
+
+	def test_check_account_type_convert_ledger_to_group_TC_ACC_186(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test account",
+				"is_group": 0,
+				"company": "_Test Company",
+				"account_type": "Cash",
+				"parent_account": "Accounts Receivable - _TC",
+			}
+		)
+		with self.assertRaises(
+			frappe.ValidationError, msg="Cannot convert to Group because Account Type is selected."
+		):
+			account.convert_ledger_to_group()
+
+	def test_should_convert_ledger_to_group_TC_ACC_187(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test Ledger Account",
+				"is_group": 0,
+				"company": "_Test Company",
+				"parent_account": "Accounts Receivable - _TC",
+			}
+		).insert()
+		account.convert_ledger_to_group()
+		account.reload()
+		self.assertEqual(account.is_group, 1)
+
+	def test_validate_madantory_TC_ACC_189(self):
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test account",
+				"is_group": 1,
+				"company": "_Test Company",
+			}
+		)
+		with self.assertRaises(frappe.ValidationError, msg="Root Type is mandatory"):
+			account.save(ignore_permissions=True)
+
+	def test_check_gle_exists_on_trash_TC_ACC_190(self):
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		make_company(company_name="_Test Company")
+		item_code = "_Test Item"
+		supplier = "_Test Supplier"
+
+		create_warehouse(
+			warehouse_name="Test Warehouse - _TC",
+			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
+			company="_Test Company",
+		)
+		create_supplier(supplier_name=supplier, default_currency="INR")
+		item = create_item(item_code=item_code, valuation_rate=100)
+		pi = frappe.new_doc("Purchase Invoice")
+		pi.supplier = supplier
+		pi.company = "_Test Company"
+		pi.currency = "INR"
+		pi.append("items", {"item_code": item.item_code, "qty": 8, "rate": 100})
+		pi.save()
+		pi.submit()
+		account = frappe.get_doc("Account", "Creditors - _TC")
+		with self.assertRaises(
+			frappe.ValidationError, msg="Account with existing transaction can not be deleted"
+		):
+			account.delete()
+
+	def test_get_parent_account_method_TC_ACC_191(self):
+		make_company(company_name="_Test Company")
+		from erpnext.accounts.doctype.account.account import get_parent_account
+
+		frappe.set_user("Administrator")
+		get_parent_account(
+			doctype="Account",
+			txt="",
+			searchfield="name",
+			start=0,
+			page_len=20,
+			filters={"company": "_Test Company"},
+		)
+
+	def test_get_account_autoname_company_validation_TC_ACC_192(self):
+		from erpnext.accounts.doctype.account.account import get_account_autoname
+
+		make_company(company_name="_Test Company")
+		account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Test account 89",
+				"is_group": 1,
+				"account_number": "45678",
+				"company": "_Test Company",
+			}
+		)
+		with self.assertRaises(frappe.ValidationError, msg="Company None does not exist"):
+			get_account_autoname(
+				account_number=account.account_number, account_name=account.account_name, company=None
+			)
+
+	def test_update_account_number_TC_ACC_193(self):
+		frappe.set_user("Administrator")
+
+		parent = make_company(company_name="Test Parent Company", is_group=True)
+		company = make_company(company_name="Test Child Company", parent_company=parent.name)
+		if not frappe.db.exists("Account", "Root Account"):
+			root_account = frappe.new_doc("Account")
+			root_account.account_name = "root"
+			root_account.is_group = 1
+			root_account.root_type = "Asset"
+			root_account.company = company.name
+			root_account.insert(ignore_mandatory=True)
+		else:
+			root_account = frappe.get_doc("Account", {"account_name": "root"})
+
+		if not frappe.db.exists("Account", "1210 - Debtors - TPC"):
+			par_acc = frappe.new_doc("Account")
+			par_acc.account_name = "Debtors"
+			par_acc.account_number = "1210"
+			par_acc.is_group = 1
+			par_acc.company = parent.name
+			par_acc.root_type = "Asset"
+			par_acc.insert(ignore_mandatory=True)
+
+		if not frappe.db.exists("Account", "1210 - Debtors - TCC"):
+			acc = frappe.new_doc("Account")
+			acc.account_name = "Debtors"
+			acc.parent_account = root_account.name
+			acc.account_number = "1210"
+			acc.company = company.name
+			acc.insert(ignore_permissions=True)
+
+			account_number, account_name = frappe.db.get_value(
+				"Account", "1210 - Debtors - TCC", ["account_number", "account_name"]
+			)
+			self.assertEqual(account_number, "1210")
+			self.assertEqual(account_name, "Debtors")
+
+		new_account_number = "1211-11-4 - 6 - "
+		new_account_name = "Debtors 1 - Test - "
+
+		new_account_name = "Debtors 1 - Test - "
+		msg = "Account Debtors exists in parent company Test Parent Company.Renaming it is only allowed via parent company Test Parent Company, to avoid mismatch.To overrule this, enable 'Allow Account Creation Against Child Company' in company Test Child Company"
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			update_account_number(
+				name="1210 - Debtors - TCC", account_name=new_account_name, account_number=new_account_number
+			)
+
 
 def _make_test_records(verbose=None):
 	from frappe.test_runner import make_test_objects
@@ -426,6 +977,28 @@ def _make_test_records(verbose=None):
 	return test_objects
 
 
+def make_company(company_name, is_group=False, **kwargs):
+	company = frappe._dict()
+	if not frappe.db.exists("Company", company_name):
+		company = frappe.get_doc(
+			dict(
+				doctype="Company",
+				company_name=company_name,
+				company_type="Company",
+				default_currency=kwargs.get("default_currency") or "INR",
+				country=kwargs.get("country") or "India",
+				is_group=is_group,
+				parent_company=kwargs.get("parent_company"),
+				allow_account_creation_against_child_company=kwargs.get(
+					"allow_account_creation_against_child_company", False
+				),
+			)
+		).insert(ignore_permissions=True)
+	else:
+		company = frappe.get_doc("Company", company_name)
+	return company
+
+
 def get_inventory_account(company, warehouse=None):
 	account = None
 	if warehouse:
@@ -448,8 +1021,6 @@ def create_account(**kwargs):
 				parent_account=kwargs.get("parent_account"),
 			)
 		)
-		account.save()
-		return account.name
 	else:
 		account = frappe.get_doc(
 			dict(
@@ -463,5 +1034,8 @@ def create_account(**kwargs):
 			)
 		)
 
+	if kwargs.get("do_not_save"):
+		return account
+	else:
 		account.save()
 		return account.name


### PR DESCRIPTION
**Title: Test Cases for Account doctype with Proper Test Data Coverage**
**<h1>Description:</h1>**

**<h3>Test Summary</h3>**

- This test suite validates the core business rules and hierarchical constraints of the Account DocType in ERPNext. It ensures robust handling of account creation, parent-child relationships, account types, and root-level restrictions. The tests cover scenarios such as unverified chart allowances, parent account validations, group-to-ledger conversion restrictions, account type enforcement, and company-specific account hierarchies.
- Doctype: Account
- TC_ACC_167: Validates creation of account under unverified chart when allow_unverified_charts is enabled.
- TC_ACC_168: Ensures child accounts cannot have the same account type as group parent in Direct Expense hierarchy.
- TC_ACC_169: Validates that an account cannot be assigned as its own parent.
- TC_ACC_170: Raises error when a ledger account is used as a parent for a new account.
- TC_ACC_171: Ensures parent account must belong to the same company as the new account.
- TC_ACC_172: Confirms that root account’s report type and root type cannot be overwritten incorrectly.
- TC_ACC_173: Validates that receivable/payable accounts cannot have incorrect account types after transactions.
- TC_ACC_174: Raises error when trying to edit a root-level account which is not editable.
- TC_ACC_175: Ensures root-level accounts must be marked as groups, not ledgers.
- TC_ACC_176: Prevents converting group account to ledger if it has child nodes.
- TC_ACC_177: Raises validation error when converting account to ledger if transactions already exist.
- TC_ACC_178: Validates successful conversion of group account to ledger when no child or GLE exists.
- TC_ACC_179: Ensures account must be either a group or a ledger, not undefined.
- TC_ACC_180: Restricts modifications to frozen accounts unless the user has special privileges.
- TC_ACC_181: Validates that opening balance for credit accounts must be in credit, not debit.
- TC_ACC_182: Ensures balance direction is validated correctly for credit nature accounts.
- TC_ACC_183: Checks account currency consistency with company default or assigned transactions.
- TC_ACC_184: Validates that account numbers follow the required format and are unique.
- TC_ACC_185: Raises error when converting ledger to group if general ledger entries exist.
- TC_ACC_186: Validates account type consistency before converting ledger to group.
- TC_ACC_187: Allows successful conversion of ledger to group when no conflicting constraints exist.
- TC_ACC_189: Validates required mandatory fields during account creation.
- TC_ACC_190: Ensures account cannot be deleted if general ledger entries exist.
- TC_ACC_191: Tests retrieval of correct parent account via utility method.
- TC_ACC_192: Ensures company name is validated when auto-naming accounts.
- TC_ACC_193: Validates account number update logic and ensures no conflict or format issues.

**Scenarios Covered**

**Input Validations**

- Validation of parent account hierarchy (self-assignment, cross-company, non-group parents).
- Enforcement of account type rules for group and ledger accounts.
- Validation of mandatory fields and account number formatting.
- Restrictions on modifying frozen accounts or root-level details.
- Validation of credit/debit nature in opening balances.

**Edge Case Coverage**

- Attempted self-parenting and invalid parent lookups.
- Handling of existing transactions during account type conversions.
- Backward compatibility with unverified chart configuration (allow_unverified_charts).
- Conversion attempts between group/ledger when constraints apply (e.g., no children or GLEs).
- Multiple variations of account creation and type changes validated.

API Response Handling
- N/A

Technology
- Python unittest framework
- Frappe/ERPNext testing utilities

Linked Feature/Bug
N/A

Issue Tracker ID
N/A