### PR TITLE
test: Reset default payment term after test creating PO For Default Supplier execution in Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -7941,6 +7941,10 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 
 		po3 = make_purchase_order_for_default_supplier(so.name, selected_items=so_items)
 		self.assertEqual(po3[0].status, "Draft")
+		# Reset supplier's payment term
+		supplier.reload()
+		supplier.payment_terms = ""
+		supplier.save()
 
 	def test_set_delivery_date_coverage_TC_S_192(self):
 		from .sales_order import set_delivery_date


### PR DESCRIPTION
### Bug Description
In the test case test_make_purchase_order_for_default_supplier_coverage_TC_S_191, the _Test Supplier was assigned a payment terms template (Test Receivable Template Selling). Since _Test Supplier is shared across test cases, this change caused failures in unrelated tests like test_mr_to_pe_flow_TC_B_080.

These failures occurred because other tests did not have the expected Payment Term: Basic Amount Receivable for Selling in their setup, leading to a LinkValidationError during document submission.

### Root Cause
The test case modified _Test Supplier by assigning a custom payment_terms.

This change was not reverted, and the updated state persisted across tests.

Other tests relying on a clean supplier setup failed due to missing payment terms setup.

### Steps to Reproduce:
Run test_make_purchase_order_for_default_supplier_coverage_TC_S_191 which sets a payment_terms on _Test Supplier.

Run test_mr_to_pe_flow_TC_B_080 afterwards.

It fails during doc_pe.submit() due to missing Payment Term: Basic Amount Receivable for Selling.

### Actual/Observed Result:
LinkValidationError: Could not find Row #1: Payment Term: Basic Amount Receivable for Selling

### Expected Result:
All test cases should pass independently without relying on residual state from previous tests.

### Fix Summary
Reset _Test Supplier's payment_terms to blank at the end of the test.

Ensures no state leakage between test cases using shared test data.
supplier.reload()
supplier.payment_terms = ""
supplier.save()

### Affected Module
Buying

### Test Cases Covered
test_make_purchase_order_for_default_supplier_coverage_TC_S_191

test_mr_to_pe_flow_TC_B_080 (indirectly impacted/fixed)
test_mr_to_pi_with_PE_TC_B_076
test_mr_to_pi_with_partial_PE_TC_B_077

Linked Issue
Fixes #2489