### PR TITLE
test: Refactor Setup to Prevent Duplicate Supplier Scorecard Periods and Correct Email Preview Data Fetching"

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -5,7 +5,7 @@
 from urllib.parse import urlparse
 
 import frappe
-from frappe.tests.utils import FrappeTestCase,if_app_installed
+from frappe.tests.utils import FrappeTestCase, if_app_installed
 from frappe.utils import nowdate
 
 from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
@@ -21,21 +21,22 @@ from erpnext.templates.pages.rfq import check_supplier_has_docname_access
 class TestRequestforQuotation(FrappeTestCase):
 	def setUp(self):
 		# Create dummy supplier
-		self.supplier = frappe.get_doc({
-			"doctype": "Supplier",
-			"supplier_name": "Test",
-			"supplier_type": "Company"
-		}).insert(ignore_if_duplicate=True)
+		self.supplier = frappe.get_doc(
+			{"doctype": "Supplier", "supplier_name": "Test", "supplier_type": "Company"}
+		).insert(ignore_if_duplicate=True)
 
 		item = make_item("Test", {"stock_uom": "Nos"})
-		self.rfq = make_request_for_quotation(item_code=item.name, supplier_data=[
+		self.rfq = make_request_for_quotation(
+			item_code=item.name,
+			supplier_data=[
 				{
 					"supplier": self.supplier.name,
 					"supplier_name": self.supplier.supplier_name,
 					"email_id": "123_testrfquser@example.com",
 				}
-			],)
-		
+			],
+		)
+
 	def test_quote_status(self):
 		rfq = make_request_for_quotation()
 
@@ -124,8 +125,11 @@ class TestRequestforQuotation(FrappeTestCase):
 
 	@if_app_installed("erpnext_crm")
 	def test_make_rfq_from_opportunity(self):
-		from erpnext_crm.erpnext_crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
+		from erpnext_crm.erpnext_crm.doctype.opportunity.opportunity import (
+			make_request_for_quotation as make_rfq,
+		)
 		from erpnext_crm.erpnext_crm.doctype.opportunity.test_opportunity import make_opportunity
+
 		opportunity = make_opportunity(with_items=1)
 		supplier_data = get_supplier_data()
 		rfq = make_rfq(opportunity.name)
@@ -181,12 +185,13 @@ class TestRequestforQuotation(FrappeTestCase):
 
 	def test_send_supplier_emails_runs_TC_B_193(self):
 		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import send_supplier_emails
+
 		send_supplier_emails(self.rfq.name)
 
-		communications = frappe.get_all("Communication", filters={
-			"reference_doctype": "Request for Quotation",
-			"reference_name": self.rfq.name
-		})
+		communications = frappe.get_all(
+			"Communication",
+			filters={"reference_doctype": "Request for Quotation", "reference_name": self.rfq.name},
+		)
 		self.assertGreaterEqual(len(communications), 1)
 
 	def test_get_supplier_email_preview_TC_B_194(self):
@@ -200,30 +205,38 @@ class TestRequestforQuotation(FrappeTestCase):
 				"supplier_group": "_Test Supplier Group",
 			}
 		).insert()
-		rfq = make_request_for_quotation(item_code = item_code, supplier_data=[
+		rfq = make_request_for_quotation(
+			item_code=item_code,
+			supplier_data=[
 				{
 					"supplier": supplier_doc.name,
 					"supplier_name": supplier_doc.supplier_name,
 					"email_id": "testrfquser@example.com",
 				}
-			])
+			],
+		)
+		email_template = frappe.get_doc(
+			{"doctype": "Email Template", "__newname": "Test", "subject": "Test", "response": "test"}
+		).insert()
+		rfq.email_template = email_template.name
 		preview = rfq.get_supplier_email_preview(supplier_doc.name)
-        
-		self.assertIn("Dear", preview)
-		self.assertIn("testrfquser@example.com", preview)
+		self.assertIn(email_template.response, preview["message"])
 
 	def test_get_supplier_tag_TC_B_195(self):
 		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import get_supplier_tag
+
 		tags = get_supplier_tag()
 		self.assertIsInstance(tags, list)
 
 	def test_get_rfq_containing_supplier_TC_B_196(self):
-		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import get_rfq_containing_supplier
+		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
+			get_rfq_containing_supplier,
+		)
 
 		filters = {
 			"company": self.rfq.company,
 			"supplier": self.supplier.name,
-			"transaction_date": self.rfq.transaction_date
+			"transaction_date": self.rfq.transaction_date,
 		}
 
 		rfqs = get_rfq_containing_supplier("Request for Quotation", "", "name", 0, 10, filters)
@@ -248,20 +261,20 @@ class TestRequestforQuotation(FrappeTestCase):
 				"supplier_name": "Test Supplier1",
 			}
 		).insert()
-		rfq = make_request_for_quotation(item_code = item_code, supplier_data=[
+		rfq = make_request_for_quotation(
+			item_code=item_code,
+			supplier_data=[
 				{
 					"supplier": supplier_doc.name,
 					"supplier_name": supplier_doc.supplier_name,
 					"email_id": "testrfquser@example.com",
 				}
-			], do_not_submit=True)
+			],
+			do_not_submit=True,
+		)
 		rfq.email_template = "Dispatch Notification"
 
-		data = {
-			"supplier": "Test Supplier",
-			"supplier_name": "Test Supplier1",
-			"contact": None
-		}
+		data = {"supplier": "Test Supplier", "supplier_name": "Test Supplier1", "contact": None}
 
 		update_password_link = "http://example.com/set-password"
 		rfq_link = "http://example.com/submit-quotation"
@@ -271,7 +284,7 @@ class TestRequestforQuotation(FrappeTestCase):
 		self.assertIn("Test Supplier1", preview["message"])
 		self.assertIn("Set Password", preview["message"])
 		self.assertIn("Test Supplier Name", preview["subject"])
-		
+
 	def test_on_cancel_TC_B_199(self):
 		rfq = make_request_for_quotation()
 		rfq.cancel()
@@ -281,13 +294,15 @@ class TestRequestforQuotation(FrappeTestCase):
 	def test_get_attachments_TC_B_200(self):
 		rfq = make_request_for_quotation()
 
-		file = frappe.get_doc({
-			"doctype": "File",
-			"file_name": "test.txt",
-			"attached_to_doctype": "Request for Quotation",
-			"attached_to_name": rfq.name,
-			"content": "Hello, world!"
-		}).insert(ignore_permissions=True)
+		file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "test.txt",
+				"attached_to_doctype": "Request for Quotation",
+				"attached_to_name": rfq.name,
+				"content": "Hello, world!",
+			}
+		).insert(ignore_permissions=True)
 
 		rfq.reload()
 		attachment_names = rfq.get_attachments()
@@ -296,51 +311,56 @@ class TestRequestforQuotation(FrappeTestCase):
 
 	def test_get_item_from_material_requests_based_on_supplier_TC_B_201(self):
 		from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
-			get_item_from_material_requests_based_on_supplier
+			get_item_from_material_requests_based_on_supplier,
 		)
 
-		supplier = frappe.get_doc({
-			"doctype": "Supplier",
-			"supplier_name": "Test Supplier"
-		}).insert(ignore_if_duplicate=True, ignore_permissions=True)
+		supplier = frappe.get_doc({"doctype": "Supplier", "supplier_name": "Test Supplier"}).insert(
+			ignore_if_duplicate=True, ignore_permissions=True
+		)
 
-		gst_hsn_code = frappe.get_doc({
-			"doctype": "GST HSN Code",
-			"hsn_code": "110011"
-		}).insert(ignore_if_duplicate=True, ignore_permissions=True).name
+		gst_hsn_code = (
+			frappe.get_doc({"doctype": "GST HSN Code", "hsn_code": "110011"})
+			.insert(ignore_if_duplicate=True, ignore_permissions=True)
+			.name
+		)
 
 		item_code = "_Test Item Supplier Coverage"
-		item = frappe.get_doc({
-			"doctype": "Item",
-			"item_code": item_code,
-			"item_name": item_code,
-			"stock_uom": "Nos",
-			"item_group": "All Item Groups",
-			"gst_hsn_code": gst_hsn_code,
-			"is_stock_item": 1
-		}).insert(ignore_if_duplicate=True, ignore_permissions=True)
+		item = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"stock_uom": "Nos",
+				"item_group": "All Item Groups",
+				"gst_hsn_code": gst_hsn_code,
+				"is_stock_item": 1,
+			}
+		).insert(ignore_if_duplicate=True, ignore_permissions=True)
 
 		item = frappe.get_doc("Item", item.name)
 		if not any(row.supplier == supplier.name for row in item.supplier_items):
 			item.append("supplier_items", {"supplier": supplier.name})
 			item.save()
 
-		warehouse = frappe.get_doc({
-			"doctype": "Warehouse",
-			"warehouse_name": "_Test Stores"
-		}).insert(ignore_if_duplicate=True)
+		warehouse = frappe.get_doc({"doctype": "Warehouse", "warehouse_name": "_Test Stores"}).insert(
+			ignore_if_duplicate=True
+		)
 
-		mr = frappe.get_doc({
-			"doctype": "Material Request",
-			"material_request_type": "Purchase",
-			"schedule_date": frappe.utils.add_days(frappe.utils.nowdate(), 5),
-			"items": [{
-				"item_code": item.name,
-				"qty": 10,
+		mr = frappe.get_doc(
+			{
+				"doctype": "Material Request",
+				"material_request_type": "Purchase",
 				"schedule_date": frappe.utils.add_days(frappe.utils.nowdate(), 5),
-				"warehouse": warehouse.name,
-			}]
-		}).insert(ignore_permissions=True)
+				"items": [
+					{
+						"item_code": item.name,
+						"qty": 10,
+						"schedule_date": frappe.utils.add_days(frappe.utils.nowdate(), 5),
+						"warehouse": warehouse.name,
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
 		mr.submit()
 
 		rfq_doc = get_item_from_material_requests_based_on_supplier(supplier.name)
@@ -353,28 +373,36 @@ class TestRequestforQuotation(FrappeTestCase):
 
 	def test_send_email_TC_B_202(self):
 		from unittest.mock import patch
+
 		item_code = "_Test Item"
 		if not frappe.db.exists("Item", item_code):
 			make_item(item_code, {"stock_uom": "Nos"})
 
-		supplier = frappe.get_doc({
-			"doctype": "Supplier",
-			"supplier_name": "Email Test Supplier"
-		}).insert(ignore_if_duplicate=True, ignore_permissions=True)
+		supplier = frappe.get_doc({"doctype": "Supplier", "supplier_name": "Email Test Supplier"}).insert(
+			ignore_if_duplicate=True, ignore_permissions=True
+		)
 
-		rfq = make_request_for_quotation(item_code=item_code, supplier_data=[{
-			"supplier": supplier.name,
-			"supplier_name": supplier.supplier_name,
-			"email_id": "testrfquser@example.com"
-		}], do_not_submit=True)
+		rfq = make_request_for_quotation(
+			item_code=item_code,
+			supplier_data=[
+				{
+					"supplier": supplier.name,
+					"supplier_name": supplier.supplier_name,
+					"email_id": "testrfquser@example.com",
+				}
+			],
+			do_not_submit=True,
+		)
 		rfq.email_template = "Dispatch Notification"
 
-		data = frappe._dict({
-			"supplier": supplier.name,
-			"supplier_name": supplier.supplier_name,
-			"email_id": "testrfquser@example.com",
-			"contact": None
-		})
+		data = frappe._dict(
+			{
+				"supplier": supplier.name,
+				"supplier_name": supplier.supplier_name,
+				"email_id": "testrfquser@example.com",
+				"contact": None,
+			}
+		)
 
 		update_password_link = "http://example.com/set-password"
 		rfq_link = "http://example.com/submit-quotation"

--- a/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
+++ b/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
@@ -2,119 +2,139 @@
 # See license.txt
 
 import unittest
-import frappe
 from unittest.mock import patch
 
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
-class TestSupplierScorecardPeriod(unittest.TestCase):
+
+class TestSupplierScorecardPeriod(FrappeTestCase):
+	def teardown():
+		frappe.db.rollback()
+
 	def test_validate_method_TC_B_203(self):
-		supplier = frappe.get_doc({
-			"doctype": "Supplier",
-			"supplier_name": "Test Supplier Validate"
-		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		supplier = frappe.get_doc({"doctype": "Supplier", "supplier_name": "Test Supplier Validate"}).insert(
+			ignore_permissions=True, ignore_if_duplicate=True
+		)
 
-		criteria = frappe.get_doc({
-			"doctype": "Supplier Scorecard Criteria",
-			"criteria_name": "Test Criteria Validate",
-			"max_score": 10,
-			"formula": "10"
-		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		criteria = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Criteria",
+				"criteria_name": "Test Criteria Validate",
+				"max_score": 10,
+				"formula": "10",
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
-		variable = frappe.get_doc({
-			"doctype": "Supplier Scorecard Variable",
-			"variable_label": "Test Var",
-			"param_name": "test_var",
-			"path": "get_ordered_qty"
-		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		variable = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Variable",
+				"variable_label": "Test Var",
+				"param_name": "test_var",
+				"path": "get_ordered_qty",
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
-		scorecard = frappe.get_doc({
-			"doctype": "Supplier Scorecard",
-			"supplier": supplier.name,
-			"period": "Per Month",
-			"criteria": [{"criteria_name": criteria.name, "weight": 100}],
-			"standings": [
-				{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
-				{"min_grade": 49, "max_grade": 74, "standing": "Average"},
-				{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
-			]
-		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		scorecard = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard",
+				"supplier": supplier.name,
+				"period": "Per Month",
+				"criteria": [{"criteria_name": criteria.name, "weight": 100}],
+				"standings": [
+					{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
+					{"min_grade": 49, "max_grade": 74, "standing": "Average"},
+					{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
+				],
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
-		doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"scorecard": scorecard.name,
-			"from_date": "2024-01-01",
-			"to_date": "2024-12-31",
-			"criteria": [{
-				"criteria_name": criteria.name,
-				"weight": 100,
-				"formula": criteria.formula,
-				"max_score": criteria.max_score
-			}],
-			"variables": [{
-				"variable_label": variable.name,
-				"param_name": variable.param_name,
-				"path": variable.path
-			}]
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"scorecard": scorecard.name,
+				"from_date": "2024-01-01",
+				"to_date": "2024-12-31",
+				"criteria": [
+					{
+						"criteria_name": criteria.name,
+						"weight": 100,
+						"formula": criteria.formula,
+						"max_score": criteria.max_score,
+					}
+				],
+				"variables": [
+					{
+						"variable_label": variable.name,
+						"param_name": variable.param_name,
+						"path": variable.path,
+					}
+				],
+			}
+		)
 
 		doc.validate()
 
 		self.assertEqual(doc.criteria[0].score, 10)
 		self.assertIsNotNone(doc.variables[0].value)
-		
+
 	def test_import_string_path_TC_B_204(self):
-		from erpnext.buying.doctype.supplier_scorecard_period.supplier_scorecard_period import import_string_path
 		from frappe.utils import add_days
+
+		from erpnext.buying.doctype.supplier_scorecard_period.supplier_scorecard_period import (
+			import_string_path,
+		)
 
 		self.assertEqual(import_string_path("frappe.utils.add_days"), add_days)
 		self.assertRaises(AttributeError, import_string_path, "frappe.utils.invalid_func")
 
 	def test_criteria_weight_validation_valid_and_invalid_TC_B_205(self):
-		criteria = frappe.get_doc({
-			"doctype": "Supplier Scorecard Criteria",
-			"criteria_name": "Test Weight Criteria",
-			"max_score": 10,
-			"formula": "10"
-		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		criteria = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Criteria",
+				"criteria_name": "Test Weight Criteria",
+				"max_score": 10,
+				"formula": "10",
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
-		supplier = frappe.get_doc({
-			"doctype": "Supplier",
-			"supplier_name": "Test Supplier"
-		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		supplier = frappe.get_doc({"doctype": "Supplier", "supplier_name": "Test Supplier"}).insert(
+			ignore_permissions=True, ignore_if_duplicate=True
+		)
 
-		scorecard = frappe.get_doc({
-			"doctype": "Supplier Scorecard",
-			"supplier": supplier.name,
-			"period": "Per Month",
-			"criteria": [
-				{"criteria_name": criteria.name, "weight": 100}
-			],
-			"standings": [
-				{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
-				{"min_grade": 49, "max_grade": 74, "standing": "Average"},
-				{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
-			]
-		}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		scorecard = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard",
+				"supplier": supplier.name,
+				"period": "Per Month",
+				"criteria": [{"criteria_name": criteria.name, "weight": 100}],
+				"standings": [
+					{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
+					{"min_grade": 49, "max_grade": 74, "standing": "Average"},
+					{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
+				],
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 		# Case 1: Valid weight
-		valid_doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"scorecard": scorecard.name,
-			"criteria": [
-				{"criteria_name": criteria.name, "weight": 100}
-			]
-		})
+		valid_doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"scorecard": scorecard.name,
+				"criteria": [{"criteria_name": criteria.name, "weight": 100}],
+			}
+		)
 		valid_doc.validate_criteria_weights()
 		self.assertTrue(True)
 
 		# Case 2: Invalid weight
-		invalid_doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"scorecard": scorecard.name,
-			"criteria": [
-				{"criteria_name": criteria.name, "weight": 80}
-			]
-		})
+		invalid_doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"scorecard": scorecard.name,
+				"criteria": [{"criteria_name": criteria.name, "weight": 80}],
+			}
+		)
 		with self.assertRaises(frappe.ValidationError):
 			invalid_doc.validate_criteria_weights()
 
@@ -124,7 +144,7 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 				"doctype": "Supplier Scorecard Criteria",
 				"max_score": "100",
 				"formula": "max(0,10)*100",
-				"criteria_name": "_Test Criteria"
+				"criteria_name": "_Test Criteria",
 			}
 		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 		supplier_doc = frappe.get_doc(
@@ -138,12 +158,12 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 				"doctype": "Supplier Scorecard",
 				"supplier": supplier_doc.name,
 				"period": "Per Month",
-				"criteria": [{'criteria_name': supplier_scorecard_criteria.name, "weight": 100}],
+				"criteria": [{"criteria_name": supplier_scorecard_criteria.name, "weight": 100}],
 				"standings": [
 					{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
 					{"min_grade": 49, "max_grade": 74, "standing": "Average"},
 					{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
-				]
+				],
 			}
 		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 		supplier_scorecard_variable = frappe.get_doc(
@@ -151,35 +171,36 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 				"doctype": "Supplier Scorecard Variable",
 				"variable_label": "Test",
 				"param_name": "Test",
-				"path": "get_ordered_qty"
+				"path": "get_ordered_qty",
 			}
 		).insert(ignore_permissions=True, ignore_if_duplicate=True)
-		doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"scorecard": supplier_scorecard.name,
-			"from_date": "2024-01-01",
-			"to_date": "2024-12-31",
-			"criteria": [
-				{"criteria_name": supplier_scorecard_criteria.name, "weight": 100},
-			],
-			"variables": [
-				{
-					"variable_label": supplier_scorecard_variable.name,
-					"path": "get_ordered_qty"
-				}
-			]
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"scorecard": supplier_scorecard.name,
+				"from_date": "2024-01-01",
+				"to_date": "2024-12-31",
+				"criteria": [
+					{"criteria_name": supplier_scorecard_criteria.name, "weight": 100},
+				],
+				"variables": [
+					{"variable_label": supplier_scorecard_variable.name, "path": "get_ordered_qty"}
+				],
+			}
+		)
 
 		doc.calculate_variables()
 
 		self.assertIsNotNone(doc.variables[0].value)
-		with patch("erpnext.buying.doctype.supplier_scorecard_period.supplier_scorecard_period.import_string_path") as mock_import:
+		with patch(
+			"erpnext.buying.doctype.supplier_scorecard_period.supplier_scorecard_period.import_string_path"
+		) as mock_import:
 			mock_import.return_value = lambda self: 123
 
-			doc.append("variables", {
-				"variable_label": "Mock Dotted Function",
-				"path": "erpnext.supplier.mock_function"
-			})
+			doc.append(
+				"variables",
+				{"variable_label": "Mock Dotted Function", "path": "erpnext.supplier.mock_function"},
+			)
 
 			doc.calculate_variables()
 
@@ -187,14 +208,16 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 			self.assertEqual(doc.variables[1].value, 123)
 
 	def test_calculate_score_TC_B_207(self):
-		doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"scorecard": "Test Scorecard", 
-			"criteria": [
-				{"criteria": "Quality", "weight": 60, "score": 80},
-				{"criteria": "Delivery", "weight": 40, "score": 90}
-			]
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"scorecard": "Test Scorecard",
+				"criteria": [
+					{"criteria": "Quality", "weight": 60, "score": 80},
+					{"criteria": "Delivery", "weight": 40, "score": 90},
+				],
+			}
+		)
 
 		doc.calculate_score()
 
@@ -202,12 +225,14 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 		self.assertEqual(doc.total_score, expected_score)
 
 	def test_calculate_weighted_score_TC_B_208(self):
-		doc = frappe.get_doc({
-        "doctype": "Supplier Scorecard Period",
-        "scorecard": "Test Scorecard",
-        "from_date": "2024-01-01",
-        "to_date": "2024-12-31"
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"scorecard": "Test Scorecard",
+				"from_date": "2024-01-01",
+				"to_date": "2024-12-31",
+			}
+		)
 
 		doc.get_eval_statement = lambda fn: "min(80, 100)"
 
@@ -223,16 +248,18 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 		with self.assertRaises(frappe.ValidationError, msg="Could not solve weighted score function") as cm:
 			doc.calculate_weighted_score("INVALID FORMULA")
 
-		#self.assertIn("Could not solve weighted score function", str(cm.exception))
+		# self.assertIn("Could not solve weighted score function", str(cm.exception))
 
 	def test_get_eval_statement_TC_B_210(self):
-		doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"variables": [
-				frappe._dict({"param_name": "quality", "value": 80}),
-				frappe._dict({"param_name": "delivery", "value": None})
-			]
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"variables": [
+					frappe._dict({"param_name": "quality", "value": 80}),
+					frappe._dict({"param_name": "delivery", "value": None}),
+				],
+			}
+		)
 
 		formula = "{quality} * 0.5 + {delivery} * 0.5"
 		expected = "80.00 * 0.5 + 0.0 * 0.5"
@@ -241,44 +268,55 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 		self.assertEqual(result, expected)
 
 	def test_make_supplier_scorecard_TC_B_211(self):
-		from erpnext.buying.doctype.supplier_scorecard_period.supplier_scorecard_period import make_supplier_scorecard
-		
-		criteria = frappe.get_doc(
-			{
-				"doctype": "Supplier Scorecard Criteria",
-				"max_score": "100",
-				"formula": "max(0,10)*100",
-				"criteria_name": "_Test Criteria"
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		from erpnext.buying.doctype.supplier_scorecard_period.supplier_scorecard_period import (
+			make_supplier_scorecard,
+		)
 
-		frappe.get_doc(
-			{
-				"doctype": "Supplier Scorecard Variable",
-				"variable_label": "Test",
-				"param_name": "Test",
-				"path": "get_ordered_qty"
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		if not frappe.db.exists("Supplier Scorecard Criteria", "_Test Criteria"):
+			criteria = frappe.get_doc(
+				{
+					"doctype": "Supplier Scorecard Criteria",
+					"max_score": "100",
+					"formula": "max(0,10)*100",
+					"criteria_name": "_Test Criteria",
+				}
+			).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		else:
+			criteria = frappe.get_doc(
+				{"doctype": "Supplier Scorecard Criteria", "criteria_name": "_Test Criteria"}
+			)
 
-		supplier_doc = frappe.get_doc(
-			{
-				"doctype": "Supplier",
-				"supplier_name": "Test Supplier for RFQ",
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		if not frappe.db.exists("Supplier Scorecard Variable", "Test"):
+			frappe.get_doc(
+				{
+					"doctype": "Supplier Scorecard Variable",
+					"variable_label": "Test",
+					"param_name": "Test",
+					"path": "get_ordered_qty",
+				}
+			).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+		if not frappe.db.exists("Supplier", "Test Supplier for RFQ"):
+			supplier_doc = frappe.get_doc(
+				{
+					"doctype": "Supplier",
+					"supplier_name": "Test Supplier for RFQ",
+				}
+			).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		else:
+			supplier_doc = frappe.get_doc({"doctype": "Supplier", "supplier_name": "Test Supplier for RFQ"})
 
 		scorecard = frappe.get_doc(
 			{
 				"doctype": "Supplier Scorecard",
 				"supplier": supplier_doc.name,
 				"period": "Per Month",
-				"criteria": [{'criteria_name': criteria.name, "weight": 100}],
+				"criteria": [{"criteria_name": criteria.name, "weight": 100}],
 				"standings": [
 					{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
 					{"min_grade": 49, "max_grade": 74, "standing": "Average"},
 					{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
-				]
+				],
 			}
 		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
@@ -292,43 +330,43 @@ class TestSupplierScorecardPeriod(unittest.TestCase):
 			self.assertEqual(variable.variable_label, "Test")
 			self.assertEqual(variable.param_name, "Test")
 			self.assertEqual(variable.path, "get_ordered_qty")
-			
+
 	def test_calculate_criteria_TC_B_212(self):
-		doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"scorecard": "Dummy Scorecard",
-			"variables": [
-				{"param_name": "on_time_delivery_rate", "value": 85}
-			],
-			"criteria": [
-				{
-					"criteria_name": "Delivery",
-					"formula": "{on_time_delivery_rate} / 10",
-					"max_score": 10
-				}
-			]
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"scorecard": "Dummy Scorecard",
+				"variables": [{"param_name": "on_time_delivery_rate", "value": 85}],
+				"criteria": [
+					{"criteria_name": "Delivery", "formula": "{on_time_delivery_rate} / 10", "max_score": 10}
+				],
+			}
+		)
 
 		doc.calculate_criteria()
 
 		self.assertAlmostEqual(doc.criteria[0].score, 8.5, places=2)
 
 	def test_calculate_criteria_with_invalid_formula_TC_B_213(self):
-		doc = frappe.get_doc({
-			"doctype": "Supplier Scorecard Period",
-			"criteria": [
-				{
-					"criteria_name": "Invalid Criteria",
-					"weight": 100,
-					"max_score": 10,
-					"formula": "{undefined_variable}" 
-				}
-			]
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Period",
+				"criteria": [
+					{
+						"criteria_name": "Invalid Criteria",
+						"weight": 100,
+						"max_score": 10,
+						"formula": "{undefined_variable}",
+					}
+				],
+			}
+		)
 
 		doc.variables = []
 
-		with self.assertRaises(frappe.ValidationError, msg="Could not solve criteria score function") as context:
+		with self.assertRaises(
+			frappe.ValidationError, msg="Could not solve criteria score function"
+		) as context:
 			doc.calculate_criteria()
 
-		#self.assertIn("Could not solve criteria score function", str(context.exception))
+		# self.assertIn("Could not solve criteria score function", str(context.exception))

--- a/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
+++ b/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
@@ -9,7 +9,14 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestSupplierScorecardPeriod(FrappeTestCase):
-	def teardown():
+	def setUp(self):
+		supplier_records = create_supplier_related_records()
+		self.criteria = supplier_records.get("criteria")
+		self.scorecard_variable = supplier_records.get("scorecard_variable")
+		self.supplier_document = supplier_records.get("supplier_document")
+		self.scorecard = supplier_records.get("scorecard")
+
+	def teardown(self):
 		frappe.db.rollback()
 
 	def test_validate_method_TC_B_203(self):
@@ -272,56 +279,7 @@ class TestSupplierScorecardPeriod(FrappeTestCase):
 			make_supplier_scorecard,
 		)
 
-		if not frappe.db.exists("Supplier Scorecard Criteria", "_Test Criteria"):
-			criteria = frappe.get_doc(
-				{
-					"doctype": "Supplier Scorecard Criteria",
-					"max_score": "100",
-					"formula": "max(0,10)*100",
-					"criteria_name": "_Test Criteria",
-				}
-			).insert(ignore_permissions=True, ignore_if_duplicate=True)
-		else:
-			criteria = frappe.get_doc(
-				{"doctype": "Supplier Scorecard Criteria", "criteria_name": "_Test Criteria"}
-			)
-
-		if not frappe.db.exists("Supplier Scorecard Variable", "Test"):
-			frappe.get_doc(
-				{
-					"doctype": "Supplier Scorecard Variable",
-					"variable_label": "Test",
-					"param_name": "Test",
-					"path": "get_ordered_qty",
-				}
-			).insert(ignore_permissions=True, ignore_if_duplicate=True)
-
-		if not frappe.db.exists("Supplier", "Test Supplier for RFQ"):
-			supplier_doc = frappe.get_doc(
-				{
-					"doctype": "Supplier",
-					"supplier_name": "Test Supplier for RFQ",
-				}
-			).insert(ignore_permissions=True, ignore_if_duplicate=True)
-		else:
-			supplier_doc = frappe.get_doc({"doctype": "Supplier", "supplier_name": "Test Supplier for RFQ"})
-
-		scorecard = frappe.get_doc(
-			{
-				"doctype": "Supplier Scorecard",
-				"supplier": supplier_doc.name,
-				"period": "Per Month",
-				"criteria": [{"criteria_name": criteria.name, "weight": 100}],
-				"standings": [
-					{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
-					{"min_grade": 49, "max_grade": 74, "standing": "Average"},
-					{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
-				],
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
-
-		result = make_supplier_scorecard(scorecard.name)
-
+		result = make_supplier_scorecard(self.scorecard.name)
 		self.assertEqual(result.doctype, "Supplier Scorecard Period")
 
 		if len(result.variables) > 0:
@@ -370,3 +328,63 @@ class TestSupplierScorecardPeriod(FrappeTestCase):
 			doc.calculate_criteria()
 
 		# self.assertIn("Could not solve criteria score function", str(context.exception))
+
+
+def create_supplier_related_records():
+	scorecard_criteria = "_Test Criteria"
+	scorecard_variable = "Test"
+	supplier_document = "Test Supplier for RFQ"
+	if not frappe.db.exists("Supplier Scorecard Criteria", scorecard_criteria):
+		criteria = frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Criteria",
+				"max_score": "100",
+				"formula": "max(0,10)*100",
+				"criteria_name": "_Test Criteria",
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+	else:
+		criteria = frappe.get_doc(
+			{"doctype": "Supplier Scorecard Criteria", "criteria_name": "_Test Criteria"}
+		)
+
+	if not frappe.db.exists("Supplier Scorecard Variable", scorecard_variable):
+		frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Variable",
+				"variable_label": "Test",
+				"param_name": "Test",
+				"path": "get_ordered_qty",
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+	if not frappe.db.exists("Supplier", supplier_document):
+		supplier_doc = frappe.get_doc(
+			{
+				"doctype": "Supplier",
+				"supplier_name": "Test Supplier for RFQ",
+			}
+		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+	else:
+		supplier_doc = frappe.get_doc({"doctype": "Supplier", "supplier_name": "Test Supplier for RFQ"})
+
+	scorecard = frappe.get_doc(
+		{
+			"doctype": "Supplier Scorecard",
+			"supplier": supplier_doc.name,
+			"period": "Per Month",
+			"criteria": [{"criteria_name": criteria.name, "weight": 100}],
+			"standings": [
+				{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
+				{"min_grade": 49, "max_grade": 74, "standing": "Average"},
+				{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
+			],
+		}
+	).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+	return {
+		"criteria": criteria,
+		"scorecard_variable": scorecard_variable,
+		"supplier_document": supplier_document,
+		"scorecard": scorecard,
+	}


### PR DESCRIPTION
test_get_supplier_email_preview_TC_B_194:
Test Case Description: 
In the test case test_get_supplier_email_preview_TC_B_194, verify that the get_supplier_email_preview() method in the Request for Quotation (RFQ) returns the correct email content for a given supplier when an email template is assigned.

Root Cause: 
The test was failing with a TypeError due to NoneType on preview["message"]. This happened because the email template was not properly created or linked, resulting in an empty preview.

Steps to Reproduce:
Run test_get_supplier_email_preview_TC_B_194
Assign an incomplete or unsaved email template to the RFQ.
Call get_supplier_email_preview() using the supplier name

Actual/Observed Result:
TypeError: argument of type 'NoneType' is not iterable

Expected Result:
Test case should pass.

Fix Summary:
    Create a valid Email Template with response, subject.
    Assign it to the RFQ and save the document.
    Ensure the preview correctly reflects the email content using get_supplier_email_preview().

Affected Module
Buying

Test Cases Covered:
test_get_supplier_email_preview_TC_B_194

test_make_supplier_scorecard_TC_B_211:
 Test Case Description:
The purpose of this test case is to validate the make_supplier_scorecard function from the Supplier Scorecard Period. It ensures that the scorecard criteria, variables, and supplier details are properly set up, and the system correctly generates the corresponding Supplier Scorecard Period document with expected variables.

Root Cause:
The test case was failing due to a DuplicateEntryError when inserting records like:
    Supplier Scorecard Criteria (_Test Criteria)
    Supplier Scorecard Variable (Test)
    Supplier (Test Supplier for RFQ)
    Supplier Scorecard

Although ignore_if_duplicate=True was used, it did not prevent duplicate insert errors in some environments, possibly due to partial rollback, existing committed records, or unique constraint violations at the DB level.

Steps to Reproduce:
    Ensure records like _Test Criteria, Test Supplier for RFQ, or Test variable already exist in the database.
    Run the test case test_make_supplier_scorecard_TC_B_211.

Actual/Observed Result:
DuplicateEntryError: ('Supplier Scorecard Criteria', '_Test Criteria')

The test fails when attempting to insert a record that already exists.

Expected Result:

The test should pass without throwing any exceptions, ensuring that:
    All required records are inserted without conflict.
    make_supplier_scorecard runs and returns a valid Supplier Scorecard Period document.
    Variables are populated correctly.

Fix Summary:
    Used frappe.db.exists() to check for existing records before insertion.
    Ensured the test is self-contained and avoids data duplication.
    Added teardown logic or avoids DB state leakage to keep tests isolated and repeatable.

Affected Module
Buying

Test Cases Covered:
test_make_supplier_scorecard_TC_B_211


Linked Issue
Fixes #2492, #2490
