### PR TITLE
test: Replace 'India' by 'Test Territory' in Sales Order test case while creating Customer.

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -8392,7 +8392,7 @@ def create_registered_customer():
 				"customer_name": "_Test Registered Customer",
 				"customer_type": "Company",
 				"customer_group": "Commercial",
-				"territory": "India",
+				"territory": "_Test Territory",
 				"gstin": "24AANFA2641L1ZF",
 				"gst_category": "Registered Regular",
 			}


### PR DESCRIPTION
### Description:

Bug Description
Certain automated test cases were failing due to a missing "India" territory record. This resulted in a Could not find Territory: India error when creating a test customer with the territory field set to "India".

### Root Cause
The test function create_registered_customer relied on the presence of the "India" territory in the database, which isn't guaranteed in a fresh or isolated test environment.
Steps to Reproduce:

Run test case test_2360 on a new or cleaned site.

Trigger the creation of a customer with territory="India".

### Actual/Observed Result:
Test case fails with: Could not find Territory: India ( Territory India isn't part of test_recods.json ) and can't be used as global record.

### Expected Result:
Test case should run successfully with a valid territory assigned.

### Fix Summary
Replaced the hardcoded "India" territory with the existing default _Test Territory, which is created during test setup. This ensures consistency and removes dependency on external data setup.

### Affected Module
Selling

### Test Cases Covered
Any test relying on create_registered_customer() for eg, 
Test Case ID
--
TC_S_043
TC_S_042
TC_S_094
TC_S_020
TC_S_011
TC_S_014
TC_S_015
TC_S_012
TC_S_013
TC_S_019
TC_S_018
TC_S_065
TC_S_062
TC_S_059

### Linked Issue
Fixes #2360