### PR TITLE
fix: Duplicate serial no in test case

### DIFF
--- a/erpnext/stock/doctype/manufacturer/test_manufacturer.py
+++ b/erpnext/stock/doctype/manufacturer/test_manufacturer.py
@@ -12,7 +12,7 @@ class TestManufacturer(unittest.TestCase):
 		frappe.db.rollback()
 
 	# codecov
-	def test_onload_TC_SCK_314(self):
+	def test_onload_TC_SCK_315(self):
 		manufacturer_doc = frappe.get_doc(
 			{
 				"doctype": "Manufacturer",


### PR DESCRIPTION
Title: Fix: Duplicate method name in Manufacturer test case

Description:

Bug Description
There was a duplicate method name test_manufacturer_TC_SCK_314 already present in the test suite for the Manufacturer doctype. Having the same method name twice leads to overwriting the earlier method, which causes the intended test to be skipped silently.

Root Cause
The test method for Manufacturer was mistakenly assigned the same serial number (TC_SCK_314) as an already existing one.
Steps to Reproduce:

Add two test methods with the same name (test_manufacturer_TC_SCK_314) in test_manufacturer.py.

Run bench run-tests.

Only one test will be executed; the other is silently ignored.

Actual/Observed Result:
One of the test cases is skipped due to Python method name overwriting.

Expected Result:
Each test case should have a unique method name to ensure all are executed.

Fix Summary
The method name was updated from test_manufacturer_TC_SCK_314 to test_manufacturer_TC_SCK_315 to avoid duplication and ensure both test cases are executed.

Affected Module
Manufacturer Doctype (Test File)

Test Cases Covered
test_manufacturer_TC_SCK_314 (existing)

test_manufacturer_TC_SCK_315 (renamed to avoid conflict)

Linked Issue
Fixes #None

PR Reference
https://github.com/8848digital/erpnext/pull/2486#issuecomment-2943766391