### PR TITLE
test: Validates that linked Contacts and Addresses are deleted upon Bank deletion.

### DIFF
--- a/erpnext/accounts/doctype/bank/bank.py
+++ b/erpnext/accounts/doctype/bank/bank.py
@@ -15,7 +15,7 @@ class Bank(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.bank_transaction_mapping.bank_transaction_mapping import (

--- a/erpnext/accounts/doctype/bank/test_bank.py
+++ b/erpnext/accounts/doctype/bank/test_bank.py
@@ -3,6 +3,40 @@
 
 import unittest
 
+import frappe
+
+from erpnext.accounts.doctype.bank.bank import Bank
+
 
 class TestBank(unittest.TestCase):
-	pass
+	def test_on_trash_TC_ACC_196(self):
+		if not frappe.db.exists("Bank", "Test Bank"):
+			bank = frappe.get_doc({"doctype": "Bank", "bank_name": "Test Bank"}).insert()
+		else:
+			bank = frappe.get_doc("Bank", "Test Bank")
+
+		# Create test contact linked only to this Bank
+		contact = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "Test Contact",
+				"links": [{"link_doctype": "Bank", "link_name": bank.name}],
+			}
+		).insert()
+		address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": "Test Address",
+				"address_type": "Billing",
+				"gst_category": "unregistered",
+				"city": "Test City",
+				"country": "United States",
+				"address_line1": "Test Address Line 1",
+				"links": [{"link_doctype": "Bank", "link_name": bank.name}],
+			}
+		).insert()
+		self.assertTrue(frappe.db.exists("Contact", contact.name))
+		self.assertTrue(frappe.db.exists("Address", address.name))
+		Bank.on_trash(self=bank)
+		self.assertFalse(frappe.db.exists("Contact", contact.name))
+		self.assertFalse(frappe.db.exists("Address", address.name))


### PR DESCRIPTION
**Test Case ID:** test_on_trash_TC_ACC_196

**Test Summary:**
Added test case to verify the on_trash method of the Bank doctype. Ensures that linked Contact and Address documents are automatically deleted when the parent Bank record is trashed, maintaining referential integrity.

**Scenarios Covered:**
Validates that linked Contacts and Addresses are deleted upon Bank deletion.

**Edge Cases:**
Tests behavior when a Bank has multiple linked documents (Contact + Address).
Confirms test records (Bank, Contact, Address) are created successfully before trash operation.

**Technology:**
Python unittest framework
Frappe testing utilities

**Linked Feature/Bug:**
Ensures proper cleanup of linked documents in relational workflows.

**Issue ID:** N/A (Preventive test coverage)

