### PR TITLE
docs: Added no pragma to ignore the files on codecoverage

### DIFF
--- a/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.py
+++ b/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.py
@@ -2,16 +2,16 @@
 # For license information, please see license.txt
 
 
-from frappe.model.document import Document
+from frappe.model.document import Document  # pragma: no cover
 
 
-class CustomsTariffNumber(Document):
+class CustomsTariffNumber(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		description: DF.Data | None

--- a/erpnext/stock/doctype/item_attribute/item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.py
@@ -24,7 +24,7 @@ class ItemAttribute(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.stock.doctype.item_attribute_value.item_attribute_value import ItemAttributeValue
@@ -49,7 +49,7 @@ class ItemAttribute(Document):
 	def on_update(self):
 		self.validate_exising_items()
 		self.set_enabled_disabled_in_items()
-		
+
 	def set_enabled_disabled_in_items(self):
 		db_value = self.get_doc_before_save()
 		if not db_value or db_value.disabled != self.disabled:

--- a/erpnext/stock/doctype/item_quality_inspection_parameter/item_quality_inspection_parameter.py
+++ b/erpnext/stock/doctype/item_quality_inspection_parameter/item_quality_inspection_parameter.py
@@ -11,7 +11,7 @@ class ItemQualityInspectionParameter(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		acceptance_formula: DF.Code | None

--- a/erpnext/stock/doctype/item_variant/item_variant.py
+++ b/erpnext/stock/doctype/item_variant/item_variant.py
@@ -11,7 +11,7 @@ class ItemVariant(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		item_attribute: DF.Link

--- a/erpnext/stock/doctype/item_website_specification/item_website_specification.py
+++ b/erpnext/stock/doctype/item_website_specification/item_website_specification.py
@@ -4,16 +4,16 @@
 # For license information, please see license.txt
 
 
-from frappe.model.document import Document
+from frappe.model.document import Document  # pragma: no cover
 
 
-class ItemWebsiteSpecification(Document):
+class ItemWebsiteSpecification(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING: # pragma: no cover
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		description: DF.TextEditor | None

--- a/erpnext/stock/doctype/quality_inspection_parameter_group/quality_inspection_parameter_group.py
+++ b/erpnext/stock/doctype/quality_inspection_parameter_group/quality_inspection_parameter_group.py
@@ -3,16 +3,16 @@
 
 
 # import frappe
-from frappe.model.document import Document
+from frappe.model.document import Document  # pragma: no cover
 
 
-class QualityInspectionParameterGroup(Document):
+class QualityInspectionParameterGroup(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+	from typing import TYPE_CHECKING  # pragma: no cover
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		group_name: DF.Data

--- a/erpnext/stock/doctype/shipment_parcel_template/shipment_parcel_template.py
+++ b/erpnext/stock/doctype/shipment_parcel_template/shipment_parcel_template.py
@@ -3,16 +3,16 @@
 
 
 # import frappe
-from frappe.model.document import Document
+from frappe.model.document import Document  # pragma: no cover
 
 
-class ShipmentParcelTemplate(Document):
+class ShipmentParcelTemplate(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+	from typing import TYPE_CHECKING  # pragma: no cover
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		height: DF.Int

--- a/erpnext/stock/doctype/uom_category/uom_category.py
+++ b/erpnext/stock/doctype/uom_category/uom_category.py
@@ -11,7 +11,7 @@ class UOMCategory(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		category_name: DF.Data


### PR DESCRIPTION
Title:Added no pragma to ignore the files on codecoverage

Description:

Optimization Summary
As we are using # pragma: no cover, this directive tells coverage tools to ignore those lines. Since child tables do not contain business logic or testable functions/methods, they are excluded from test coverage. To increase the code coverage percentage, we added the no cover pragma where appropriate.

Before vs After
Old Behavior: Code coverage percentage for the Stock module was low due to untestable child table definitions.

New Behavior: After explicitly marking those lines, code coverage percentage improved as those lines are now excluded from the coverage report.

Affected Areas
Stock module DocTypes with child tables lacking testable methods.

Linked Issue
N/A – No issue was created for this task.

Child table Doctypes:
customs_tariff_number
item_attribute
item_quality_inspection_parameter
item_variant
item_website_specification
quality_inspection_parameter_group
shipment_parcel_template
uom_category
