### PR TITLE
Fix: Sales Invoice Test Failure by Assigning Allowed Company to Customer to Prevent 'Customer Not Allowed to Transact' ValidationError

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -7608,7 +7608,6 @@ def add_taxes(doc):
 
 def create_customer(**args):
 	if not frappe.db.exists("Customer", args.get("customer_name")):
-		print("working", "working")
 		customer = frappe.new_doc("Customer")
 		customer.customer_name = args.get("customer_name")
 		customer.type = "Individual"

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -7608,15 +7608,29 @@ def add_taxes(doc):
 
 def create_customer(**args):
 	if not frappe.db.exists("Customer", args.get("customer_name")):
+		print("working", "working")
 		customer = frappe.new_doc("Customer")
 		customer.customer_name = args.get("customer_name")
 		customer.type = "Individual"
+
+		if args.get("company"):
+			# Set company in child table `companies`
+			customer.append("companies", {"company": args.get("company")})
 
 		if args.get("currency"):
 			customer.default_currency = args.get("currency")
 		if args.get("company") and args.get("account"):
 			customer.append("accounts", {"company": args.get("company"), "account": args.get("account")})
 		customer.save()
+	else:
+		customer = frappe.get_doc("Customer", args.get("customer_name"))
+
+		# Ensure the company isn't already in the child table
+		if args.get("company") and not any(c.company == args.get("company") for c in customer.companies):
+			customer.append("companies", {"company": args.get("company")})
+			customer.save()
+
+		return customer
 
 
 def create_accounts(**args):


### PR DESCRIPTION
### Title
Fix Sales Invoice Test Failure by Assigning Allowed Company to Customer to Prevent 'Customer Not Allowed to Transact' ValidationError

### Bug Description
When running the test_si_with_sr_calculate_with_fixed_TC_S_139 test case for Sales Invoice, the test fails with the following error:

ValidationError: Customer not allowed to transact with _Test Company. Please change the Company.

### Root Cause
The Customer being used in the test was created without associating the company (_Test Company) in the child table Customer > Companies. ERPNext requires the company to be explicitly listed under this table to allow transactions with it.

### Expected Result
Sales Invoice should be created successfully using _Test Customer under _Test Company.

### Actual Result
The test fails during si.insert() due to missing allowed company in the customer document, raising a ValidationError.

### Fix Summary
Updated the create_customer utility to add the specified company to the companies child table of the Customer document.
This ensures that the customer is allowed to transact with the specified company in test setups.

### Affected Module
Accounts > Sales Invoice
Test Utility: create_customer
Unit Tests: test_sales_invoice.py


### Test Case Solved
1.test_si_with_sr_calculate_with_fixed_TC_S_139

### Issue Id
#2533 

