### PR TITLE
fix: Grouping error in Journal Entry matching query during auto reconciliation

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -805,6 +805,18 @@ def get_je_matching_query(
 	if cint(filter_by_reference_date):
 		filter_by_date = je.cheque_date.between(from_reference_date, to_reference_date)
 
+	groupby_fields = [je.name]
+	if frappe.db.db_type == "postgres":
+		groupby_fields = [
+			je.name,
+			je.cheque_no,
+			je.cheque_date,
+			je.pay_to_recd_from,
+			jea.party_type,
+			je.posting_date,
+			jea.account_currency,
+		]
+
 	subquery = (
 		frappe.qb.from_(jea)
 		.join(je)
@@ -825,15 +837,7 @@ def get_je_matching_query(
 		.where(je.clearance_date.isnull())
 		.where(jea.account == common_filters.bank_account)
 		.where(filter_by_date)
-		.groupby(
-			je.name,
-			je.cheque_no,
-			je.cheque_date,
-			je.pay_to_recd_from,
-			jea.party_type,
-			je.posting_date,
-			jea.account_currency,
-		)
+		.groupby(*groupby_fields)
 		.orderby(je.cheque_date if cint(filter_by_reference_date) else je.posting_date)
 	)
 

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -10,9 +10,10 @@ from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt
-from erpnext.accounts.party import get_party_account
+
 from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.bank_transaction.bank_transaction import get_total_allocated_amount
+from erpnext.accounts.party import get_party_account
 from erpnext.accounts.report.bank_reconciliation_statement.bank_reconciliation_statement import (
 	get_amounts_not_reflected_in_system,
 	get_entries,
@@ -391,8 +392,8 @@ def auto_reconcile_vouchers(
 			from_reference_date,
 			to_reference_date,
 		)
- 
- 
+
+
 def start_auto_reconcile(
 	bank_transactions, from_date, to_date, filter_by_reference_date, from_reference_date, to_reference_date
 ):
@@ -517,6 +518,7 @@ def subtract_allocations(gl_account, vouchers):
 
 		copied.append(voucher)
 	return copied
+
 
 def get_allocated_amount(voucher_allocated_amounts, voucher, gl_account):
 	if not (voucher_details := voucher_allocated_amounts.get((voucher.get("doctype"), voucher.get("name")))):
@@ -797,7 +799,6 @@ def get_je_matching_query(
 	je = frappe.qb.DocType("Journal Entry")
 	jea = frappe.qb.DocType("Journal Entry Account")
 
-
 	amount_field = f"{cr_or_dr}_in_account_currency"
 
 	filter_by_date = je.posting_date.between(from_date, to_date)
@@ -824,7 +825,15 @@ def get_je_matching_query(
 		.where(je.clearance_date.isnull())
 		.where(jea.account == common_filters.bank_account)
 		.where(filter_by_date)
-		.groupby(je.name)
+		.groupby(
+			je.name,
+			je.cheque_no,
+			je.cheque_date,
+			je.pay_to_recd_from,
+			jea.party_type,
+			je.posting_date,
+			jea.account_currency,
+		)
 		.orderby(je.cheque_date if cint(filter_by_reference_date) else je.posting_date)
 	)
 


### PR DESCRIPTION
### Bug Description
While using the Bank Reconciliation Tool, users encountered an error when attempting to auto-reconcile vouchers. The system failed to fetch matching Journal Entries, and an internal server error was raised, preventing successful reconciliation.

### Root Cause
The issue was due to a PostgreSQL GroupingError in the query that fetches matching Journal Entries. PostgreSQL requires that all selected fields in a GROUP BY query either be grouped or aggregated. However, the query was selecting multiple fields (e.g., party_type, posting_date, account_currency) without including them in the GROUP BY clause or applying an aggregate function.

### Steps to Reproduce:

Go to Bank Reconciliation Tool.

Click on Auto Reconcile.

Ensure the selected bank account has unreconciled entries within the date range.

### Actual/Observed Result:
An internal error is raised with the message:

column "tabJournal Entry Account.party_type" must appear in the GROUP BY clause or be used in an aggregate function

## Expected Result:
The system should retrieve and display matching Journal Entries without errors.

### Fix Summary
The issue was resolved by including all non-aggregated selected fields in the GROUP BY clause of the query that retrieves Journal Entry data. This ensures PostgreSQL compatibility and eliminates the GroupingError.

### Affected Module
Bank Reconciliation Tool
Accounts


### Linked Issue
Fixes #2524 
