### PR TITLE
test: Resolve Customer Transaction Restriction with _Test Company Causing ValidationError

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -4614,9 +4614,14 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(si.status, "Paid")
 
 	def test_sales_order_create_si_via_pe_dn_with_pricing_rule_TC_S_046(self):
+		self.customer = frappe.get_doc("Customer", self.customer)
+		# Append company if not already present
+		company = "_Test Company"
+		if company and not any(c.company == company for c in self.customer.companies):
+			self.customer.append("companies", {"company": company})
+			self.customer.save()
 		make_item_price()
 		make_pricing_rule()
-
 		so = make_sales_order(qty=10, rate=90)
 		so.save()
 		so.submit()


### PR DESCRIPTION
### Bug Description:
Test case TC_S_046 fails with ValidationError: Customer not allowed to transact with _Test Company.

### Root Cause:
The test customer did not have _Test Company linked in the Customer > Companies child table.

### Expected Result:
Customer should be allowed to transact with _Test Company.

### Actual Result:
Validation error is raised during Sales Order creation due to missing company association.

### Fix Summary:
Ensure _Test Company is appended to the customer's company list in the test setup.

### Affected Module:
Accounts, Selling (Test Case: TC_S_046)

### Test case resolved
test_sales_order_create_si_via_pe_dn_with_pricing_rule_TC_S_046

### Issue Id
#2458 