### PR TITLE
docs: Added no pragma to Item Variant Doctype to ignore the files on codecoverage

### DIFF
--- a/erpnext/stock/doctype/item_variant/item_variant.py
+++ b/erpnext/stock/doctype/item_variant/item_variant.py
@@ -2,16 +2,16 @@
 # For license information, please see license.txt
 
 
-from frappe.model.document import Document
+from frappe.model.document import Document  # pragma: no cover
 
 
-class ItemVariant(Document):
+class ItemVariant(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		item_attribute: DF.Link


### PR DESCRIPTION
Title:Added no pragma to Item Variant Doctype to  ignore the files on codecoverage

Description:

Optimization Summary
As we are using # pragma: no cover, this directive tells coverage tools to ignore those lines. Since child tables do not contain business logic or testable functions/methods, they are excluded from test coverage. To increase the code coverage percentage, we added the no cover pragma where appropriate.

Before vs After
Old Behavior: Code coverage percentage for the Stock module was low due to untestable child table definitions.

New Behavior: After explicitly marking those lines, code coverage percentage improved as those lines are now excluded from the coverage report.

Affected Areas
Stock module DocTypes with child tables lacking testable methods.

Linked Issue
N/A – No issue was created for this task.

Child table Doctypes:
Item variant