### PR TITLE
test: Shipment Validate behavior and business rules in Shipment Doctype (Parcel weight, Value, Timing, Child Tables)

### DIFF
--- a/erpnext/stock/doctype/shipment/shipment.py
+++ b/erpnext/stock/doctype/shipment/shipment.py
@@ -17,7 +17,7 @@ class Shipment(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.stock.doctype.shipment_delivery_note.shipment_delivery_note import (
@@ -97,7 +97,7 @@ class Shipment(Document):
 
 	def set_total_weight(self):
 		self.total_weight = self.get_total_weight()
- 
+
 	def get_total_weight(self):
 		return sum(flt(parcel.weight) * parcel.count for parcel in self.shipment_parcel if parcel.count > 0)
 

--- a/erpnext/stock/doctype/shipment/test_shipment.py
+++ b/erpnext/stock/doctype/shipment/test_shipment.py
@@ -13,6 +13,39 @@ from erpnext.stock.doctype.delivery_note.delivery_note import make_shipment
 
 
 class TestShipment(FrappeTestCase):
+	def setUp(self):
+		self.company = "_Test Indian Registered Company"
+		if not frappe.db.exists("Company", self.company):
+			make_company(self.company)
+
+		self.args1 = {
+			"address_title": "Test Address1",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": self.company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": self.company,
+		}
+
+		self.args2 = {
+			"address_title": "Test Address2",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": self.company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": self.company,
+		}
+
 	def test_shipment_from_delivery_note(self):
 		delivery_note = create_test_delivery_note()
 		delivery_note.submit()
@@ -28,38 +61,9 @@ class TestShipment(FrappeTestCase):
 
 	# codecov
 	def test_validate_weight_TC_SCK_353(self):
-		company = "_Test Indian Registered Company"
-		if not frappe.db.exists("Company", company):
-			make_company(company)
-		args1 = {
-			"address_title": "Test Address1",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address1 = create_address(**args1)
+		address1 = create_address(**self.args1)
 
-		args2 = {
-			"address_title": "Test Address2",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",  # lowercase corrected
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address2 = create_address(**args2)
+		address2 = create_address(**self.args2)
 
 		shipment = frappe.get_doc(
 			{
@@ -80,38 +84,8 @@ class TestShipment(FrappeTestCase):
 
 	# codecov
 	def test_on_submit_TC_SCK_354(self):
-		company = "_Test Indian Registered Company"
-		if not frappe.db.exists("Company", company):
-			make_company(company)
-		args1 = {
-			"address_title": "Test Address1",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address1 = create_address(**args1)
-
-		args2 = {
-			"address_title": "Test Address2",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",  # lowercase corrected
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address2 = create_address(**args2)
+		address1 = create_address(**self.args1)
+		address2 = create_address(**self.args2)
 
 		shipment = frappe.get_doc(
 			{
@@ -134,38 +108,8 @@ class TestShipment(FrappeTestCase):
 
 	# codecov
 	def test_on_submit_no_shipment_parcel_TC_SCK_355(self):
-		company = "_Test Indian Registered Company"
-		if not frappe.db.exists("Company", company):
-			make_company(company)
-		args1 = {
-			"address_title": "Test Address1",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address1 = create_address(**args1)
-
-		args2 = {
-			"address_title": "Test Address2",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",  # lowercase corrected
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address2 = create_address(**args2)
+		address1 = create_address(**self.args1)
+		address2 = create_address(**self.args2)
 
 		shipment = frappe.get_doc(
 			{
@@ -189,38 +133,8 @@ class TestShipment(FrappeTestCase):
 
 	# codecov
 	def test_validate_pickup_time_TC_SCK_356(self):
-		company = "_Test Indian Registered Company"
-		if not frappe.db.exists("Company", company):
-			make_company(company)
-		args1 = {
-			"address_title": "Test Address1",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address1 = create_address(**args1)
-
-		args2 = {
-			"address_title": "Test Address2",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address2 = create_address(**args2)
+		address1 = create_address(**self.args1)
+		address2 = create_address(**self.args2)
 
 		shipment = frappe.get_doc(
 			{
@@ -249,38 +163,9 @@ class TestShipment(FrappeTestCase):
 			get_contact_name,
 		)
 
-		company = "_Test Indian Registered Company"
-		if not frappe.db.exists("Company", company):
-			make_company(company)
-		args1 = {
-			"address_title": "Test Address1",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address1 = create_address(**args1)
+		address1 = create_address(**self.args1)
 
-		args2 = {
-			"address_title": "Test Address2",
-			"address_type": "Permanent",
-			"address_line1": "Test Address1",
-			"is_primary_address": 1,
-			"state": "Karnataka",
-			"country": "India",
-			"pincode": "581115",
-			"company": company,
-			"is_your_company_address": 1,
-			"doctype": "Company",
-			"docname": company,
-		}
-		address2 = create_address(**args2)
+		address2 = create_address(**self.args2)
 
 		shipment = frappe.get_doc(
 			{

--- a/erpnext/stock/doctype/shipment/test_shipment.py
+++ b/erpnext/stock/doctype/shipment/test_shipment.py
@@ -5,7 +5,10 @@ from datetime import date, timedelta
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, flt, get_time, now
 
+from erpnext.accounts.doctype.account.test_account import make_company
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_address
 from erpnext.stock.doctype.delivery_note.delivery_note import make_shipment
 
 
@@ -19,6 +22,316 @@ class TestShipment(FrappeTestCase):
 		self.assertEqual(second_shipment.value_of_goods, delivery_note.grand_total)
 		self.assertEqual(len(second_shipment.shipment_delivery_note), 1)
 		self.assertEqual(second_shipment.shipment_delivery_note[0].delivery_note, delivery_note.name)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	# codecov
+	def test_validate_weight_TC_SCK_353(self):
+		company = "_Test Indian Registered Company"
+		if not frappe.db.exists("Company", company):
+			make_company(company)
+		args1 = {
+			"address_title": "Test Address1",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address1 = create_address(**args1)
+
+		args2 = {
+			"address_title": "Test Address2",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",  # lowercase corrected
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address2 = create_address(**args2)
+
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Shipment",
+				"pickup_from_type": "Company",
+				"pickup_address_name": address1.name,
+				"pickup_contact_person": "Administrator",
+				"delivery_address_name": address2.name,
+				"description_of_content": "Test Shipment",
+				"value_of_goods": 10,
+				"pickup_date": frappe.utils.now(),
+				"shipment_parcel": [{"length": 10, "width": 12, "height": 20, "weight": 0, "count": 1}],
+			}
+		)
+		msg = "Parcel weight cannot be 0"
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			shipment.insert()
+
+	# codecov
+	def test_on_submit_TC_SCK_354(self):
+		company = "_Test Indian Registered Company"
+		if not frappe.db.exists("Company", company):
+			make_company(company)
+		args1 = {
+			"address_title": "Test Address1",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address1 = create_address(**args1)
+
+		args2 = {
+			"address_title": "Test Address2",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",  # lowercase corrected
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address2 = create_address(**args2)
+
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Shipment",
+				"pickup_from_type": "Company",
+				"pickup_address_name": address1.name,
+				"pickup_contact_person": "Administrator",
+				"delivery_address_name": address2.name,
+				"description_of_content": "Test Shipment",
+				"value_of_goods": 0,
+				"pickup_date": frappe.utils.now(),
+				"shipment_parcel": [{"length": 10, "width": 12, "height": 20, "weight": 12, "count": 1}],
+			}
+		)
+		shipment.insert()
+		shipment.reload()
+		msg = "Value of goods cannot be 0"
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			shipment.submit()
+
+	# codecov
+	def test_on_submit_no_shipment_parcel_TC_SCK_355(self):
+		company = "_Test Indian Registered Company"
+		if not frappe.db.exists("Company", company):
+			make_company(company)
+		args1 = {
+			"address_title": "Test Address1",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address1 = create_address(**args1)
+
+		args2 = {
+			"address_title": "Test Address2",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",  # lowercase corrected
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address2 = create_address(**args2)
+
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Shipment",
+				"pickup_from_type": "Company",
+				"pickup_address_name": address1.name,
+				"pickup_contact_person": "Administrator",
+				"delivery_address_name": address2.name,
+				"description_of_content": "Test Shipment",
+				"value_of_goods": 0,
+				"pickup_date": frappe.utils.now(),
+			}
+		)
+		shipment.insert()
+		shipment.reload()
+		msg = "Please enter Shipment Parcel information"
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			shipment.submit()
+		shipment.reload()
+		shipment.cancel()
+
+	# codecov
+	def test_validate_pickup_time_TC_SCK_356(self):
+		company = "_Test Indian Registered Company"
+		if not frappe.db.exists("Company", company):
+			make_company(company)
+		args1 = {
+			"address_title": "Test Address1",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address1 = create_address(**args1)
+
+		args2 = {
+			"address_title": "Test Address2",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address2 = create_address(**args2)
+
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Shipment",
+				"pickup_from_type": "Company",
+				"pickup_address_name": address1.name,
+				"pickup_contact_person": "Administrator",
+				"delivery_address_name": address2.name,
+				"description_of_content": "Test Shipment",
+				"value_of_goods": 0,
+				"pickup_date": add_to_date(now(), hours=-1),
+				"pickup_from": add_to_date(now(), hours=+1),
+				"pickup_to": frappe.utils.now(),
+				"shipment_parcel": [{"length": 10, "width": 12, "height": 20, "weight": 12, "count": 1}],
+			}
+		)
+		msg = "Pickup To time should be greater than Pickup From time"
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			shipment.insert()
+
+	# codecov
+	def test_whitelisted_methods_TC_SCK_357(self):
+		from erpnext.stock.doctype.shipment.shipment import (
+			get_address_name,
+			get_company_contact,
+			get_contact_name,
+		)
+
+		company = "_Test Indian Registered Company"
+		if not frappe.db.exists("Company", company):
+			make_company(company)
+		args1 = {
+			"address_title": "Test Address1",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address1 = create_address(**args1)
+
+		args2 = {
+			"address_title": "Test Address2",
+			"address_type": "Permanent",
+			"address_line1": "Test Address1",
+			"is_primary_address": 1,
+			"state": "Karnataka",
+			"country": "India",
+			"pincode": "581115",
+			"company": company,
+			"is_your_company_address": 1,
+			"doctype": "Company",
+			"docname": company,
+		}
+		address2 = create_address(**args2)
+
+		shipment = frappe.get_doc(
+			{
+				"doctype": "Shipment",
+				"pickup_from_type": "Company",
+				"pickup_address_name": address1.name,
+				"pickup_contact_person": "Administrator",
+				"delivery_address_name": address2.name,
+				"description_of_content": "Test Shipment",
+				"value_of_goods": 0,
+				"pickup_date": add_to_date(now(), hours=+1),
+				"pickup_from": add_to_date(now(), hours=-1),
+				"pickup_to": frappe.utils.now(),
+				"shipment_parcel": [{"length": 10, "width": 12, "height": 20, "weight": 12, "count": 1}],
+			}
+		)
+		shipment.insert()
+		get_address_name("Shipment", shipment.name)
+		get_contact_name("Shipment", shipment.name)
+		self.assertEqual(shipment.pickup_address_name, address1.name)
+
+	# codecov
+	def test_get_company_contact_TC_SCK_392(self):
+		from erpnext.stock.doctype.shipment.shipment import get_company_contact
+
+		# Create test user directly
+		user_email = "testuser@example.com"
+		if frappe.db.exists("User", user_email):
+			frappe.delete_doc("User", user_email, force=1)
+
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": user_email,
+				"first_name": "Test",
+				"last_name": "User",
+				"mobile_no": "9876543210",
+				"gender": "Male",
+			}
+		).insert(ignore_permissions=True)
+
+		# Call the function
+		result = get_company_contact(user)
+
+		# Assertions
+		self.assertEqual(result["first_name"], "Test")
+		self.assertEqual(result["last_name"], "User")
+		self.assertEqual(result["email"], "testuser@example.com")
+		self.assertEqual(result["mobile_no"], "9876543210")
+		self.assertEqual(result["phone"], "9876543210")  # fallback works
+		self.assertEqual(result["gender"], "Male")
 
 	def test_get_total_weight(self):
 		shipment = frappe.new_doc("Shipment")


### PR DESCRIPTION
Title:
Shipment Validate behavior and business rules in Shipment Doctype (Parcel weight, Value, Timing, Child Tables)

Description:
Test Summary
The Shipment Doctype lacked adequate validation coverage for business-critical fields such as parcel weight, value of goods, pickup time consistency, and the presence of child records. This commit introduces comprehensive negative test cases to ensure backend validations reflect real-world scenarios and protect against data inconsistency.

The new tests reinforce system behavior around essential logistics parameters, ensuring that only well-formed and policy-compliant shipments can proceed to submission or processing stages.

Doctypes Covered:
Shipment

Shipment Parcel

Company

Address

Test Cases Implemented:
🔸 TC_SCK_353: test_validate_weight_TC_SCK_353
Creates a Shipment with a parcel weight of 0.

Validates that saving the document raises a frappe.ValidationError.

Expected Result: Error message "Parcel weight cannot be 0".

🔸 TC_SCK_354: test_on_submit_TC_SCK_354
Tests submission of a Shipment with a value_of_goods of 0.

Expected Result: Submission fails with error "Value of goods cannot be 0".

🔸 TC_SCK_355: test_on_submit_no_shipment_parcel_TC_SCK_355
Creates a Shipment without adding records to the Shipment Parcel child table.

Expected Result: ValidationError with "Please enter Shipment Parcel information".

🔸 TC_SCK_356: test_validate_pickup_time_TC_SCK_356
Sets the pickup time range such that pickup_from is greater than pickup_to.

Expected Result: Error raised with message "Pickup To time should be greater than Pickup From time".

🔸 TC_SCK_357: test_whitelisted_methods_TC_SCK_357
Tests Frappe's whitelisted methods:

get_address_name

get_contact_name

get_company_contact

Ensures each function returns expected output using test Shipment.

🔸 TC_SCK_392: test_get_company_contact_TC_SCK_392
Confirms correct linkage of company contact with the Shipment after retrieval from Frappe method.

Key Enhancements:
Introduced negative tests for edge cases like:

Zero parcel weight.

Zero goods value.

Empty Shipment Parcel child table.

Invalid pickup time ranges.

Validated core Frappe methods via backend test coverage.

Improved data protection through stricter validations.

Enhanced regression coverage for Shipment submission logic.

Scenarios Covered:
Shipment with invalid parcel weight.

Shipment with zero value of goods.

Shipment submission without child table entries.

Time logic validation in logistics scheduling.

Backend method validation for address/contact resolution.

Technology Used:
Python unittest framework

Frappe test utilities:

frappe.get_doc

frappe.get_all

frappe.set_user

make_address, make_company

Exception handling via self.assertRaises(frappe.ValidationError)

Linked Feature/Bug:
N/A

Issue ID:
N/A