### PR TITLE
test: Removed improper save from test_item_query_TC_SCK_290 test case, make_stock_entry function function creates a new SE and saves the record. 

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -980,7 +980,6 @@ class TestQualityInspection(FrappeTestCase):
 		# Link to SE item
 		for d in se.items:
 			d.quality_inspection = qi.name
-		se.save()
 		se.reload()
 		se.submit()
 


### PR DESCRIPTION
### Bug Description
A TimestampMismatchError was encountered during the execution of the test case test_item_query_TC_SCK_290. This error occurs when the document being saved has been modified elsewhere after it was last loaded. This caused the test to fail intermittently and disrupted automated test runs.

### Root Cause
The issue was triggered by calling se.save() after linking the Quality Inspection to the Stock Entry. The document was already loaded in memory, and another process (like qi.submit() or previous insert() actions) slightly updated the document's modified timestamp. As a result, the save operation failed with a timestamp mismatch.

### Steps to Reproduce:
Run the test case test_item_query_TC_SCK_290.

Let it reach the point where a Quality Inspection is created and submitted and then se.save() is called.
The save triggers check_if_latest(), which detects a timestamp mismatch.

### Actual/Observed Result:
Test case fails with frappe.exceptions.TimestampMismatchError.

### Expected Result:
The test case should complete successfully, and the document should be submitted without any timestamp conflict.

### Fix Summary
Removed the redundant call to se.save() since the document changes are already in saved state.

### Affected Module
Stock 

### Test Cases Covered
test_item_query_TC_SCK_290

### Linked Issue
Fixes #2528
