### PR TITLE
test: passed item_group also for item creation because it's a mandatory field

### DIFF
--- a/erpnext/stock/doctype/item_attribute/test_item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/test_item_attribute.py
@@ -50,6 +50,7 @@ class TestItemAttribute(FrappeTestCase):
 					"has_variants": 1,
 					"variant_based_on": "Item Attribute",
 					"gst_hsn_code": "01011010",
+					"item_group": "All Item Groups",
 					"attributes": [{"attribute": attribute.name}],
 				}
 			).insert()
@@ -63,6 +64,7 @@ class TestItemAttribute(FrappeTestCase):
 					"item_name": "Test Variant Item",
 					"variant_of": template.name,
 					"gst_hsn_code": "01011010",
+					"item_group": "All Item Groups",
 					"attributes": [{"attribute": attribute.name, "attribute_value": "Blue"}],
 				}
 			).insert()


### PR DESCRIPTION
### Bug Description
The test case test_validate_exising_items_TC_SCK_325 in the Item Attribute module was failing with a MandatoryError due to a missing item_group field when creating test Item documents. This prevented the test suite from executing successfully.

### Root Cause
When creating the Item Template (Test Template Item) and its variant (Test Variant Item), the item_group field was not provided. In ERPNext, item_group is a mandatory field for the Item doctype. As a result, the insert() operation raised a frappe.exceptions.MandatoryError.

### Steps to Reproduce:
Run the test test_validate_exising_items_TC_SCK_325.

Observe that it attempts to create a new Item without setting the item_group.

The test fails with a MandatoryError.

### Actual/Observed Result:
frappe.exceptions.MandatoryError: [Item, Test Template Item]: item_group

### Expected Result:
The test should create the item and validate attribute assignment without any mandatory field errors.

### Fix Summary
Added the item_group field ("All Item Groups") while creating the template and variant items within the test. This satisfies the mandatory field requirement and allows the test to proceed successfully.

### Affected Module
Stock 

### Test Cases Covered
test_validate_exising_items_TC_SCK_325
Linked Issue
Fixes #2585