### PR TITLE
test: allow_negative_stock setting cofiguration is not required in test_validate_stock_reservation_TC_SCK_339 test case , therefore disabled it

### DIFF
--- a/erpnext/stock/doctype/stock_settings/test_stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/test_stock_settings.py
@@ -83,7 +83,7 @@ class TestStockSettings(FrappeTestCase):
 	@change_settings(
 		"Stock Settings",
 		{
-			"allow_negative_stock": 1,
+			"allow_negative_stock": 0,
 			"enable_stock_reservation": 1,
 			"allow_to_edit_stock_uom_qty_for_sales": 0,
 		},


### PR DESCRIPTION
### Bug Description
The test case test_validate_stock_reservation_TC_SCK_339 was failing due to a validation error triggered by conflicting stock settings. Specifically, enabling Allow Negative Stock while Stock Reservation was already enabled caused a frappe.exceptions.ValidationError.

### Root Cause
ERPNext enforces a validation that prevents enabling Allow Negative Stock if Stock Reservation is active, as these two settings are logically incompatible.
In this test case, Allow Negative Stock was unnecessarily being enabled, which conflicted with the already enabled Stock Reservation setting.

### Steps to Reproduce:
Ensure Stock Reservation is enabled in Stock Settings.

Attempt to enable Allow Negative Stock via the test case.

The test will raise a ValidationError.

### Actual/Observed Result:
frappe.exceptions.ValidationError: As Stock Reservation is enabled, you can not enable Allow Negative Stock.

### Expected Result:
The test should configure only relevant stock settings and pass without triggering validation errors.

### Fix Summary
Removed the configuration of allow_negative_stock from the test case test_validate_stock_reservation_TC_SCK_339, as it was not required for the test scenario and was conflicting with the stock_reservation setting.

### Affected Module
Stock

###  Test Cases Covered
test_validate_stock_reservation_TC_SCK_339

### Linked Issue
Fixes #2586
