### PR TITLE
test: Add Test Cases for Item Validation, BOM Updates, Merging, and Item Variant Logic

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -57,7 +57,7 @@ class Item(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.stock.doctype.item_barcode.item_barcode import ItemBarcode

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -1229,8 +1229,10 @@ class TestItem(FrappeTestCase):
 			"valuation_rate": 100
 		}
 		msg = '"Customer Provided Item" cannot have Valuation Rate'
-		with self.assertRaises(frappe.ValidationError, msg=msg):
+		with self.assertRaises(frappe.ValidationError) as e:
 			item = make_item("_test_valuation_rate_item", item_fields)
+
+		self.assertIn(msg, str(e.exception))
 	
 	def test_validate_customer_provided_part_is_purchase_item_TC_SCK_392(self):
 		item_fields = {
@@ -1239,8 +1241,10 @@ class TestItem(FrappeTestCase):
 			"is_purchase_item": 1,
 		}
 		msg = '"Customer Provided Item" cannot be Purchase Item also'
-		with self.assertRaises(frappe.ValidationError, msg=msg):
+		with self.assertRaises(frappe.ValidationError) as e:
 			item = make_item("_test_purchase_item", item_fields)
+
+		self.assertIn(msg, str(e.exception))
 
 	def test_validate_set_opening_stock_TC_SCK_393(self):
 		item_fields = {
@@ -1253,8 +1257,10 @@ class TestItem(FrappeTestCase):
 			"opening_stock":1
 		}
 		msg = frappe._("Valuation Rate is mandatory if Opening Stock entered")
-		with self.assertRaises(frappe.ValidationError, msg=msg):
+		with self.assertRaises(frappe.ValidationError) as e:
 			item = make_item("_test_opening_stock_item", item_fields)
+
+		self.assertIn(msg, str(e.exception))
 		
 	def test_validate_naming_series_for_dot_TC_SCK_394(self):
 		item_fields = {
@@ -1263,8 +1269,10 @@ class TestItem(FrappeTestCase):
 		}
 
 		msg = frappe._("Invalid naming series (. missing) for Serial Number Series")
-		with self.assertRaises(frappe.ValidationError, msg=msg):
+		with self.assertRaises(frappe.ValidationError) as e:
 			make_item("_test_naming_series_item", item_fields)
+
+		self.assertIn(msg, str(e.exception))
 	
 	def test_validate_naming_series_for_hash_TC_SCK_395(self):
 		item_fields = {
@@ -1272,8 +1280,10 @@ class TestItem(FrappeTestCase):
 			"serial_no_series": "SRS. ###", 
 		}
 		msg = (frappe._("Invalid naming series (avoid spaces between '.' and '#') for Serial Number Series."))
-		with self.assertRaises(frappe.ValidationError, msg=msg):
+		with self.assertRaises(frappe.ValidationError) as e:
 			make_item("_test_naming_series_item", item_fields)
+
+		self.assertIn(msg, str(e.exception))
 	
 	def test_update_bom_item_description_TC_SCK_396(self):
 		item = make_item("_test-item-for-bom", {"is_stock_item": 1})
@@ -1346,14 +1356,10 @@ class TestItem(FrappeTestCase):
 			"attribute": "Color",
 			"attribute_values": ["Red", "Blue"]
 		})
-		msg = frappe._(
-			"The following deleted attributes exist in Variants but not in the Template. "
-			"You can either delete the Variants or keep the attribute(s) in template.\n\n"
-			"Variant Items        Attributes\n"
-			"_test_variant_attr1  Size"
-		)
-		with self.assertRaises(frappe.ValidationError, msg=msg):
+		msg = frappe._("The following deleted attributes exist in Variants but not in the Template.")
+		with self.assertRaises(frappe.ValidationError) as cm:
 			template.save()
+		self.assertIn(msg, str(cm.exception))
    
 	def test_item_autoname_with_naming_series_TC_SCK_398(self):
 		frappe.db.set_default("item_naming_by", "Naming Series")
@@ -1524,8 +1530,9 @@ class TestItem(FrappeTestCase):
 			"has_serial_no": 0,
 			"has_batch_no": 0
 		})
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(frappe.ValidationError) as e:
 			item_1.validate_properties_before_merge(item_2.name)
+		self.assertIn("To merge, following properties must be same for both items", str(e.exception))
 	
 	def test_validate_duplicate_product_bundles_before_merge_pass_TC_SCK_402(self):
 		from erpnext.stock.doctype.item.test_item import make_item
@@ -1548,8 +1555,9 @@ class TestItem(FrappeTestCase):
 				{"item_code": item_2.name, "qty": 1}
 			]
 		}).insert()
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(frappe.ValidationError) as e:
 			item_1.validate_duplicate_product_bundles_before_merge(item_1.name, item_2.name)
+		self.assertIn("Please delete Product Bundle", str(e.exception))
 	
 	def test_update_variants_TC_SCK_403(self):
 		from erpnext.stock.doctype.item.item import update_variants

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -1222,6 +1222,365 @@ class TestItem(FrappeTestCase):
 		item = make_item("_Test Book", item_fields)
 		self.assertEqual(item.name, "_Test Book")
 		self.assertEqual(item.valuation_method, "FIFO")
+	def test_validate_customer_provided_part_valuation_rate_TC_SCK_391(self):
+		item_fields = {
+			"is_stock_item": 1,
+			"is_customer_provided_item": 1,
+			"is_purchase_item": 0,
+			"valuation_rate": 100
+		}
+		msg = '"Customer Provided Item" cannot have Valuation Rate'
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			item = make_item("_test_valuation_rate_item", item_fields)
+	
+	def test_validate_customer_provided_part_is_purchase_item_TC_SCK_392(self):
+		item_fields = {
+			"is_stock_item": 1,
+			"is_customer_provided_item": 1,
+			"is_purchase_item": 1,
+		}
+		msg = '"Customer Provided Item" cannot be Purchase Item also'
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			item = make_item("_test_purchase_item", item_fields)
+
+	def test_validate_set_opening_stock_TC_SCK_393(self):
+		item_fields = {
+			"is_stock_item": 1,
+			"is_customer_provided_item": 0,
+			"standard_rate":0,
+			"valuation_rate":0,
+			"has_serial_no":0,
+			"has_batch_no":0,
+			"opening_stock":1
+		}
+		msg = frappe._("Valuation Rate is mandatory if Opening Stock entered")
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			item = make_item("_test_opening_stock_item", item_fields)
+		
+	def test_validate_naming_series_for_dot_TC_SCK_394(self):
+		item_fields = {
+			"is_stock_item": 1,
+			"serial_no_series": "SRS###",
+		}
+
+		msg = frappe._("Invalid naming series (. missing) for Serial Number Series")
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			make_item("_test_naming_series_item", item_fields)
+	
+	def test_validate_naming_series_for_hash_TC_SCK_395(self):
+		item_fields = {
+			"is_stock_item": 1,
+			"serial_no_series": "SRS. ###", 
+		}
+		msg = (frappe._("Invalid naming series (avoid spaces between '.' and '#') for Serial Number Series."))
+		with self.assertRaises(frappe.ValidationError, msg=msg):
+			make_item("_test_naming_series_item", item_fields)
+	
+	def test_update_bom_item_description_TC_SCK_396(self):
+		item = make_item("_test-item-for-bom", {"is_stock_item": 1})
+		item.description = "Initial Description"
+		item.save()
+
+		bom = frappe.get_doc({
+			"doctype": "BOM",
+			"item": item.name,
+			"quantity": 1,
+			"is_active": 1,
+			"is_default": 1,
+			"items": [{
+				"item_code": item.name,
+				"qty": 1,
+				"rate": 100
+			}]
+		})
+		bom.insert()
+		bom.submit()
+
+		item.reload()
+		item.description = "Updated BOM Description"
+		item.save()
+
+		item.update_bom_item_desc()
+
+		bom_desc = frappe.db.get_value("BOM", bom.name, "description")
+		bom_item_desc = frappe.db.get_value("BOM Item", {"parent": bom.name, "item_code": item.name}, "description")
+		explosion_desc = frappe.db.get_value("BOM Explosion Item", {"parent": bom.name, "item_code": item.name}, "description")
+		
+		self.assertEqual(bom_desc, "Updated BOM Description")
+		self.assertEqual(bom_item_desc, "Updated BOM Description")
+		self.assertEqual(explosion_desc, "Updated BOM Description")
+	
+	def test_deleted_attribute_in_template_raises_error_TC_SCK_397(self):
+		create_attribute("Color", ["Red", "Blue"])
+		create_attribute("Size", ["S", "M", "L"])
+		if not frappe.db.exists("GST HSN Code", "1445576"):
+			gst_hsn_code = frappe.new_doc("GST HSN Code")
+			gst_hsn_code.hsn_code = "14455767"
+			gst_hsn_code.save()
+		template = frappe.get_doc({
+			"doctype": "Item",
+			"item_code": "_test_variant_attr",
+			"item_group": "All Item Groups",
+			"gst_hsn_code": "14455767",
+			"has_variants":1,
+			"attributes": [
+				{"attribute": "Color", "attribute_value": "Red"},
+				{"attribute": "Size", "attribute_value": "M"}
+			]
+		}).insert(ignore_permissions=True)
+
+		variant = frappe.get_doc({
+			"doctype": "Item",
+			"item_code": "_test_variant_attr1",
+			"item_group": "All Item Groups",
+			"gst_hsn_code": "14455767",
+			"variant_of": template.name,
+			"attributes": [
+				{"attribute": "Color", "attribute_value": "Red"},
+				{"attribute": "Size", "attribute_value": "M"}
+			]
+		})
+		variant.insert(ignore_permissions=True)
+
+		template.reload()
+		template.set("attributes", [])
+		template.append("attributes", {
+			"attribute": "Color",
+			"attribute_values": ["Red", "Blue"]
+		})
+		with self.assertRaises(frappe.ValidationError) as context:
+			template.save()
+	
+ 
+	def test_item_autoname_with_naming_series_TC_SCK_398(self):
+		frappe.db.set_default("item_naming_by", "Naming Series")
+	
+		template = frappe.get_doc({
+			"doctype": "Item",
+			"item_code": "_test_variant_template",
+			"item_name": "Test Variant Template",
+			"stock_uom": "Nos",
+			"item_group": "All Item Groups",
+			"has_variants": 1,
+			"gst_hsn_code": "14455767",
+			"attributes": [{
+				"attribute": "Color",
+				"attribute_value": "Red"
+			}]
+		}).insert(ignore_permissions=True)
+
+		variant = frappe.get_doc({
+			"doctype": "Item",
+			"item_name": "Variant Without Item Code",
+			"variant_of": template.name,
+			"gst_hsn_code": "14455767",
+			"stock_uom": "Nos",
+			"item_group": "All Item Groups",
+			"attributes": [{
+				"attribute": "Color",
+				"attribute_value": "Red"
+			}]
+		})
+
+		variant.autoname()
+  
+	def test_update_template_tables_TC_SCK_399(self):
+		create_tax_accounts()
+		frappe.db.set_default("item_naming_by", "Naming Series")
+
+		if not frappe.db.exists("Item Tax Template", "Standard Tax Template - _TC"):
+			tax_template = frappe.get_doc({
+				"doctype": "Item Tax Template",
+				"title": "Standard Tax Template",
+				"gst_rate": 18,
+				"company": "_Test Company",
+				"item_tax_template_name": "Standard Tax Template",
+				"taxes": [
+					{
+						"tax_type": "CGST - _TC",
+						"tax_rate": 9
+					},
+					{
+						"tax_type": "SGST - _TC",
+						"tax_rate": 9
+					}
+				],
+				"gst_category": "Taxable"
+			})
+			tax_template.insert(ignore_permissions=True)
+
+		template = frappe.get_doc({
+			"doctype": "Item",
+			"item_code": "_test_template_tables",
+			"item_name": "Template Tables",
+			"item_group": "All Item Groups",
+			"stock_uom": "Nos",
+			"gst_hsn_code": get_hsn(),
+			"has_variants": 1,
+			"taxes": [
+				{	"item_tax_template": "Standard Tax Template - _TC",
+					"charge_type": "On Net Total",
+					"account_head": "CGST - _TC",
+					"maximum_net_rate": 9
+				},
+			],
+			"reorder_levels": [
+				{
+					"warehouse": "_Test Warehouse - _TC",
+					"warehouse_reorder_level": 10,
+					"warehouse_reorder_qty": 25,
+					"material_request_type": "Purchase"
+				}
+			],
+			"attributes": [
+				{
+					"attribute": "Color",
+					"attribute_value": "Red"
+				}
+			]
+		}).insert(ignore_permissions=True)
+
+		item = frappe.get_doc({
+			"doctype": "Item",
+			"item_code": "_test_update_template_tables",
+			"item_name": "Test Copy From Template",
+			"variant_of": template.name,
+			"item_group": "All Item Groups",
+			"stock_uom": "Nos",
+			"gst_hsn_code": get_hsn(),
+			"item_tax_template": "Standard Tax Template"
+		})
+
+		item.update_template_tables()
+
+		self.assertEqual(len(item.taxes), 1)
+		self.assertEqual(item.taxes[0].maximum_net_rate, 9)
+		self.assertEqual(len(item.reorder_levels), 1)
+		self.assertEqual(item.reorder_levels[0].warehouse_reorder_qty, 25)
+	def test_after_rename_with_merge_TC_SCK_400(self):
+		old_item = make_item("_test_old_item", {"stock_uom": "Nos"})
+
+		new_item = make_item("_test_new_item", {"stock_uom": "Nos"})
+		if not frappe.db.exists("Account", "Test Tax Account - _TC"):
+			account = frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Test Tax Account",
+					"parent_account": "Duties and Taxes - _TC",  # Change suffix to match your company abbreviation
+					"company": "_Test Company",
+					"is_group": 0,
+					"account_type": "Tax",
+				}
+			).insert()
+		invoice = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": "_Test Customer",
+				"company": "_Test Company",
+				"items": [{"item_code": old_item.name, "qty": 1, "rate": 100}],
+				"taxes": [
+					{
+						"charge_type": "On Net Total",
+						"account_head": "Test Tax Account - _TC",
+						"description": "Test Tax",
+						"item_wise_tax_detail": json.dumps(
+							{old_item.name: ["10.0", "INR"]}
+						),
+					}
+				],
+			}
+		).insert()
+
+		item_doc = frappe.get_doc("Item", new_item.name)
+		item_doc.after_rename(old_item.name, new_item.name, merge=True)
+
+		invoice.reload()
+		tax_detail = json.loads(invoice.taxes[0].item_wise_tax_detail)
+		assert new_item.name in tax_detail
+		assert old_item.name not in tax_detail
+		assert frappe.db.get_value("Item", new_item.name, "item_code") == new_item.name
+
+
+	def test_validate_properties_before_merge_TC_SCK_401(self):
+
+		item_1 = make_item("_test_item_merge_1", {
+			"stock_uom": "Nos",
+			"is_stock_item": 1,
+			"has_serial_no": 0,
+			"has_batch_no": 0
+		})
+
+		item_2 = make_item("_test_item_merge_2", {
+			"stock_uom": "Box",
+			"is_stock_item": 1,
+			"has_serial_no": 0,
+			"has_batch_no": 0
+		})
+		with self.assertRaises(frappe.ValidationError):
+			item_1.validate_properties_before_merge(item_2.name)
+	
+	def test_validate_duplicate_product_bundles_before_merge_pass_TC_SCK_402(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item_1 = make_item("_test_item_bundle_1", {"stock_uom": "Nos", "is_stock_item": 0})
+		item_2 = make_item("_test_item_bundle_2", {"stock_uom": "Nos", "is_stock_item": 0})
+
+		frappe.get_doc({
+			"doctype": "Product Bundle",
+			"new_item_code": item_1.name,
+			"items": [
+				{"item_code": item_1.name, "qty": 1}
+			]
+		}).insert()
+
+		frappe.get_doc({
+			"doctype": "Product Bundle",
+			"new_item_code": item_2.name,
+			"items": [
+				{"item_code": item_2.name, "qty": 1}
+			]
+		}).insert()
+		with self.assertRaises(frappe.ValidationError):
+			item_1.validate_duplicate_product_bundles_before_merge(item_1.name, item_2.name)
+	
+	def test_update_variants_TC_SCK_403(self):
+		from erpnext.stock.doctype.item.item import update_variants
+		create_attribute("Color", ["Red", "Blue"])
+		create_attribute("Size", ["S", "M", "L"])
+		template = frappe.get_doc(
+				{
+					"doctype": "Item",
+					"item_code": "_test_variant_attr",
+					"item_group": "All Item Groups",
+					"gst_hsn_code": get_hsn(),
+					"has_variants": 1,
+					"attributes": [
+						{"attribute": "Color", "attribute_value": "Red"},
+						{"attribute": "Size", "attribute_value": "M"},
+					],
+				}
+			).insert(ignore_permissions=True)
+
+		variant = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": "_test_variant_attr1",
+				"item_group": "All Item Groups",
+				"gst_hsn_code": get_hsn(),
+				"variant_of": template.name,
+				"attributes": [
+					{"attribute": "Color", "attribute_value": "Red"},
+					{"attribute": "Size", "attribute_value": "M"},
+				],
+			}
+		)
+		variant.insert(ignore_permissions=True)
+		variants = [variant.name]
+
+		update_variants(variants, template, publish_progress=True)
+
+		variant.reload()
+		assert variant.stock_uom == template.stock_uom
 
 def set_item_variant_settings(fields):
 	doc = frappe.get_doc("Item Variant Settings")
@@ -1294,3 +1653,74 @@ def create_item(
 	else:
 		item = frappe.get_doc("Item", item_code)
 	return item
+
+def create_attribute(name, values):
+    existing = frappe.db.get("Item Attribute", name)
+    if existing:
+        attr_doc = frappe.get_doc("Item Attribute", name)
+        existing_values = {v.attribute_value for v in attr_doc.item_attribute_values}
+        existing_abbrs = {v.abbr for v in attr_doc.item_attribute_values if v.abbr}
+
+        for v in values:
+            if v not in existing_values:
+                abbr = v[:1].upper()
+                counter = 1
+                while abbr in existing_abbrs:
+                    abbr = f"{v[:1].upper()}{counter}"
+                    counter += 1
+                attr_doc.append("item_attribute_values", {
+                    "attribute_value": v,
+                    "abbr": abbr
+                })
+                existing_abbrs.add(abbr)
+        attr_doc.save()
+    else:
+        abbrs = set()
+        value_rows = []
+        for v in values:
+            abbr = v[:1].upper()
+            counter = 1
+            while abbr in abbrs:
+                abbr = f"{v[:1].upper()}{counter}"
+                counter += 1
+            value_rows.append({
+                "attribute_value": v,
+                "abbr": abbr
+            })
+            abbrs.add(abbr)
+
+        frappe.get_doc({
+            "doctype": "Item Attribute",
+            "attribute_name": name,
+            "item_attribute_values": value_rows
+        }).insert()
+def get_hsn(hsn="14455767"):
+	if not frappe.db.exists("GST HSN Code", hsn):
+		gst_hsn_code = frappe.new_doc("GST HSN Code")
+		gst_hsn_code.hsn_code = hsn
+		gst_hsn_code.save()
+		return gst_hsn_code.name
+	else: return hsn
+ 
+def create_tax_accounts():
+	from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+	create_company()
+	if not frappe.db.exists("Account", "CGST - _TC"):
+		frappe.get_doc({
+			"doctype": "Account",
+			"account_name": "CGST",
+			"company": "_Test Company",
+			"parent_account": "Duties and Taxes - _TC",
+			"account_type": "Tax",
+			"is_group": 0
+		}).insert(ignore_permissions=True)
+
+	if not frappe.db.exists("Account", "SGST - _TC"):
+		frappe.get_doc({
+			"doctype": "Account",
+			"account_name": "SGST",
+			"company": "_Test Company",
+			"parent_account": "Duties and Taxes - _TC",
+			"account_type": "Tax",
+			"is_group": 0
+		}).insert(ignore_permissions=True)

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -12,7 +12,6 @@ from frappe.utils import add_days, today
 import re
 import random
 from erpnext.stock.doctype.warehouse.warehouse import convert_to_group_or_ledger
-
 from erpnext.controllers.item_variant import (
 	InvalidItemAttributeValueError,
 	ItemVariantExistsError,
@@ -1313,33 +1312,32 @@ class TestItem(FrappeTestCase):
 	def test_deleted_attribute_in_template_raises_error_TC_SCK_397(self):
 		create_attribute("Color", ["Red", "Blue"])
 		create_attribute("Size", ["S", "M", "L"])
-		if not frappe.db.exists("GST HSN Code", "1445576"):
-			gst_hsn_code = frappe.new_doc("GST HSN Code")
-			gst_hsn_code.hsn_code = "14455767"
-			gst_hsn_code.save()
+		
 		template = frappe.get_doc({
 			"doctype": "Item",
 			"item_code": "_test_variant_attr",
 			"item_group": "All Item Groups",
-			"gst_hsn_code": "14455767",
 			"has_variants":1,
 			"attributes": [
 				{"attribute": "Color", "attribute_value": "Red"},
 				{"attribute": "Size", "attribute_value": "M"}
 			]
-		}).insert(ignore_permissions=True)
-
+		})
+		if "india_compliance" in frappe.get_installed_apps():
+			template.gst_hsn_code = get_hsn()
+		template.insert(ignore_permissions=True)
 		variant = frappe.get_doc({
 			"doctype": "Item",
 			"item_code": "_test_variant_attr1",
 			"item_group": "All Item Groups",
-			"gst_hsn_code": "14455767",
 			"variant_of": template.name,
 			"attributes": [
 				{"attribute": "Color", "attribute_value": "Red"},
 				{"attribute": "Size", "attribute_value": "M"}
 			]
 		})
+		if "india_compliance" in frappe.get_installed_apps():
+			variant.gst_hsn_code = get_hsn()
 		variant.insert(ignore_permissions=True)
 
 		template.reload()
@@ -1348,13 +1346,17 @@ class TestItem(FrappeTestCase):
 			"attribute": "Color",
 			"attribute_values": ["Red", "Blue"]
 		})
-		with self.assertRaises(frappe.ValidationError) as context:
+		msg = frappe._(
+			"The following deleted attributes exist in Variants but not in the Template. "
+			"You can either delete the Variants or keep the attribute(s) in template.\n\n"
+			"Variant Items        Attributes\n"
+			"_test_variant_attr1  Size"
+		)
+		with self.assertRaises(frappe.ValidationError, msg=msg):
 			template.save()
-	
- 
+   
 	def test_item_autoname_with_naming_series_TC_SCK_398(self):
 		frappe.db.set_default("item_naming_by", "Naming Series")
-	
 		template = frappe.get_doc({
 			"doctype": "Item",
 			"item_code": "_test_variant_template",
@@ -1362,18 +1364,19 @@ class TestItem(FrappeTestCase):
 			"stock_uom": "Nos",
 			"item_group": "All Item Groups",
 			"has_variants": 1,
-			"gst_hsn_code": "14455767",
 			"attributes": [{
 				"attribute": "Color",
 				"attribute_value": "Red"
 			}]
-		}).insert(ignore_permissions=True)
+		})
+		if "india_compliance" in frappe.get_installed_apps():
+			template.gst_hsn_code = get_hsn()
+		template.insert(ignore_permissions=True)
 
 		variant = frappe.get_doc({
 			"doctype": "Item",
-			"item_name": "Variant Without Item Code",
+			"item_code": "Variant Without Item Code",
 			"variant_of": template.name,
-			"gst_hsn_code": "14455767",
 			"stock_uom": "Nos",
 			"item_group": "All Item Groups",
 			"attributes": [{
@@ -1381,8 +1384,13 @@ class TestItem(FrappeTestCase):
 				"attribute_value": "Red"
 			}]
 		})
-
+		if "india_compliance" in frappe.get_installed_apps():
+			template.gst_hsn_code = get_hsn()
+		
 		variant.autoname()
+		
+  		#set name as item code 
+		self.assertEqual(variant.name, "Variant Without Item Code")
   
 	def test_update_template_tables_TC_SCK_399(self):
 		create_tax_accounts()


### PR DESCRIPTION
### Test Summary
This PR adds comprehensive test coverage for various critical validations and business logic related to the Item doctype, ensuring data integrity and correctness across stock item creation, BOM updates, merging operations, and variant handling in ERPNext.

The tests focus on preventing invalid data entry (e.g., conflicting flags, improper naming series), ensuring BOM consistency, validating merge preconditions, and enforcing variant rules. They also verify updates to related records (such as Sales Invoices or BOMs) post-operations like rename with merge.

**Doctypes Covered:**
🔹 Item

**Test Cases Implemented:**

🔸 TC_SCK_425 / TC_SCK_426: Customer Provided Item Validations

Ensure a customer-provided item cannot have a valuation rate.

Ensure a customer-provided item cannot be a purchase item simultaneously.

Assert frappe.ValidationError is raised for violations.

🔸 TC_SCK_393: Opening Stock Validation

Ensure valuation rate is mandatory when opening stock is entered.

🔸 TC_SCK_427 / TC_SCK_428: Serial Number Naming Series Validation

Validate proper use of dot (.) and no spaces in serial number series format.

🔸 TC_SCK_429: Update BOM Item Description

Verify that BOM, BOM Item, and BOM Explosion Item descriptions update after item description changes.

🔸 TC_SCK_397: Deleted Attribute in Template Raises Error

Ensure deleted attributes in item templates raise validation errors when saving.

🔸 TC_SCK_430: Item Autoname with Naming Series

Verify item naming when using naming series for variants.

🔸 TC_SCK_431: Update Template Tables on Variant

Ensure variant items inherit taxes and reorder levels from the template correctly.

🔸 TC_SCK_400: After Rename With Merge

Ensure tax details on linked Sales Invoices update correctly after merging items.

🔸 TC_SCK_432: Validate Properties Before Merge

Ensure incompatible items cannot be merged (e.g., differing stock UOM).

🔸 TC_SCK_433: Validate Duplicate Product Bundles Before Merge

Ensure merging is prevented when both items are linked to product bundles.

🔸 TC_SCK_434: Update Variants

Ensure variant properties update correctly when template properties change.

**Key Enhancements:**
✔ Enforced validation logic for conflicting item properties.
✔ Strengthened merge safety with pre-merge validation checks.
✔ Improved BOM consistency and downstream document updates.
✔ Verified naming conventions and inheritance in item variants.
✔ Protected data integrity in stock and sales workflows.

### Scenarios Covered:
✅ Invalid item property combinations.
✅ Item renaming and merging with linked documents.
✅ BOM update propagation.
✅ Variant inheritance logic.
✅ Assertion-based validation using unittest framework.

### Technology Used:

Python unittest framework

frappe.ValidationError assertions

ERPNext testing utilities (e.g., make_item, create_attribute, apply_putaway_rule)

Internal ERPNext methods (update_bom_item_desc, update_variants, after_rename, etc.)

### Linked Feature/Bug:
N/A

### Issue ID:
N/A