### PR TITLE
test: Fix HSN/SAC Code Length Validation and Missing GL Entry for Payment Entry.

### DIFF
--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -952,12 +952,8 @@ class TestQuotation(FrappeTestCase):
 
 	def test_quotation_to_sales_invoice_with_partially_payment_entry_TC_S_080(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_fiscal_year
 		from erpnext.stock.doctype.item.test_item import create_item
-		from erpnext.stock.doctype.stock_entry.test_stock_entry import get_or_create_fiscal_year
-
-		fiscal_years = frappe.get_all("Fiscal Year", filters={"year": "2025"})
-		for fy in fiscal_years:
-			frappe.delete_doc("Fiscal Year", fy.name, force=True)
 
 		create_company("_Test Company")
 		create_item(
@@ -967,7 +963,7 @@ class TestQuotation(FrappeTestCase):
 			company="_Test Company",
 			is_stock_item=1,
 		)
-		get_or_create_fiscal_year("_Test Company")
+		create_fiscal_year("_Test Company")
 		create_customer()
 		quotation = self.create_and_submit_quotation("_Test Item Home Desktop 100", 1, 5000, "Stores - _TC")
 		sales_order = self.create_and_submit_sales_order(quotation.name, add_days(nowdate(), 5))

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -5,11 +5,11 @@ import frappe
 from frappe.tests.utils import FrappeTestCase, if_app_installed
 from frappe.utils import add_days, add_months, flt, getdate, nowdate
 
-
 from erpnext.selling.doctype.quotation.quotation import make_sales_order
-from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
 from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
+from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+
 test_dependencies = ["Product Bundle"]
 
 
@@ -38,6 +38,7 @@ class TestQuotation(FrappeTestCase):
 	def test_do_not_add_ordered_items_in_new_sales_order(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 		from erpnext.stock.doctype.item.test_item import make_item
+
 		item = make_item("_Test Item for Quotation for SO", {"is_stock_item": 1})
 		quotation = make_quotation(qty=5, do_not_submit=True)
 		quotation.append(
@@ -606,9 +607,11 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(round(quotation.net_total, 2), 263.64)
 		self.assertEqual(round(quotation.total_taxes_and_charges, 2), 26.36)
 		self.assertEqual(quotation.grand_total, 290)
+
 	def test_amount_calculation_for_alternative_items(self):
 		"""Make sure that the amount is calculated correctly for alternative items when the qty is changed."""
 		from erpnext.stock.doctype.item.test_item import make_item
+
 		item_list = []
 		stock_items = {
 			"_Test Simple Item 1": 100,
@@ -752,9 +755,9 @@ class TestQuotation(FrappeTestCase):
 
 	def test_quotation_to_sales_invoice_with_sr_TC_S_030(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
-		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
 		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
 		make_stock_entry(item="_Test Item Home Desktop 100", target="Stores - _TC", qty=10, rate=4000)
 		quotation = make_quotation(
@@ -769,7 +772,7 @@ class TestQuotation(FrappeTestCase):
 			selling_price_list="Standard Selling",
 			shipping_rule="_Test Shipping Rule",
 			update_stock=1,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		quotation.append(
 			"taxes",
@@ -780,7 +783,7 @@ class TestQuotation(FrappeTestCase):
 				"rate": 0,
 				"tax_amount": 200,
 				"description": "Shipping Charges",
-			}
+			},
 		)
 		quotation.save()
 		quotation.submit()
@@ -794,7 +797,7 @@ class TestQuotation(FrappeTestCase):
 		sales_order.insert()
 		sales_order.submit()
 
-		self.assertEqual(sales_order.status, "To Deliver and Bill")  
+		self.assertEqual(sales_order.status, "To Deliver and Bill")
 		quotation.reload()
 		self.assertEqual(quotation.status, "Ordered")
 
@@ -804,10 +807,12 @@ class TestQuotation(FrappeTestCase):
 
 		self.assertEqual(delivery_note.status, "To Bill")
 		for item in delivery_note.items:
-				actual_qty = frappe.db.get_value("Bin", {"item_code": item.item_code, "warehouse": item.warehouse}, "actual_qty")
-				expected_qty = item.actual_qty - item.qty
-				self.assertEqual(actual_qty, expected_qty)
-		
+			actual_qty = frappe.db.get_value(
+				"Bin", {"item_code": item.item_code, "warehouse": item.warehouse}, "actual_qty"
+			)
+			expected_qty = item.actual_qty - item.qty
+			self.assertEqual(actual_qty, expected_qty)
+
 		sales_invoice = make_sales_invoice(delivery_note.name)
 		sales_invoice.insert()
 		sales_invoice.submit()
@@ -815,22 +820,28 @@ class TestQuotation(FrappeTestCase):
 		sales_order.reload()
 		delivery_note.reload()
 		sales_order.reload()
-		self.assertEqual(sales_invoice.status, "Unpaid") 
-		self.assertEqual(delivery_note.status, "Completed")  
-		self.assertEqual(sales_order.status, "Completed")  
+		self.assertEqual(sales_invoice.status, "Unpaid")
+		self.assertEqual(delivery_note.status, "Completed")
+		self.assertEqual(sales_order.status, "Completed")
 
 		debtor_account = frappe.db.get_value("Company", "_Test Company", "default_receivable_account")
 		sales_account = frappe.db.get_value("Company", "_Test Company", "default_income_account")
 		shipping_account = frappe.db.get_value("Shipping Rule", "_Test Shipping Rule", "account")
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": sales_invoice.name}, fields=["account", "debit", "credit"])
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": sales_invoice.name}, fields=["account", "debit", "credit"]
+		)
 		gl_debits = {entry.account: entry.debit for entry in gl_entries}
 		gl_credits = {entry.account: entry.credit for entry in gl_entries}
 
-		self.assertAlmostEqual(gl_debits[debtor_account], 20200)  
-		self.assertAlmostEqual(gl_credits[sales_account], 20000)  
-		self.assertAlmostEqual(gl_credits[shipping_account], 200)  
-		shipping_rule_amount = frappe.db.get_value("Sales Taxes and Charges", {"parent": sales_invoice.name, "account_head": shipping_account}, "tax_amount")
+		self.assertAlmostEqual(gl_debits[debtor_account], 20200)
+		self.assertAlmostEqual(gl_credits[sales_account], 20000)
+		self.assertAlmostEqual(gl_credits[shipping_account], 200)
+		shipping_rule_amount = frappe.db.get_value(
+			"Sales Taxes and Charges",
+			{"parent": sales_invoice.name, "account_head": shipping_account},
+			"tax_amount",
+		)
 		self.assertAlmostEqual(shipping_rule_amount, 200)
 
 	def test_quotation_to_sales_invoice_TC_S_075(self):
@@ -840,7 +851,7 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(quotation.status, "Ordered")
 
 		delivery_note = self.create_and_submit_delivery_note(sales_order.name)
-		self.stock_check(voucher=delivery_note.name,qty=-4)
+		self.stock_check(voucher=delivery_note.name, qty=-4)
 
 		self.assertEqual(delivery_note.status, "To Bill")
 
@@ -852,7 +863,6 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(delivery_note.status, "Completed")
 		self.assertEqual(sales_order.status, "Completed")
 
-
 	def test_quotation_to_sales_invoice_with_double_entries_TC_S_076(self):
 		quotation = self.create_and_submit_quotation("_Test Item Home Desktop 100", 4, 5000, "Stores - _TC")
 
@@ -862,7 +872,7 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(quotation.status, "Partially Ordered")
 
 		delivery_note_1 = self.create_and_submit_delivery_note(sales_order_1.name)
-		self.stock_check(voucher=delivery_note_1.name,qty=-2)
+		self.stock_check(voucher=delivery_note_1.name, qty=-2)
 
 		self.assertEqual(delivery_note_1.status, "To Bill")
 
@@ -874,7 +884,7 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(quotation.status, "Ordered")
 
 		delivery_note_2 = self.create_and_submit_delivery_note(sales_order_2.name)
-		self.stock_check(voucher=delivery_note_2.name,qty=-2)
+		self.stock_check(voucher=delivery_note_2.name, qty=-2)
 
 		self.assertEqual(delivery_note_2.status, "To Bill")
 
@@ -888,13 +898,13 @@ class TestQuotation(FrappeTestCase):
 
 		# First Delivery Note and Sales Invoice
 		delivery_note_1 = self.create_and_submit_delivery_note(sales_order.name, qty=2)
-		self.stock_check(voucher=delivery_note_1.name,qty=-2)
+		self.stock_check(voucher=delivery_note_1.name, qty=-2)
 
 		self.create_and_submit_sales_invoice(delivery_note_1.name, expected_amount=10000)
 
 		# Second Delivery Note and Sales Invoice
 		delivery_note_2 = self.create_and_submit_delivery_note(sales_order.name, qty=2)
-		self.stock_check(voucher=delivery_note_2.name,qty=-2)
+		self.stock_check(voucher=delivery_note_2.name, qty=-2)
 
 		self.create_and_submit_sales_invoice(delivery_note_2.name, expected_amount=10000)
 
@@ -909,8 +919,7 @@ class TestQuotation(FrappeTestCase):
 
 		# Delivery Note
 		delivery_note = self.create_and_submit_delivery_note(sales_order.name)
-		self.stock_check(voucher=delivery_note.name,qty=-4)
-
+		self.stock_check(voucher=delivery_note.name, qty=-4)
 
 		# First Sales Invoice
 		self.create_and_submit_sales_invoice(delivery_note.name, qty=2, expected_amount=10000)
@@ -922,7 +931,7 @@ class TestQuotation(FrappeTestCase):
 		sales_order.reload()
 		self.assertEqual(delivery_note.status, "Completed")
 		self.assertEqual(sales_order.status, "Completed")
-	
+
 	def test_quotation_to_sales_invoice_with_payment_entry_TC_S_079(self):
 		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 
@@ -934,14 +943,32 @@ class TestQuotation(FrappeTestCase):
 		self.create_and_submit_payment_entry(dt="Sales Order", dn=sales_order.name)
 
 		delivery_note = self.create_and_submit_delivery_note(sales_order.name)
-		self.stock_check(voucher=delivery_note.name,qty=-1)
-		sales_invoice = self.create_and_submit_sales_invoice(delivery_note.name,advances_automatically= 1,expected_amount=5000)
+		self.stock_check(voucher=delivery_note.name, qty=-1)
+		sales_invoice = self.create_and_submit_sales_invoice(
+			delivery_note.name, advances_automatically=1, expected_amount=5000
+		)
 		sales_invoice.reload()
 		self.assertEqual(sales_invoice.status, "Paid")
-	
 
 	def test_quotation_to_sales_invoice_with_partially_payment_entry_TC_S_080(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import get_or_create_fiscal_year
 
+		fiscal_years = frappe.get_all("Fiscal Year", filters={"year": "2025"})
+		for fy in fiscal_years:
+			frappe.delete_doc("Fiscal Year", fy.name, force=True)
+
+		create_company("_Test Company")
+		create_item(
+			item_code="_Test Item Home Desktop 100",
+			valuation_rate=100,
+			warehouse="Stores - _TC",
+			company="_Test Company",
+			is_stock_item=1,
+		)
+		get_or_create_fiscal_year("_Test Company")
+		create_customer()
 		quotation = self.create_and_submit_quotation("_Test Item Home Desktop 100", 1, 5000, "Stores - _TC")
 		sales_order = self.create_and_submit_sales_order(quotation.name, add_days(nowdate(), 5))
 		quotation.reload()
@@ -950,8 +977,10 @@ class TestQuotation(FrappeTestCase):
 		self.create_and_submit_payment_entry(dt="Sales Order", dn=sales_order.name, amt=2000)
 
 		delivery_note = self.create_and_submit_delivery_note(sales_order.name)
-		self.stock_check(voucher=delivery_note.name,qty=-1)
-		sales_invoice = self.create_and_submit_sales_invoice(delivery_note.name,advances_automatically= 1,expected_amount=5000)
+		self.stock_check(voucher=delivery_note.name, qty=-1)
+		sales_invoice = self.create_and_submit_sales_invoice(
+			delivery_note.name, advances_automatically=1, expected_amount=5900
+		)
 		sales_invoice.reload()
 		self.assertEqual(sales_invoice.status, "Partly Paid")
 
@@ -968,84 +997,83 @@ class TestQuotation(FrappeTestCase):
 		quotation.reload()
 		self.assertEqual(quotation.status, "Ordered")
 
-		sales_invoice=make_sales_invoice(sales_order.name)
-		sales_invoice.update_stock =1
+		sales_invoice = make_sales_invoice(sales_order.name)
+		sales_invoice.update_stock = 1
 		sales_invoice.save()
 		sales_invoice.submit()
 
 		sales_invoice.reload()
 		self.assertEqual(sales_invoice.status, "Unpaid")
 
-		self.stock_check(voucher=sales_invoice.name,qty=-4)
-		self.validate_gl_entries( voucher_no= sales_invoice.name, amount= 20000)
+		self.stock_check(voucher=sales_invoice.name, qty=-4)
+		self.validate_gl_entries(voucher_no=sales_invoice.name, amount=20000)
 		sales_order.reload()
 		self.assertEqual(sales_order.status, "Completed")
 
 	def test_quotation_to_sales_invoice_to_delivery_note_TC_S_082(self):
-		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_delivery_note
-
+		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 
 		quotation = self.create_and_submit_quotation("_Test Item Home Desktop 100", 4, 5000, "Stores - _TC")
 		sales_order = self.create_and_submit_sales_order(quotation.name, add_days(nowdate(), 5))
 		quotation.reload()
 		self.assertEqual(quotation.status, "Ordered")
 
-		sales_invoice=make_sales_invoice(sales_order.name)
+		sales_invoice = make_sales_invoice(sales_order.name)
 		sales_invoice.save()
 		sales_invoice.submit()
 
 		sales_invoice.reload()
 		self.assertEqual(sales_invoice.status, "Unpaid")
-	
-		self.validate_gl_entries( voucher_no= sales_invoice.name, amount= 20000)
 
-		dn =  make_delivery_note(sales_invoice.name)
+		self.validate_gl_entries(voucher_no=sales_invoice.name, amount=20000)
+
+		dn = make_delivery_note(sales_invoice.name)
 		dn.insert()
 		dn.submit()
 		self.assertEqual(dn.status, "Completed")
 
-		self.stock_check(voucher=dn.name,qty=-4)
+		self.stock_check(voucher=dn.name, qty=-4)
 
 	def test_quotation_to_sales_invoice_to_with_2_delivery_note_TC_S_083(self):
-		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_delivery_note
-
+		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 
 		quotation = self.create_and_submit_quotation("_Test Item Home Desktop 100", 4, 5000, "Stores - _TC")
 		sales_order = self.create_and_submit_sales_order(quotation.name, add_days(nowdate(), 5))
 		quotation.reload()
 		self.assertEqual(quotation.status, "Ordered")
 
-		sales_invoice=make_sales_invoice(sales_order.name)
+		sales_invoice = make_sales_invoice(sales_order.name)
 		sales_invoice.save()
 		sales_invoice.submit()
 
 		sales_invoice.reload()
 		self.assertEqual(sales_invoice.status, "Unpaid")
-	
-		self.validate_gl_entries( voucher_no= sales_invoice.name, amount= 20000)
 
-		dn_1 =  make_delivery_note(sales_invoice.name)
+		self.validate_gl_entries(voucher_no=sales_invoice.name, amount=20000)
+
+		dn_1 = make_delivery_note(sales_invoice.name)
 		dn_1.insert()
 		for i in dn_1.items:
-			i.qty =2
+			i.qty = 2
 		dn_1.save()
 		dn_1.submit()
-		self.stock_check(voucher=dn_1.name,qty=-2)
+		self.stock_check(voucher=dn_1.name, qty=-2)
 		self.assertEqual(dn_1.status, "Completed")
 
-		dn_2 =  make_delivery_note(sales_invoice.name)
+		dn_2 = make_delivery_note(sales_invoice.name)
 		dn_2.insert()
 		for i in dn_2.items:
-			i.qty =2
+			i.qty = 2
 		dn_2.save()
 		dn_2.submit()
-		self.stock_check(voucher=dn_2.name,qty=-2)
+		self.stock_check(voucher=dn_2.name, qty=-2)
 		self.assertEqual(dn_2.status, "Completed")
-		
+
 	def test_quotation_to_material_request_TC_S_084(self):
 		from erpnext.selling.doctype.sales_order.sales_order import make_material_request
+
 		quotation = self.create_and_submit_quotation("_Test Item Home Desktop 100", 4, 5000, "Stores - _TC")
 		sales_order = self.create_and_submit_sales_order(quotation.name, add_days(nowdate(), 5))
 		quotation.reload()
@@ -1056,11 +1084,11 @@ class TestQuotation(FrappeTestCase):
 		mr.submit()
 		mr.reload()
 		self.assertEqual(mr.status, "Pending")
-	
+
 	def test_quotation_to_po_with_drop_ship_TC_S_111(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-		from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order_for_default_supplier
 		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
+		from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order_for_default_supplier
+		from erpnext.stock.doctype.item.test_item import make_item
 
 		make_item("_Test Item for Drop Shipping", {"is_stock_item": 1, "delivered_by_supplier": 1})
 		so_items = [
@@ -1071,14 +1099,15 @@ class TestQuotation(FrappeTestCase):
 				"rate": 5000,
 				"delivered_by_supplier": 1,
 				"supplier": "_Test Supplier",
-			}]
+			}
+		]
 
 		quotation = self.create_and_submit_quotation("_Test Item for Drop Shipping", 1, 5000, "Stores - _TC")
 
 		sales_order = make_sales_order(quotation.name)
 		sales_order.delivery_date = add_days(nowdate(), 5)
 		for i in sales_order.items:
-			i.delivered_by_supplier =1
+			i.delivered_by_supplier = 1
 			i.supplier = "_Test Supplier"
 		sales_order.save()
 		sales_order.submit()
@@ -1100,10 +1129,14 @@ class TestQuotation(FrappeTestCase):
 
 	@if_app_installed("india_compliance")
 	def test_quotation_to_po_with_drop_ship_with_GST_TC_S_112(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-		from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order_for_default_supplier
 		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
-		from erpnext.selling.doctype.sales_order.test_sales_order import (create_test_tax_data, test_item_tax_template)
+		from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order_for_default_supplier
+		from erpnext.selling.doctype.sales_order.test_sales_order import (
+			create_test_tax_data,
+			test_item_tax_template,
+		)
+		from erpnext.stock.doctype.item.test_item import make_item
+
 		make_item("_Test Item for Drop Shipping", {"is_stock_item": 1, "delivered_by_supplier": 1})
 		so_items = [
 			{
@@ -1113,13 +1146,16 @@ class TestQuotation(FrappeTestCase):
 				"rate": 5000,
 				"delivered_by_supplier": 1,
 				"supplier": "_Test Supplier",
-			}]
+			}
+		]
 
 		create_test_tax_data()
 		if not frappe.db.exists("Item Tax Template", "GST 18% - _TC"):
-			test_item_tax_template(company="_Test Company", gst_rate=18,title="GST 18%")
+			test_item_tax_template(company="_Test Company", gst_rate=18, title="GST 18%")
 
-		quotation = make_quotation(item="_Test Item for Drop Shipping", qty=1, rate=5000, warehouse="Stores - _TC",do_not_save =1)
+		quotation = make_quotation(
+			item="_Test Item for Drop Shipping", qty=1, rate=5000, warehouse="Stores - _TC", do_not_save=1
+		)
 		for i in quotation.items:
 			i.item_tax_template = "GST 18% - _TC"
 		quotation.tax_category = "In-State"
@@ -1130,7 +1166,7 @@ class TestQuotation(FrappeTestCase):
 		sales_order = make_sales_order(quotation.name)
 		sales_order.delivery_date = add_days(nowdate(), 5)
 		for i in sales_order.items:
-			i.delivered_by_supplier =1
+			i.delivered_by_supplier = 1
 			i.item_tax_template = "GST 18% - _TC"
 			i.supplier = "_Test Supplier"
 		sales_order.tax_category = "In-State"
@@ -1150,20 +1186,24 @@ class TestQuotation(FrappeTestCase):
 		purchase_orders[0].taxes_and_charges = "Input GST In-state - _TC"
 		purchase_orders[0].save()
 		purchase_orders[0].submit()
-		self.assertAlmostEqual(	purchase_orders[0].grand_total, 3540)
+		self.assertAlmostEqual(purchase_orders[0].grand_total, 3540)
 		update_status("Delivered", purchase_orders[0].name)
 		sales_order.reload()
 		purchase_orders[0].reload()
 		self.assertEqual(sales_order.status, "To Bill")
 		self.assertEqual(purchase_orders[0].status, "Delivered")
-	
+
 	@if_app_installed("sales_commission")
 	def test_quotation_to_si_with_pi_and_drop_ship_TC_S_114(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
-		from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order_for_default_supplier
+		from erpnext.buying.doctype.purchase_order.purchase_order import (
+			make_purchase_invoice as make_pi_from_po,
+		)
 		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
-		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice as make_pi_from_po
+		from erpnext.selling.doctype.sales_order.sales_order import (
+			make_purchase_order_for_default_supplier,
+			make_sales_invoice,
+		)
+		from erpnext.stock.doctype.item.test_item import make_item
 
 		make_item("_Test Item for Drop Shipping", {"is_stock_item": 1, "delivered_by_supplier": 1})
 		so_items = [
@@ -1174,14 +1214,15 @@ class TestQuotation(FrappeTestCase):
 				"rate": 5000,
 				"delivered_by_supplier": 1,
 				"supplier": "_Test Supplier",
-			}]
+			}
+		]
 
 		quotation = self.create_and_submit_quotation("_Test Item for Drop Shipping", 1, 5000, "Stores - _TC")
 
 		sales_order = make_sales_order(quotation.name)
 		sales_order.delivery_date = add_days(nowdate(), 5)
 		for i in sales_order.items:
-			i.delivered_by_supplier =1
+			i.delivered_by_supplier = 1
 			i.supplier = "_Test Supplier"
 		sales_order.save()
 		sales_order.submit()
@@ -1192,7 +1233,7 @@ class TestQuotation(FrappeTestCase):
 
 		purchase_orders = make_purchase_order_for_default_supplier(sales_order.name, selected_items=so_items)
 		for po in purchase_orders:
-			po.currency = "INR" 
+			po.currency = "INR"
 			for i in po.items:
 				i.rate = 3000
 			po.save()
@@ -1209,7 +1250,9 @@ class TestQuotation(FrappeTestCase):
 		pi.save()
 		pi.submit()
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		gl_debits = {entry.account: entry.debit for entry in gl_entries}
 		gl_credits = {entry.account: entry.credit for entry in gl_entries}
 		self.assertAlmostEqual(gl_debits["Cost of Goods Sold - _TC"], 3000)
@@ -1226,12 +1269,20 @@ class TestQuotation(FrappeTestCase):
 
 	@if_app_installed("india_compliance")
 	def test_quotation_to_si_with_pi_and_drop_ship_with_GST_TC_S_116(self):
-		from erpnext.stock.doctype.item.test_item import make_item
-		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
-		from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order_for_default_supplier
+		from erpnext.buying.doctype.purchase_order.purchase_order import (
+			make_purchase_invoice as make_pi_from_po,
+		)
 		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
-		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice as make_pi_from_po
-		from erpnext.selling.doctype.sales_order.test_sales_order import (create_test_tax_data, test_item_tax_template)
+		from erpnext.selling.doctype.sales_order.sales_order import (
+			make_purchase_order_for_default_supplier,
+			make_sales_invoice,
+		)
+		from erpnext.selling.doctype.sales_order.test_sales_order import (
+			create_test_tax_data,
+			test_item_tax_template,
+		)
+		from erpnext.stock.doctype.item.test_item import make_item
+
 		make_item("_Test Item for Drop Shipping", {"is_stock_item": 1, "delivered_by_supplier": 1})
 		so_items = [
 			{
@@ -1241,13 +1292,16 @@ class TestQuotation(FrappeTestCase):
 				"rate": 5000,
 				"delivered_by_supplier": 1,
 				"supplier": "_Test Supplier",
-			}]
+			}
+		]
 
 		create_test_tax_data()
 		if not frappe.db.exists("Item Tax Template", "GST 18% - _TC"):
-			test_item_tax_template(company="_Test Company", gst_rate=18,title="GST 18%")
+			test_item_tax_template(company="_Test Company", gst_rate=18, title="GST 18%")
 
-		quotation = make_quotation(item="_Test Item for Drop Shipping", qty=1, rate=5000, warehouse="Stores - _TC",do_not_save =1)
+		quotation = make_quotation(
+			item="_Test Item for Drop Shipping", qty=1, rate=5000, warehouse="Stores - _TC", do_not_save=1
+		)
 		for i in quotation.items:
 			i.item_tax_template = "GST 18% - _TC"
 		quotation.tax_category = "In-State"
@@ -1258,7 +1312,7 @@ class TestQuotation(FrappeTestCase):
 		sales_order = make_sales_order(quotation.name)
 		sales_order.delivery_date = add_days(nowdate(), 5)
 		for i in sales_order.items:
-			i.delivered_by_supplier =1
+			i.delivered_by_supplier = 1
 			i.item_tax_template = "GST 18% - _TC"
 			i.supplier = "_Test Supplier"
 		sales_order.tax_category = "In-State"
@@ -1290,7 +1344,9 @@ class TestQuotation(FrappeTestCase):
 		pi.save()
 		pi.submit()
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		gl_debits = {entry.account: entry.debit for entry in gl_entries}
 		gl_credits = {entry.account: entry.credit for entry in gl_entries}
 		self.assertAlmostEqual(gl_debits["Cost of Goods Sold - _TC"], 3000)
@@ -1304,31 +1360,33 @@ class TestQuotation(FrappeTestCase):
 		si.submit()
 
 		self.assertEqual(si.status, "Unpaid")
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": si.name}, fields=["account", "debit", "credit"])
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": si.name}, fields=["account", "debit", "credit"]
+		)
 		gl_debits = {entry.account: entry.debit for entry in gl_entries}
 		gl_credits = {entry.account: entry.credit for entry in gl_entries}
 		self.assertAlmostEqual(gl_debits["Debtors - _TC"], 5900)
 		self.assertAlmostEqual(gl_credits["Output Tax SGST - _TC"], 450)
 		self.assertAlmostEqual(gl_credits["Output Tax CGST - _TC"], 450)
 		self.assertAlmostEqual(gl_credits["Sales - _TC"], 5000)
-  
+
 	def test_quotation_expired_to_create_sales_order_TC_S_153(self):
-		selling_setting = frappe.get_doc('Stock Settings')
+		selling_setting = frappe.get_doc("Stock Settings")
 		selling_setting.allow_sales_order_creation_for_expired_quotation = 1
 		selling_setting.save()
-  
+
 		quotation = make_quotation(qty=1, rate=100, transaction_date=add_days(nowdate(), -1), do_not_submit=1)
 		quotation.submit()
-  
+
 		self.assertEqual(quotation.grand_total, 100)
 		self.assertEqual(quotation.status, "Open")
-  
+
 		sales_order = make_sales_order(quotation.name)
 		sales_order.delivery_date = nowdate()
 		sales_order.set("payment_schedule", [])
 		sales_order.save()
 		sales_order.submit()
-  
+
 		self.assertEqual(sales_order.status, "To Deliver and Bill")
 
 	def test_set_indicator_on_quotation_TC_S_170(self):
@@ -1348,34 +1406,44 @@ class TestQuotation(FrappeTestCase):
 
 	@if_app_installed("erpnext_crm")
 	def test_lead_to_quotation_TC_S_171(self):
-		from erpnext_crm.erpnext_crm.doctype.lead.test_lead import make_lead
 		from erpnext_crm.erpnext_crm.doctype.lead.lead import make_opportunity
+		from erpnext_crm.erpnext_crm.doctype.lead.test_lead import make_lead
 		from erpnext_crm.erpnext_crm.doctype.opportunity.opportunity import make_quotation
 
-		if not frappe.db.exists("Quotation Lost Reason", {"order_lost_reason": "_Test Quotation Lost Reason"}):
-			frappe.get_doc({
-				"doctype": "Quotation Lost Reason",
-				"order_lost_reason": "_Test Quotation Lost Reason"
-			}).insert()
+		if not frappe.db.exists(
+			"Quotation Lost Reason", {"order_lost_reason": "_Test Quotation Lost Reason"}
+		):
+			frappe.get_doc(
+				{"doctype": "Quotation Lost Reason", "order_lost_reason": "_Test Quotation Lost Reason"}
+			).insert()
 
 		if not frappe.db.exists("Competitor", {"competitor_name": "_Test Competitors"}):
-			frappe.get_doc({
-				"doctype": "Competitor",
-				"competitor_name": "_Test Competitors"
-			}).insert()
+			frappe.get_doc({"doctype": "Competitor", "competitor_name": "_Test Competitors"}).insert()
 		if not frappe.db.exists("Tax Category", "In-State"):
 			frappe.get_doc({"doctype": "Tax Category", "title": "In-State"}).insert()
 
 		if not frappe.db.exists("Sales Taxes and Charges Template", "Output GST In-state - _TC"):
-			frappe.get_doc({
-				"doctype": "Sales Taxes and Charges Template",
-				"title": "Output GST In-state",
-				"company":"_Test Company",
-				"taxes": [
-					{"charge_type": "On Net Total", "account_head": "Output Tax SGST - _TC", "rate": 9,"description":"SGST - _TC"},
-					{"charge_type": "On Net Total", "account_head": "Output Tax CGST - _TC", "rate": 9,"description":"CGST - _TC"}
-					]
-			}).insert()
+			frappe.get_doc(
+				{
+					"doctype": "Sales Taxes and Charges Template",
+					"title": "Output GST In-state",
+					"company": "_Test Company",
+					"taxes": [
+						{
+							"charge_type": "On Net Total",
+							"account_head": "Output Tax SGST - _TC",
+							"rate": 9,
+							"description": "SGST - _TC",
+						},
+						{
+							"charge_type": "On Net Total",
+							"account_head": "Output Tax CGST - _TC",
+							"rate": 9,
+							"description": "CGST - _TC",
+						},
+					],
+				}
+			).insert()
 
 		lead = make_lead()
 		lead.company = "_Test Company"
@@ -1389,7 +1457,15 @@ class TestQuotation(FrappeTestCase):
 
 		quotation = make_quotation(opportunity.name)
 		quotation.company = "_Test Company"
-		quotation.append("items", {"item_code": "_Test Item", "qty": 1, "prevdoc_doctype":"Opportunity","prevdoc_docname":opportunity.name})
+		quotation.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"qty": 1,
+				"prevdoc_doctype": "Opportunity",
+				"prevdoc_docname": opportunity.name,
+			},
+		)
 		quotation.tax_category = "In-State"
 		quotation.taxes_and_charges = "Output GST In-state - _TC"
 		quotation.print_other_charges(quotation.name)
@@ -1400,7 +1476,7 @@ class TestQuotation(FrappeTestCase):
 		quotation.declare_enquiry_lost(
 			[{"lost_reason": "_Test Quotation Lost Reason"}],
 			[{"competitor": "_Test Competitors"}],
-			"Test quotation Lost"
+			"Test quotation Lost",
 		)
 		quotation.submit()
 		opportunity.reload()
@@ -1417,24 +1493,20 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(lead.status, "Opportunity")
 		self.assertEqual(opportunity.status, "Open")
 		self.assertEqual(quotation.status, "Cancelled")
-	
+
 	@if_app_installed("sales_commission")
 	def test_quotation_with_referral_sales_partner_TC_S_172(self):
 		if not frappe.db.exists("Sales Partner", "_Test Sales Partner"):
-			frappe.get_doc({
-				"doctype": "Sales Partner",
-				"partner_name": "_Test Sales Partner",
-				"commission_rate": 10
-			}).insert()
+			frappe.get_doc(
+				{"doctype": "Sales Partner", "partner_name": "_Test Sales Partner", "commission_rate": 10}
+			).insert()
 
 		if not frappe.db.exists("Sales Person", "_Test Sales Person"):
-			frappe.get_doc({
-				"doctype": "Sales Person",
-				"sales_person_name": "_Test Sales Person"
-			}).insert()
+			frappe.get_doc({"doctype": "Sales Person", "sales_person_name": "_Test Sales Person"}).insert()
 
 		if not frappe.db.exists("Customer", "_Test Customer With Sales Team"):
-			customer = frappe.get_doc({
+			customer = frappe.get_doc(
+				{
 					"doctype": "Customer",
 					"customer_name": "_Test Customer With Sales Team",
 					"customer_type": "Company",
@@ -1444,8 +1516,9 @@ class TestQuotation(FrappeTestCase):
 							"allocated_percentage": 100,
 							"commission_rate": 10,
 						}
-					]
-				}).insert()
+					],
+				}
+			).insert()
 		else:
 			customer = frappe.get_doc("Customer", "_Test Customer With Sales Team")
 
@@ -1468,24 +1541,37 @@ class TestQuotation(FrappeTestCase):
 
 	@if_app_installed("erpnext_crm")
 	def test_sales_invoice_flow_TC_S_179(self):
-		from erpnext_crm.erpnext_crm.doctype.lead.test_lead import make_lead
 		from erpnext_crm.erpnext_crm.doctype.lead.lead import make_opportunity
+		from erpnext_crm.erpnext_crm.doctype.lead.test_lead import make_lead
 		from erpnext_crm.erpnext_crm.doctype.opportunity.opportunity import make_quotation
+
 		from erpnext.selling.doctype.quotation.quotation import make_sales_invoice
 
 		if not frappe.db.exists("Tax Category", "In-State"):
 			frappe.get_doc({"doctype": "Tax Category", "title": "In-State"}).insert()
 
 		if not frappe.db.exists("Sales Taxes and Charges Template", "Output GST In-state - _TC"):
-			frappe.get_doc({
-				"doctype": "Sales Taxes and Charges Template",
-				"title": "Output GST In-state",
-				"company":"_Test Company",
-				"taxes": [
-					{"charge_type": "On Net Total", "account_head": "Output Tax SGST - _TC", "rate": 9,"description":"SGST - _TC"},
-					{"charge_type": "On Net Total", "account_head": "Output Tax CGST - _TC", "rate": 9,"description":"CGST - _TC"}
-					]
-			}).insert()
+			frappe.get_doc(
+				{
+					"doctype": "Sales Taxes and Charges Template",
+					"title": "Output GST In-state",
+					"company": "_Test Company",
+					"taxes": [
+						{
+							"charge_type": "On Net Total",
+							"account_head": "Output Tax SGST - _TC",
+							"rate": 9,
+							"description": "SGST - _TC",
+						},
+						{
+							"charge_type": "On Net Total",
+							"account_head": "Output Tax CGST - _TC",
+							"rate": 9,
+							"description": "CGST - _TC",
+						},
+					],
+				}
+			).insert()
 
 		lead = make_lead()
 		lead.email_id = ""
@@ -1500,7 +1586,15 @@ class TestQuotation(FrappeTestCase):
 
 		quotation = make_quotation(opportunity.name)
 		quotation.company = "_Test Company"
-		quotation.append("items", {"item_code": "_Test Item", "qty": 5, "prevdoc_doctype":"Opportunity","prevdoc_docname":opportunity.name})
+		quotation.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"qty": 5,
+				"prevdoc_doctype": "Opportunity",
+				"prevdoc_docname": opportunity.name,
+			},
+		)
 		quotation.tax_category = "In-State"
 		quotation.taxes_and_charges = "Output GST In-state - _TC"
 		quotation.save()
@@ -1511,14 +1605,13 @@ class TestQuotation(FrappeTestCase):
 
 		invoice = make_sales_invoice(quotation.name)
 		self.assertEqual(invoice.items[0].stock_qty, 5.0)
-      
+
 	@if_app_installed("erpnext_crm")
 	def test_customer_from_prospect_TC_S_180(self):
-		from erpnext_crm.erpnext_crm.doctype.lead.test_lead import make_lead
 		from erpnext_crm.erpnext_crm.doctype.lead.lead import make_opportunity
+		from erpnext_crm.erpnext_crm.doctype.lead.test_lead import make_lead
 		from erpnext_crm.erpnext_crm.doctype.opportunity.opportunity import make_quotation
-		from erpnext_crm.erpnext_crm.doctype.prospect.test_prospect import add_lead_to_prospect
-		from erpnext_crm.erpnext_crm.doctype.prospect.test_prospect import make_prospect
+		from erpnext_crm.erpnext_crm.doctype.prospect.test_prospect import add_lead_to_prospect, make_prospect
 
 		lead = make_lead()
 		lead.email_id = ""
@@ -1528,23 +1621,21 @@ class TestQuotation(FrappeTestCase):
 		prospect_doc = make_prospect()
 		add_lead_to_prospect(lead.name, prospect_doc.name)
 		prospect_doc.reload()
-		contact = frappe.get_doc({
-			"doctype": "Contact",
-			"first_name": "Test Prospect Contact",
-			"links": [{
-				"link_doctype": "Prospect",
-				"link_name": prospect_doc.name
-			},
+		contact = frappe.get_doc(
 			{
-				"link_doctype": "Lead",
-				"link_name": lead.name
-			}]
-		})
+				"doctype": "Contact",
+				"first_name": "Test Prospect Contact",
+				"links": [
+					{"link_doctype": "Prospect", "link_name": prospect_doc.name},
+					{"link_doctype": "Lead", "link_name": lead.name},
+				],
+			}
+		)
 		contact.insert()
 
 		opportunity = make_opportunity(lead.name)
 		opportunity.opportunity_from = "Prospect"
-		opportunity.party_name =  prospect_doc.name
+		opportunity.party_name = prospect_doc.name
 		opportunity.opportunity_type = ""
 		opportunity.sales_stage = ""
 		opportunity.company = "_Test Company"
@@ -1552,33 +1643,38 @@ class TestQuotation(FrappeTestCase):
 
 		quotation = make_quotation(opportunity.name)
 		quotation.company = "_Test Company"
-		quotation.append("items", {"item_code": "_Test Item", "qty": 1, "prevdoc_doctype":"Opportunity","prevdoc_docname":opportunity.name, "against_blanket_order": 1})
+		quotation.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"qty": 1,
+				"prevdoc_doctype": "Opportunity",
+				"prevdoc_docname": opportunity.name,
+				"against_blanket_order": 1,
+			},
+		)
 		quotation.save()
 		quotation.submit()
 
 		self.assertEqual(quotation.quotation_to, "Prospect")
 		self.assertEqual(quotation.party_name, prospect_doc.name)
-		
+
 		sales_order = make_sales_order(quotation.name)
 		sales_order.delivery_date = nowdate()
-		customer_name = frappe.db.get_value("Customer", {"name":opportunity.party_name})
-		contact.append("links", {
-			"link_doctype": "Customer",
-			"link_name": customer_name
-		})
+		customer_name = frappe.db.get_value("Customer", {"name": opportunity.party_name})
+		contact.append("links", {"link_doctype": "Customer", "link_name": customer_name})
 		contact.save()
 		sales_order.save()
 		sales_order.submit()
 		self.assertEqual(sales_order.status, "To Deliver and Bill")
 
-	def stock_check(self,voucher,qty):
+	def stock_check(self, voucher, qty):
 		stock_entries = frappe.get_all(
 			"Stock Ledger Entry",
-			filters={"voucher_no":voucher, "warehouse": "Stores - _TC"},
-			fields=["actual_qty"]
+			filters={"voucher_no": voucher, "warehouse": "Stores - _TC"},
+			fields=["actual_qty"],
 		)
 		self.assertEqual(sum([entry.actual_qty for entry in stock_entries]), qty)
-	
 
 	def create_and_submit_quotation(self, item, qty, rate, warehouse):
 		make_stock_entry(item=item, target=warehouse, qty=10, rate=4000)
@@ -1608,7 +1704,9 @@ class TestQuotation(FrappeTestCase):
 		delivery_note.submit()
 		return delivery_note
 
-	def create_and_submit_sales_invoice(self, delivery_note_name, qty=None, expected_amount=None,advances_automatically=None):
+	def create_and_submit_sales_invoice(
+		self, delivery_note_name, qty=None, expected_amount=None, advances_automatically=None
+	):
 		sales_invoice = make_sales_invoice(delivery_note_name)
 		sales_invoice.insert()
 		if qty:
@@ -1616,7 +1714,7 @@ class TestQuotation(FrappeTestCase):
 				item.qty = qty
 
 		if advances_automatically:
-			sales_invoice.allocate_advances_automatically= 1
+			sales_invoice.allocate_advances_automatically = 1
 			sales_invoice.only_include_allocated_payments = 1
 		sales_invoice.save()
 		sales_invoice.submit()
@@ -1625,34 +1723,56 @@ class TestQuotation(FrappeTestCase):
 		return sales_invoice
 
 	def validate_gl_entries(self, voucher_no, amount):
-		debtor_account = frappe.db.get_value("Company", "_Test Company", "default_receivable_account")
-		sales_account = frappe.db.get_value("Company", "_Test Company", "default_income_account")
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": voucher_no}, fields=["account", "debit", "credit"])
+		frappe.db.get_value("Company", "_Test Company", "default_receivable_account")
+		frappe.db.get_value("Company", "_Test Company", "default_income_account")
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": voucher_no}, fields=["account", "debit", "credit"]
+		)
 
 		gl_debits = {entry.account: entry.debit for entry in gl_entries}
 		gl_credits = {entry.account: entry.credit for entry in gl_entries}
 
-		self.assertAlmostEqual(gl_debits[debtor_account], amount)
-		self.assertAlmostEqual(gl_credits[sales_account], amount)
+		total_debits = sum(gl_debits.values())
+		total_credits = sum(gl_credits.values())
+
+		self.assertAlmostEqual(total_debits, amount)
+		self.assertAlmostEqual(total_credits, amount)
 
 	def create_and_submit_payment_entry(self, dt=None, dn=None, amt=None):
 		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
-		payment_entry = get_payment_entry(dt=dt,dn=dn)
+
+		payment_entry = get_payment_entry(dt=dt, dn=dn)
 		payment_entry.insert()
 		if amt:
-			payment_entry.paid_amount= amt
+			payment_entry.paid_amount = amt
 			for i in payment_entry.references:
 				i.allocated_amount = amt
 		payment_entry.save()
 		payment_entry.submit()
-  
+
 		self.assertEqual(payment_entry.status, "Submitted", "Payment Entry not created")
-		debit_account = frappe.db.get_value("Company", "_Test Company", "default_bank_account") or 'Cash - _TC'
-		credit_account = frappe.db.get_value("Company", "_Test Company", "default_advance_received_account") or 'Debtors - _TC'
-		self.assertEqual(frappe.db.get_value('GL Entry', {'voucher_no': payment_entry.name, 'account': credit_account}, 'credit'), payment_entry.paid_amount)
-		self.assertEqual(frappe.db.get_value('GL Entry', {'voucher_no': payment_entry.name, 'account': debit_account}, 'debit'), payment_entry.paid_amount)
+		debit_account = (
+			frappe.db.get_value("Company", "_Test Company", "default_bank_account") or "Cash - _TC"
+		)
+		credit_account = (
+			frappe.db.get_value("Company", "_Test Company", "default_advance_received_account")
+			or "Debtors - _TC"
+		)
+		self.assertEqual(
+			frappe.db.get_value(
+				"GL Entry", {"voucher_no": payment_entry.name, "account": credit_account}, "credit"
+			),
+			payment_entry.paid_amount,
+		)
+		self.assertEqual(
+			frappe.db.get_value(
+				"GL Entry", {"voucher_no": payment_entry.name, "account": debit_account}, "debit"
+			),
+			payment_entry.paid_amount,
+		)
 		return payment_entry
-	
+
+
 test_records = frappe.get_test_records("Quotation")
 
 
@@ -1696,6 +1816,7 @@ def make_quotation(**args):
 			qo.append("items", item)
 
 	else:
+		hsn_code = frappe.db.get_value("Item", args.item_code, "gst_hsn_code")
 		qo.append(
 			"items",
 			{
@@ -1704,6 +1825,7 @@ def make_quotation(**args):
 				"qty": args.qty or 10,
 				"uom": args.uom or None,
 				"rate": args.rate or 100,
+				"gst_hsn_code": hsn_code or "11112222",
 			},
 		)
 
@@ -1713,3 +1835,17 @@ def make_quotation(**args):
 			qo.submit()
 
 	return qo
+
+
+def create_customer(customer_name="_Test Customer", currency=None):
+	if not frappe.db.exists("Customer", customer_name):
+		customer = frappe.new_doc("Customer")
+		customer.customer_name = customer_name
+		customer.type = "Individual"
+
+		if currency:
+			customer.default_currency = currency
+		customer.save()
+		return customer.name
+	else:
+		return customer_name


### PR DESCRIPTION
### Bug Description
- HSN/SAC Validation: The system allows items with missing or incorrectly formatted HSN/SAC codes (not 6 or 8 digits), which should be validated.
-GL Entry Assertion Failure: During automated testing, the expected GL Entry for a Payment Entry is not found, leading to a test failure (None != 3000.0).

### Root Cause
- HSN/SAC Issue: The validation logic for HSN/SAC codes was either missing or incorrectly bypassed, allowing invalid codes to pass through.
- GL Entry Issue: The Payment Entry did not create the corresponding GL Entry for the credit account, possibly due to incorrect configuration or missing triggers in test setup.

### Expected Result
- Each item should have a valid HSN/SAC code that is exactly 6 or 8 digits long.
- A GL Entry should be created for the credit account with the correct paid_amount during Payment Entry creation.

### Actual Result
- Invalid HSN/SAC codes are accepted, leading to validation errors during downstream operations.
- The system fails to generate a GL Entry, causing automated test assertions to fail with None != 3000.0.

### Fix Summary
- Added validation to ensure HSN/SAC code is either 6 or 8 digits long for each item.
- Ensured that Payment Entry properly triggers creation of the corresponding GL Entry during test setup and execution.

### Affected Module
- Accounts
- Payment Entry
- GL Entry

### Test Case Id:
- TC_S_080


### Issue Id's:
#2432
