### PR TITLE
test: Invalid Fiscal Year Format in Delivery Note Trends Report Test

### DIFF
--- a/erpnext/stock/report/delivery_note_trends/test_delivery_note_trends.py
+++ b/erpnext/stock/report/delivery_note_trends/test_delivery_note_trends.py
@@ -32,6 +32,7 @@ class TestDeliveryNoteTrendsReport(unittest.TestCase):
 		).insert(ignore_permissions=True)
 		self.dn.submit()
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+
 		get_or_create_fiscal_year("_Test Company")
 
 	def test_execute_with_valid_filters_T_DNT_001(self):
@@ -63,7 +64,7 @@ class TestDeliveryNoteTrendsReport(unittest.TestCase):
 		filters = frappe._dict(
 			{
 				"company": "_Test Company",
-				"fiscal_year": "2024-2025",
+				"fiscal_year": "2025",
 				"based_on": "Customer",
 				"group_by": "Item",
 				"period": "Monthly",
@@ -87,7 +88,7 @@ class TestDeliveryNoteTrendsReport(unittest.TestCase):
 		filters = frappe._dict(
 			{
 				"company": "_Test Company",
-				"fiscal_year": "2024-2025",
+				"fiscal_year": "2025",
 				"based_on": "Customer",
 				"group_by": "Item",
 				"period": "Monthly",


### PR DESCRIPTION
### Title: 
Fix: Invalid Fiscal Year Format in Delivery Note Trends Report Test

### Bug Description
The test case test_execute_with_fiscal_year_filter_T_DNT_002 failed due to the use of an invalid fiscal year format ("2024-2025"), which does not match any existing Fiscal Year in the test database. This caused a ValidationError.

### Root Cause
The test was referencing a fiscal year "2024-2025", which wasn't available in the test environment.
ERPNext expects the fiscal_year filter to be a valid Fiscal Year document, and the missing record caused the test to fail.

Steps to Reproduce:

Run the test suite for Delivery Note Trends report.

The test test_execute_with_fiscal_year_filter_T_DNT_002 fails with a ValidationError.

Actual Result: Validation error due to missing fiscal year.
Expected Result: Test should execute and return valid report structure.

### Fix Summary
Replaced the fiscal year "2024-2025" with "2025", a known valid fiscal year in the test system, ensuring the report executes successfully.

### Affected Module
erpnext.stock.report.delivery_note_trends

### Test Cases Covered
test_execute_with_fiscal_year_filter_T_DNT_002

### Linked Issue
None

### PR Reference
None