### PR TITLE
test: Test Coverage for ERPNext Purchase Receipt Trends – Filters, Edge Cases, and Chart Data

### DIFF
--- a/erpnext/stock/report/purchase_receipt_trends/test_purchase_receipt_trends.py
+++ b/erpnext/stock/report/purchase_receipt_trends/test_purchase_receipt_trends.py
@@ -1,0 +1,168 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import getdate
+
+from erpnext.stock.doctype.item.test_item import create_item
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import (
+	make_purchase_receipt,
+)
+from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+from erpnext.stock.report.purchase_receipt_trends.purchase_receipt_trends import (
+	execute,
+	get_chart_data,
+)
+
+
+class TestPurchaseReceiptTrendsReport(FrappeTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.company = frappe.get_doc("Company", "_Test Company")
+
+		# Fetch dynamic accounts
+		self.expense_account = frappe.get_value("Company", self.company.name, "default_expense_account")
+		self.inventory_account = frappe.get_value("Company", self.company.name, "default_inventory_account")
+		self.payable_account = frappe.get_value("Company", self.company.name, "default_payable_account")
+		self.stock_received_account = frappe.get_value(
+			"Company", self.company.name, "stock_received_but_not_billed"
+		)
+		self.stock_adjustment_account = frappe.get_value(
+			"Company", self.company.name, "stock_adjustment_account"
+		)
+		self.cost_center = frappe.get_value("Company", self.company.name, "cost_center")
+
+		assert all(
+			[
+				self.expense_account,
+				self.inventory_account,
+				self.payable_account,
+				self.stock_received_account,
+				self.stock_adjustment_account,
+				self.cost_center,
+			]
+		), "One or more required company account fields are missing"
+
+		self.supplier_names = []
+		self.purchase_receipts = []
+		self.warehouse = create_warehouse("_Test PR Trends WH")
+
+		for i in range(12):
+			supplier_name = f"Test Supplier {i}"
+			if not frappe.db.exists("Supplier", supplier_name):
+				supplier = frappe.get_doc(
+					{"doctype": "Supplier", "supplier_name": supplier_name, "supplier_type": "Company"}
+				).insert()
+			else:
+				supplier = frappe.get_doc("Supplier", supplier_name)
+
+			self.supplier_names.append(supplier.name)
+
+			item = create_item(item_code=f"_Test Item Chart {i}", is_stock_item=1, stock_uom="Nos")
+			item.set("item_defaults", [])
+			item.append(
+				"item_defaults",
+				{
+					"company": self.company.name,
+					"expense_account": self.expense_account,
+					"default_warehouse": self.warehouse,
+					"buying_cost_center": self.cost_center,
+				},
+			)
+			item.save()
+
+			pr = make_purchase_receipt(
+				company=self.company.name,
+				supplier=supplier.name,
+				item_code=item.name,
+				qty=1,
+				rate=100 + i,
+				warehouse=self.warehouse,
+			)
+			pr.submit()
+			self.purchase_receipts.append(pr)
+
+		self.default_filters = frappe._dict(
+			{
+				"company": self.company.name,
+				"fiscal_year": "2025",
+				"based_on": "Supplier",
+				"group_by": "Item",
+				"period": "Monthly",
+				"period_based_on": "posting_date",
+			}
+		)
+
+	def tearDown(self):
+		for pr in self.purchase_receipts:
+			if frappe.db.exists("Purchase Receipt", pr.name):
+				doc = frappe.get_doc("Purchase Receipt", pr.name)
+				if doc.docstatus == 1:
+					doc.cancel()
+
+		for supplier in self.supplier_names:
+			if frappe.db.exists("Supplier", supplier):
+				supplier = frappe.get_doc("Supplier", supplier)
+				supplier.disabled = 1
+
+		if frappe.db.exists("Fiscal Year", "2099-2100"):
+			frappe.delete_doc("Fiscal Year", "2099-2100", force=True)
+
+	def test_execute_with_valid_filters_T_PRT_001(self):
+		cols, data, none_val, chart = execute(self.default_filters)
+
+		self.assertIsInstance(cols, list)
+		self.assertGreater(len(cols), 0)
+
+		self.assertIsInstance(data, list)
+		self.assertGreater(len(data), 0)
+
+		self.assertIsInstance(chart, dict)
+		self.assertIn("datasets", chart["data"])
+		self.assertIn("labels", chart["data"])
+
+	def test_execute_with_empty_data_T_PRT_002(self):
+		if not frappe.db.exists("Fiscal Year", "2099-2100"):
+			frappe.get_doc(
+				{
+					"doctype": "Fiscal Year",
+					"year": "2099-2100",
+					"year_start_date": getdate("2099-04-01"),
+					"year_end_date": getdate("2100-03-31"),
+					"disabled": 0,
+					"companies": [{"company": self.company.name}],
+				}
+			).insert(ignore_permissions=True)
+
+		filters = frappe._dict(
+			{
+				"company": self.company.name,
+				"fiscal_year": "2099-2100",
+				"based_on": "Supplier",
+				"group_by": "Item",
+				"period": "Monthly",
+				"period_based_on": "posting_date",
+			}
+		)
+
+		cols, data, none_val, chart = execute(filters)
+		self.assertEqual(data, [])
+
+	def test_chart_data_top_10_cutoff_T_PRT_003(self):
+		_, data, _, _ = execute(self.default_filters)
+		chart = get_chart_data(data, self.default_filters)
+
+		self.assertGreater(len(chart["data"]["labels"]), 0)
+		self.assertLessEqual(len(chart["data"]["labels"]), 10)
+
+	def test_chart_data_without_group_by_T_PRT_004(self):
+		filters = self.default_filters.copy()
+		del filters["group_by"]
+
+		_, data, _, _ = execute(filters)
+		chart = get_chart_data(data, filters)
+
+		self.assertLessEqual(len(chart["data"]["labels"]), 10)
+
+	def test_chart_data_with_no_data_T_PRT_005(self):
+		data = []
+		chart = get_chart_data(data, self.default_filters)
+		self.assertTrue(chart == [] or chart == {})

--- a/erpnext/stock/report/purchase_receipt_trends/test_purchase_receipt_trends.py
+++ b/erpnext/stock/report/purchase_receipt_trends/test_purchase_receipt_trends.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import getdate
 
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import (
 	make_purchase_receipt,
@@ -16,6 +17,7 @@ from erpnext.stock.report.purchase_receipt_trends.purchase_receipt_trends import
 class TestPurchaseReceiptTrendsReport(FrappeTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
+		create_company()
 		self.company = frappe.get_doc("Company", "_Test Company")
 
 		# Fetch dynamic accounts
@@ -92,19 +94,7 @@ class TestPurchaseReceiptTrendsReport(FrappeTestCase):
 		)
 
 	def tearDown(self):
-		for pr in self.purchase_receipts:
-			if frappe.db.exists("Purchase Receipt", pr.name):
-				doc = frappe.get_doc("Purchase Receipt", pr.name)
-				if doc.docstatus == 1:
-					doc.cancel()
-
-		for supplier in self.supplier_names:
-			if frappe.db.exists("Supplier", supplier):
-				supplier = frappe.get_doc("Supplier", supplier)
-				supplier.disabled = 1
-
-		if frappe.db.exists("Fiscal Year", "2099-2100"):
-			frappe.delete_doc("Fiscal Year", "2099-2100", force=True)
+		frappe.db.rollback()
 
 	def test_execute_with_valid_filters_T_PRT_001(self):
 		cols, data, none_val, chart = execute(self.default_filters)


### PR DESCRIPTION
### Title: 
Add Test Cases for Purchase Receipt Trends Report

### Test Summary:
This test suite adds automated test cases for the Purchase Receipt Trends report in ERPNext. The purpose is to ensure the report behaves correctly under different conditions, including valid inputs, empty datasets, missing filters, and chart edge cases. It covers both the execute() report logic and get_chart_data() function responsible for preparing chart configurations.

### Scenarios Covered
Input Validations
test_execute_with_valid_filters_T_PRT_001
Validates that when all required filters (company, fiscal_year, based_on, group_by, etc.) are provided, the report returns a list of columns, non-empty data, and a properly formatted chart dictionary including datasets and labels.

test_execute_with_empty_data_T_PRT_002
Simulates a scenario with a fiscal year that has no transactions and confirms the report handles it gracefully by returning an empty dataset and chart.

Edge Cases
test_chart_data_top_10_cutoff_T_PRT_003
Ensures the report chart only includes up to 10 items (suppliers/items/months) even if more data is available, keeping chart rendering performant and readable.

test_chart_data_without_group_by_T_PRT_004
Confirms that even when the group_by filter is not set, the report executes without errors and still limits chart labels to 10 items.

test_chart_data_with_no_data_T_PRT_005
Validates that get_chart_data() handles completely empty report data correctly by returning an empty or safe chart object (empty dict or list).

API Response Handling
test_execute_with_valid_filters_T_PRT_001
Verifies that the tuple returned by execute() includes:

test_chart_data_top_10_cutoff_T_PRT_003
Confirms the structure of chart["data"] adheres to expectations, especially ensuring consistent frontend compatibility with top-10 datasets.

### Technology:

Framework: FrappeTestCase (Frappe's built-in test framework)

### Linked Feature/Bug:

None
