### PR TITLE
test: Add Unit Tests for Stock Projected Quantity Report with Item Code, UOM, and Shortage Quantity Validations

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -7161,8 +7161,6 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		return payment_entry
 
 	def validate_gl_entries(self, voucher_no, amount):
-		frappe.db.get_value("Company", "_Test Company", "default_receivable_account")
-		frappe.db.get_value("Company", "_Test Company", "default_income_account")
 		gl_entries = frappe.get_all(
 			"GL Entry", filters={"voucher_no": voucher_no}, fields=["account", "debit", "credit"]
 		)

--- a/erpnext/stock/report/batch_item_expiry_status/test_batch_item_expiry_stats.py
+++ b/erpnext/stock/report/batch_item_expiry_status/test_batch_item_expiry_stats.py
@@ -1,0 +1,38 @@
+import frappe
+from frappe.utils import add_days, today
+
+from erpnext.stock.report.batch_item_expiry_status.batch_item_expiry_status import execute
+
+
+class TestExpiryReportValidateFilters(frappe.tests.utils.FrappeTestCase):
+	def test_missing_all_filters_T_BIES_001(self):
+		# No filters passed
+		with self.assertRaises(frappe.ValidationError) as cm:
+			execute({})
+		self.assertIn("Please select the required filters", str(cm.exception))
+
+	def test_missing_from_date_T_BIES_002(self):
+		# Only to_date provided
+		filters = {"to_date": today()}
+		with self.assertRaises(frappe.ValidationError) as cm:
+			execute(filters)
+		self.assertIn("'From Date' is required", str(cm.exception))
+
+	def test_missing_to_date_T_BIES_003(self):
+		# Only from_date provided
+		filters = {"from_date": today()}
+		with self.assertRaises(frappe.ValidationError) as cm:
+			execute(filters)
+		self.assertIn("'To Date' is required", str(cm.exception))
+
+	def test_valid_filters_T_BIES_004(self):
+		# All required filters provided, should not raise
+		filters = {
+			"from_date": today(),
+			"to_date": add_days(today(), 10),
+		}
+		# Should not raise any ValidationError
+		try:
+			columns, data = execute(filters)
+		except frappe.ValidationError:
+			self.fail("execute() raised ValidationError unexpectedly!")

--- a/erpnext/stock/report/stock_projected_qty/test_stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/test_stock_projected_qty.py
@@ -1,0 +1,76 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+from erpnext.accounts.doctype.payment_ledger_entry.test_payment_ledger_entry import make_sales_order
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_territory
+from erpnext.stock.doctype.item.test_item import create_item
+from erpnext.stock.doctype.stock_entry.test_stock_entry import get_or_create_fiscal_year
+from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+# from your_module_path import execute
+from erpnext.stock.report.stock_projected_qty.stock_projected_qty import execute
+
+
+class TestStockReorderReportExecute(FrappeTestCase):
+	def setUp(self):
+		self.company = create_company("_Test Company")
+		self.company = "_Test Company"
+		self.warehouse = create_warehouse(warehouse_name="_Test Warehouse - _TC", company="_Test Company")
+		self.item_code = create_item(
+			item_code="TEST-STOCK-ITEM",
+			valuation_rate=100,
+			warehouse="_Test Warehouse - _TC",
+			company="_Test Company",
+		)
+
+		# self.item_code = "TEST-ITEM-EXEC"
+		self.uom_name = "Box"
+		self.stock_uom = "Nos"
+
+		# Create UOM if not exists
+		if not frappe.db.exists("UOM", self.uom_name):
+			frappe.get_doc({"doctype": "UOM", "uom_name": self.uom_name}).insert()
+
+	def test_execute_with_item_code_filter_T_SPQ_001(self):
+		"""Ensure only filtered item_code is returned in execute()"""
+		columns, data = execute({"item_code": "TEST-STOCK-ITEM"})
+		item_codes = [row[0] for row in data]
+		self.assertIn(self.item_code.name, item_codes)
+		self.assertEqual(len(set(item_codes)), 1)  # Ensure only 1 item is returned
+		self.assertEqual(item_codes[0], self.item_code.name)
+
+	def test_execute_with_include_uom_T_SPQ_002(self):
+		"""Ensure UOM conversion factor is applied in execute() when include_uom is used"""
+		columns, data = execute({"item_code": self.item_code.name, "include_uom": self.uom_name})
+		uom_col_index = [col["fieldname"] for col in columns].index("stock_uom")
+		self.assertTrue(any(row[uom_col_index] == self.stock_uom for row in data))
+		# self.assertTrue(any(row[uom_col_index] == self.stock_uom for row in data))
+		for row in data:
+			self.assertEqual(row[uom_col_index], self.stock_uom)
+
+		conversion_col_index = [col["fieldname"] for col in columns].index(
+			"stock_uom"
+		)  # or separate if extended
+		self.assertTrue(any(row[conversion_col_index] for row in data))
+
+	def test_execute_shortage_qty_calculation_T_SPQ_003(self):
+		"""Test that shortage quantity is calculated when reorder level > projected_qty"""
+		columns, data = execute({"item_code": self.item_code.name})
+		shortage_index = [col["fieldname"] for col in columns].index("shortage_qty")
+		shortages = [row[shortage_index] for row in data]
+		self.assertTrue(any(s == 0 for s in shortages))
+		shortage_index = [col["fieldname"] for col in columns].index("shortage_qty")
+		reorder_index = [col["fieldname"] for col in columns].index("re_order_level")
+		projected_index = [col["fieldname"] for col in columns].index("projected_qty")
+
+		for row in data:
+			reorder_level = row[reorder_index]
+			projected_qty = row[projected_index]
+			shortage_qty = row[shortage_index]
+
+			if reorder_level and reorder_level > projected_qty:
+				expected_shortage = reorder_level - projected_qty
+				self.assertEqual(shortage_qty, expected_shortage)
+			else:
+				self.assertEqual(shortage_qty, 0)


### PR DESCRIPTION
### Title: Unit Tests for Stock Projected Quantity Report (stock_projected_qty) Execution

### Test Summary:
- This test suite validates the behavior of the execute function used in the ERPNext Stock Projected Quantity report. It ensures that item filtering, unit of measure inclusion, and shortage quantity calculations are functioning as expected.
- The tests are written using the Frappe test framework and simulate a controlled environment by creating necessary test data such as companies, warehouses, items, and UOMs.

### Scenarios Covered:
**T_SPQ_001 – Filter by Item Code:**
- Verifies that only the specified item_code is returned in the report output.

**T_SPQ_002 – Include UOM in Report:**
-Ensures that the report includes UOM conversion and correctly displays the stock UOM when include_uom filter is applied.

**T_SPQ_003 – Shortage Quantity Calculation:**
- Confirms that shortage quantity is computed correctly:
- If reorder_level > projected_qty, then shortage_qty = reorder_level - projected_qty.
- Otherwise, shortage_qty = 0.

**Technology:**
- Framework: Frappe Test Framework (Python-based)
- ERP: ERPNext Stock Module
- Language: Python

### Test Case Id:
- T_SPQ_001
- T_SPQ_002
- T_SPQ_003

### API/Report Execution
N/A

### Linked Feature/Bug
N/A

### Issue Tracker ID
N/A