### PR TITLE
fix: Corrected address state from "Test State" to "Maharashtra" in test data

### DIFF
--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -24,7 +24,7 @@ def create_test_contact_and_address():
 			"address_type": "Office",
 			"address_line1": "Station Road",
 			"city": "_Test City",
-			"state": "Test State",
+			"state": "Maharashtra",
 			"country": "India",
 			"links": [{"link_doctype": "Customer", "link_name": "_Test Customer"}],
 		}


### PR DESCRIPTION
Title: fix: Corrected address state from "Test State" to "Maharashtra" in test data

Description:

Bug Description
The test data for address creation used a placeholder value "Test State" which did not reflect realistic or valid data in certain test environments. This could lead to confusion during validation or integration with real-world workflows and address validation logic.

Root Cause
The static test address data had "state": "Test State" which was not aligned with expected standardized state names.

Steps to Reproduce:

Run create_test_contact_and_address() function.

Check the generated Address record.

Observe the state field value.

Actual/Observed Result:
State field was populated with "Test State".

Expected Result:
State field should reflect a valid real-world state like "Maharashtra".

Fix Summary
Replaced the hardcoded "Test State" with "Maharashtra" in the test data setup function create_test_contact_and_address().

Affected Module
Delivery Trip

Test Cases Covered
test_on_save_and_cancel_TC_SCK_306

test_process_route_TC_SCK_307

Linked Issue
Fixes [#2629](https://github.com/8848digital/erpnext/issues/2629)

PR Reference
[ValidationError: Please select a valid State from available options #2629](https://github.com/8848digital/erpnext/issues/2629)
