### PR TITLE
test: Fix: Prevent AssertionError in test_territory_wise_sales_report_TC_S_221 by Skipping Tax Category

### DIFF
--- a/erpnext/selling/report/territory_wise_sales/test_territory_wise_sales.py
+++ b/erpnext/selling/report/territory_wise_sales/test_territory_wise_sales.py
@@ -29,15 +29,21 @@ class TestTerritoryWiseSales(FrappeTestCase):
 
 		qo = make_quotation(op.name)
 		qo.items[0].warehouse = "_Test Warehouse - _TC"
+		qo.taxes_and_charges = ""
+		qo.taxes = []
 		qo.insert(ignore_permissions=True)
 		qo.submit()
 
 		so = make_sales_order(qo.name)
 		so.delivery_date = add_days(today(), 2)
+		so.taxes_and_charges = ""
+		so.taxes = []
 		so.insert(ignore_permissions=True)
 		so.submit()
 
 		si = make_sales_invoice(so.name)
+		si.taxes_and_charges = ""
+		si.taxes = []
 		si.insert(ignore_permissions=True)
 		si.submit()
 		filters = frappe._dict(


### PR DESCRIPTION
### Title: 
-  Prevent AssertionError in test_territory_wise_sales_report_TC_S_221 by Skipping Tax Category

### Bug Description
- The test case test_territory_wise_sales_report_TC_S_221 failed in the due to tax rates 

### Root Cause
- The test was referencing a total amount of 100 for quotation, sales order, sales invoice. Because tax rates and gst is not required for this test case

### Steps to Reproduce:

- Create any of quotaion, sales order and sales invoice and select tax category then grand total willl change accordingly

- The test test_territory_wise_sales_report_TC_S_221 fails with a AssertionError.

#### Actual Result 
 - AssertionError error due to missmatch of expected grand total and actual grand total.
#### Expected Result 
 - Test should execute and checks all the documents grand total amount.

### Fix Summary 
- not selecting any tax category while creating documents

### Affected Module
- Selling
### Test Cases Covered
- test_territory_wise_sales_report_TC_S_221

### Linked Issue
- #2633 

### PR Reference
- None