### PR TITLE
test: fixed local variable issue in test_make_purchase_order_for_default_supplier_coverage_TC_S_191 test case

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -7913,8 +7913,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 			address.insert(ignore_permissions=True)
 
 		so = make_sales_order(item_list=so_items, do_not_submit=True)
-		if address:
-			so.shipping_address_name = address.name
+		so.shipping_address_name = "_Test Address so-Billing-1"
 		so.submit()
 
 		po1 = make_purchase_order_for_default_supplier(so.name)


### PR DESCRIPTION
### Bug Description
The test case test_make_purchase_order_for_default_supplier_coverage_TC_S_191 was failing due to an UnboundLocalError. The test was attempting to reference the variable address before it was properly assigned. This caused the test to crash and blocked the validation of automated purchase order creation for the default supplier scenario.

### Root Cause
In the test case, the address variable was referenced inside a conditional block without being initialized.
Steps to reproduce:

Run the test case: test_make_purchase_order_for_default_supplier_coverage_TC_S_191

Observe the crash at line 7915 in test_sales_order.py

### Actual Result:
UnboundLocalError: local variable 'address' referenced before assignment

### Expected Result:
The test should use a valid address for the shipping_address_name field without throwing any error.

### Fix Summary
The unassigned variable address was removed from the condition. Instead, the test now explicitly assigns a valid test address string:
so.shipping_address_name = "_Test Address so-Billing-1"
This ensures that the test runs without referencing an undefined variable.

### Affected Module
Selling

### Test Cases Covered
test_make_purchase_order_for_default_supplier_coverage_TC_S_191


### Linked Issue
Fixes #2600