### PR TITLE
test: check if address exists and then create GST-registered billing address for test company and customers

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -7056,6 +7056,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 
 		create_registered_company()
 		create_registered_customer()
+		create_registered_address_for_gst_entities()
 		get_or_create_fiscal_year("_Test Indian Registered Company")
 		create_test_warehouse(
 			name="Stores - _TIRC", warehouse_name="Stores", company="_Test Indian Registered Company"
@@ -8425,6 +8426,34 @@ def create_registered_customer():
 			}
 		)
 		address.insert()
+
+
+def create_registered_address_for_gst_entities():
+	if not frappe.db.exists("Address", "_Test Indian Registered Company-Billing"):
+		address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"name": "_Test Indian Registered Company-Billing",
+				"address_title": "_Test Indian Registered Company",
+				"address_type": "Billing",
+				"address_line1": "Test Address - 1",
+				"city": "Test City",
+				"state": "Gujarat",
+				"pincode": "380015",
+				"country": "India",
+				"gstin": "24AAQCA8719H1ZC",
+				"gst_category": "Registered Regular",
+				"is_primary_address": 1,
+				"is_company_address": 1,
+				"is_shipping_address": 1,
+				"links": [
+					{"link_doctype": "Company", "link_name": "_Test Indian Registered Company"},
+					{"link_doctype": "Customer", "link_name": "_Test Registered Customer"},
+					{"link_doctype": "Customer", "link_name": "_Test Registered Composition Customer"},
+				],
+			}
+		)
+		address.insert(ignore_permissions=True)
 
 
 def create_exchange_rate(date):


### PR DESCRIPTION
### Bug Description
The test case test_sales_order_create_si_via_partial_pe_dn_with_gst_TC_S_043 was failing with an IndexError. The error occurred while trying to access the company billing address for a GST-registered company. Since the expected address record (_Test Indian Registered Company-Billing) was missing, the get_gst_details(...) method returned an empty list, causing the test to crash.

### Root Cause
The method create_and_submit_sales_order_with_gst expected a pre-created billing address linked to both the company and customer entities. However, while create_registered_company() and create_registered_customer() created the required parties, the corresponding Address document with GST details was never created.

### Steps to reproduce:

Run test_sales_order_create_si_via_partial_pe_dn_with_gst_TC_S_043 in a clean test environment.

Observe failure at this line:

company_add = get_gst_details("Address", {"name": "_Test Indian Registered Company-Billing"})[0]
### Actual Result:
Test fails with IndexError: list index out of range.

### Expected Result:
Test should fetch valid address and proceed with Sales Order submission.

### Fix Summary
A new utility method create_registered_address_for_gst_entities() was added to create the missing billing address record with appropriate GST fields and entity links. This method is now invoked as part of the test setup to ensure all dependencies are satisfied.

### Affected Module
GST Validation in Sales Order flow

Address creation and linkage for test entities

### Test Cases Covered
test_sales_order_create_si_via_partial_pe_dn_with_gst_TC_S_043


### Linked Issue
Fixes #2589

PR Reference
PR #N/A