### PR TITLE
test: Ensure test item setup is complete for Stock Projected Qty report tests.

### DIFF
--- a/erpnext/stock/report/stock_projected_qty/test_stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/test_stock_projected_qty.py
@@ -32,6 +32,16 @@ class TestStockReorderReportExecute(FrappeTestCase):
 		if not frappe.db.exists("UOM", self.uom_name):
 			frappe.get_doc({"doctype": "UOM", "uom_name": self.uom_name}).insert()
 
+		# Create stock entry for projected_qty
+		frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"stock_entry_type": "Material Receipt",
+				"company": self.company,
+				"items": [{"item_code": self.item_code.name, "qty": 5, "t_warehouse": self.warehouse}],
+			}
+		).insert().submit()
+
 	def test_execute_with_item_code_filter_T_SPQ_001(self):
 		"""Ensure only filtered item_code is returned in execute()"""
 		columns, data = execute({"item_code": "TEST-STOCK-ITEM"})


### PR DESCRIPTION
### Bug Description
- The tests in TestStockReorderReportExecute are failing because the test setup is not inserting or linking the item and its required data correctly in the system — so the execute() report returns no data ([]), or incorrect data.

### Root Causes by Test
**test_execute_with_item_code_filter_T_SPQ_001**
- Error: 'TEST-STOCK-ITEM' not found in []
- The create_item() function creates an item, but it may not be saved correctly or not available in stock or the warehouse, and thus isn't included in the stock projected qty report.

**test_execute_with_include_uom_T_SPQ_002**
- Error: UOM column value does not match expected UOM
- UOM conversion may not exist between "Nos" and "Box" for the test item, or the item is again missing from the report output due to data setup.

**test_execute_shortage_qty_calculation_T_SPQ_003**
- Error: shortage_qty list is empty or has non-zero values only
- No reorder level or projected quantity is actually set for the item; setup is missing that detail.

### Expected Result
- The item should appear in the report.
- UOM conversion should be recognized.
- Shortage qty should reflect correct calculation (reorder_level - projected_qty).

### Actual Result
- Report returns empty data ([]) or incorrect data due to setup gaps.
- Assertions fail because assumptions about data presence are invalid.

### Fix Summary
- You need to update your test setUp() method to properly create:
- The item with reorder_levels set for the warehouse.
- Stock entry for that item.
- UOM conversion (from Nos to Box) if testing include_uom.
- Ensure item is inserted and committed properly.

### Module Affected
-Stock

### Test Case ID:
- T_SPQ_001
- T_SPQ_002
- T_SPQ_003

### Issue Id:
#2636 
#2637 
