### PR TITLE
Fix: TDS not fetched from Supplier on PO and PI also console issue cdt undefined on Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -348,6 +348,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 				),
 			},
 			function () {
+				me.frm.trigger("set_tds");
 				me.apply_pricing_rule();
 				me.frm.doc.apply_tds = me.frm.supplier_tds ? 1 : 0;
 				me.frm.doc.tax_withholding_category = me.frm.supplier_tds;
@@ -363,6 +364,15 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		);
 	}
 
+	set_tds() {
+		if (this.frm.supplier_tds) {
+			this.frm.set_value("apply_tds", 1);
+		} else {
+			this.frm.set_value("apply_tds", 0);
+		}
+		this.frm.trigger("apply_tds");
+	}
+
 	apply_tds(frm) {
 		var me = this;
 		me.frm.set_value("tax_withheld_vouchers", []);
@@ -374,7 +384,6 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 			me.frm.set_df_property("tax_withholding_category", "hidden", 0);
 		}
 	}
-
 
 	tax_withholding_category(frm) {
 		var me = this;
@@ -469,7 +478,6 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 			frm: cur_frm,
 		});
 	}
-
 };
 
 cur_frm.script_manager.make(erpnext.accounts.PurchaseInvoice);
@@ -582,15 +590,19 @@ frappe.ui.form.on("Purchase Invoice", {
 				frm.trigger("create_landed_cost_voucher");
 			},
 		};
-		var list = frm.fields_dict['items'].grid.get_field('work_breakdown_structure').get_query = function (doc, cdt, cdn) {
+		var list = (frm.fields_dict["items"].grid.get_field("work_breakdown_structure").get_query = function (
+			doc,
+			cdt,
+			cdn
+		) {
 			var child = locals[cdt][cdn];
 			return {
 				filters: {
-					project : child.project,
-					is_group: 0
-				}
+					project: child.project,
+					is_group: 0,
+				},
 			};
-		};
+		});
 
 		frm.set_query("additional_discount_account", function () {
 			return {
@@ -674,7 +686,9 @@ frappe.ui.form.on("Purchase Invoice", {
 	},
 
 	onload: function (frm) {
-		frm.savecancel = function(btn, callback, on_error){ return frm._cancel(btn, callback, on_error, false);}
+		frm.savecancel = function (btn, callback, on_error) {
+			return frm._cancel(btn, callback, on_error, false);
+		};
 		if (frm.doc.__onload && frm.doc.supplier) {
 			if (frm.is_new()) {
 				frm.doc.apply_tds = frm.doc.__onload.supplier_tds ? 1 : 0;
@@ -734,46 +748,55 @@ frappe.ui.form.on("Purchase Invoice", {
 });
 
 frappe.ui.form.on("Purchase Invoice Item", {
-    work_breakdown_structure: function(frm,cdt,cdn) {
+	work_breakdown_structure: function (frm, cdt, cdn) {
 		let child = locals[cdt][cdn];
-		frappe.db.get_value("Work Breakdown Structure", child.work_breakdown_structure, ["wbs_name", 'locked', 'gl_account'])
-		.then(response => {
-			if (response.message && response.message.wbs_name) {
-				let wbs_name = response.message.wbs_name;
-				if (response.message.locked == 1) {
-					frappe.msgprint(__(`WBS "${child.work_breakdown_structure}" is locked`));
-					child.work_breakdown_structure = null;
+		frappe.db
+			.get_value("Work Breakdown Structure", child.work_breakdown_structure, [
+				"wbs_name",
+				"locked",
+				"gl_account",
+			])
+			.then((response) => {
+				if (response.message && response.message.wbs_name) {
+					let wbs_name = response.message.wbs_name;
+					if (response.message.locked == 1) {
+						frappe.msgprint(__(`WBS "${child.work_breakdown_structure}" is locked`));
+						child.work_breakdown_structure = null;
+					} else {
+						child.wbs_name = wbs_name;
+					}
+					if (response.message.gl_account) {
+						child.expense_account = response.message.gl_account;
+					}
 				} else {
-					child.wbs_name = wbs_name;
+					child.wbs_name = null;
 				}
-				if (response.message.gl_account) {
-					child.expense_account = response.message.gl_account;
-				}
-			} else {
-				child.wbs_name = null;
-			}
-			let row = frm.fields_dict['items'].grid.get_row(cdn);
-			row.refresh_field('work_breakdown_structure')
-            row.refresh_field('wbs_name');
-			row.refresh_field('expense_account');
-		})
+				let row = frm.fields_dict["items"].grid.get_row(cdn);
+				row.refresh_field("work_breakdown_structure");
+				row.refresh_field("wbs_name");
+				row.refresh_field("expense_account");
+			});
 	},
-	expense_account: function(frm,cdt,cdn) {
+	expense_account: function (frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
 		if (child.work_breakdown_structure && child.expense_account) {
-			frappe.db.get_value("Work Breakdown Structure",child.work_breakdown_structure,'gl_account')
-			.then(response => {
-				if (response.message && response.message.gl_account) {
-					if (child.expense_account != response.message.gl_account) {
-						frappe.msgprint(__(`${child.expense_account} is not a GL Account of WBS ${child.work_breakdown_structure}`));
-						child.expense_account = null;
-						let row = frm.fields_dict['items'].grid.get_row(cdn);
-						row.refresh_field('expense_account');
-						row.refresh_field('work_breakdown_structure');
+			frappe.db
+				.get_value("Work Breakdown Structure", child.work_breakdown_structure, "gl_account")
+				.then((response) => {
+					if (response.message && response.message.gl_account) {
+						if (child.expense_account != response.message.gl_account) {
+							frappe.msgprint(
+								__(
+									`${child.expense_account} is not a GL Account of WBS ${child.work_breakdown_structure}`
+								)
+							);
+							child.expense_account = null;
+							let row = frm.fields_dict["items"].grid.get_row(cdn);
+							row.refresh_field("expense_account");
+							row.refresh_field("work_breakdown_structure");
+						}
 					}
-				}
-			});
+				});
 		}
-	}
+	},
 });
-

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -25,17 +25,19 @@ frappe.ui.form.on("Purchase Order", {
 			});
 		}
 
-		var list = frm.fields_dict['items'].grid.get_field('work_breakdown_structure').get_query = function (doc, cdt, cdn) {
+		var list = (frm.fields_dict["items"].grid.get_field("work_breakdown_structure").get_query = function (
+			doc,
+			cdt,
+			cdn
+		) {
 			var child = locals[cdt][cdn];
 			return {
 				filters: {
-					project : child.project,
-					is_group: 0
-				}
+					project: child.project,
+					is_group: 0,
+				},
 			};
-		};
-		
-
+		});
 
 		frm.set_indicator_formatter("item_code", function (doc) {
 			return doc.qty <= doc.received_qty ? "green" : "orange";
@@ -94,10 +96,21 @@ frappe.ui.form.on("Purchase Order", {
 				fetch_payment_terms_template: cint(!frm.doc.ignore_default_payment_terms_template),
 			},
 			function () {
+				frm.trigger("set_tds");
 				frm.set_df_property("apply_tds", "read_only", frm.supplier_tds ? 0 : 1);
 				frm.set_df_property("tax_withholding_category", "hidden", frm.supplier_tds ? 0 : 1);
 			}
 		);
+	},
+
+	set_tds: function (frm) {
+		if (frm.is_new() && frm.supplier_tds) {
+			frm.set_value("apply_tds", 1);
+		}
+		if (!frm.supplier_tds) {
+			frm.set_value("apply_tds", 0);
+		}
+		frm.trigger("apply_tds");
 	},
 
 	get_materials_from_supplier: function (frm) {
@@ -139,7 +152,10 @@ frappe.ui.form.on("Purchase Order", {
 
 	onload: function (frm) {
 		set_schedule_date(frm);
-		frm.savecancel = function(btn, callback, on_error){ console.log("jiiri");return frm._cancel(btn, callback, on_error, false);}
+		frm.savecancel = function (btn, callback, on_error) {
+			console.log("jiiri");
+			return frm._cancel(btn, callback, on_error, false);
+		};
 		if (!frm.doc.transaction_date) {
 			frm.set_value("transaction_date", frappe.datetime.get_today());
 		}
@@ -154,9 +170,9 @@ frappe.ui.form.on("Purchase Order", {
 		}
 
 		erpnext.queries.setup_queries(frm, "Warehouse", function () {
-			return  {
+			return {
 				filters: {
-					company:frm.doc.company,
+					company: frm.doc.company,
 				},
 			};
 		});
@@ -297,61 +313,70 @@ frappe.ui.form.on("Purchase Order Item", {
 			}
 		}
 	},
-	project: function(frm,cdt,cdn) {
+	project: function (frm, cdt, cdn) {
 		let child = locals[cdt][cdn];
-		frappe.db.get_value("Project", child.project, "project_name")
-		.then(response => {
+		frappe.db.get_value("Project", child.project, "project_name").then((response) => {
 			if (response.message && response.message.project_name) {
 				let project_name = response.message.project_name;
 				child.project_name = project_name;
 			} else {
 				child.project_name = null;
 			}
-			let row = frm.fields_dict['items'].grid.get_row(cdn);
-            row.refresh_field('project_name');
-		})
+			let row = frm.fields_dict["items"].grid.get_row(cdn);
+			row.refresh_field("project_name");
+		});
 	},
-	work_breakdown_structure: function(frm,cdt,cdn) {
+	work_breakdown_structure: function (frm, cdt, cdn) {
 		let child = locals[cdt][cdn];
-		frappe.db.get_value("Work Breakdown Structure", child.work_breakdown_structure, ["wbs_name", 'locked', 'gl_account'])
-		.then(response => {
-			if (response.message && response.message.wbs_name) {
-				let wbs_name = response.message.wbs_name;
-				if (response.message.locked == 1) {
-					frappe.msgprint(__(`WBS "${child.work_breakdown_structure}" is locked`));
-					child.work_breakdown_structure = null;
+		frappe.db
+			.get_value("Work Breakdown Structure", child.work_breakdown_structure, [
+				"wbs_name",
+				"locked",
+				"gl_account",
+			])
+			.then((response) => {
+				if (response.message && response.message.wbs_name) {
+					let wbs_name = response.message.wbs_name;
+					if (response.message.locked == 1) {
+						frappe.msgprint(__(`WBS "${child.work_breakdown_structure}" is locked`));
+						child.work_breakdown_structure = null;
+					} else {
+						child.wbs_name = wbs_name;
+					}
+					if (response.message.gl_account) {
+						child.expense_account = response.message.gl_account;
+					}
 				} else {
-					child.wbs_name = wbs_name;
+					child.wbs_name = null;
 				}
-				if (response.message.gl_account) {
-					child.expense_account = response.message.gl_account;
-				}
-			} else {
-				child.wbs_name = null;
-			}
-			let row = frm.fields_dict['items'].grid.get_row(cdn);
-			row.refresh_field('work_breakdown_structure')
-            row.refresh_field('wbs_name');
-			row.refresh_field('expense_account');
-		})
+				let row = frm.fields_dict["items"].grid.get_row(cdn);
+				row.refresh_field("work_breakdown_structure");
+				row.refresh_field("wbs_name");
+				row.refresh_field("expense_account");
+			});
 	},
-	expense_account: function(frm,cdt,cdn) {
+	expense_account: function (frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
 		if (child.work_breakdown_structure && child.expense_account) {
-			frappe.db.get_value("Work Breakdown Structure",child.work_breakdown_structure,'gl_account')
-			.then(response => {
-				if (response.message && response.message.gl_account) {
-					if (child.expense_account != response.message.gl_account) {
-						frappe.msgprint(__(`${child.expense_account} is not a GL Account of WBS ${child.work_breakdown_structure}`));
-						child.expense_account = null;
-						let row = frm.fields_dict['items'].grid.get_row(cdn);
-						row.refresh_field('expense_account');
-						row.refresh_field('work_breakdown_structure');
+			frappe.db
+				.get_value("Work Breakdown Structure", child.work_breakdown_structure, "gl_account")
+				.then((response) => {
+					if (response.message && response.message.gl_account) {
+						if (child.expense_account != response.message.gl_account) {
+							frappe.msgprint(
+								__(
+									`${child.expense_account} is not a GL Account of WBS ${child.work_breakdown_structure}`
+								)
+							);
+							child.expense_account = null;
+							let row = frm.fields_dict["items"].grid.get_row(cdn);
+							row.refresh_field("expense_account");
+							row.refresh_field("work_breakdown_structure");
+						}
 					}
-				}
-			});
+				});
 		}
-	}
+	},
 });
 
 erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
@@ -458,7 +483,6 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 				if (doc.status != "On Hold") {
 					if (flt(doc.per_received) < 100 && allow_receipt) {
 						cur_frm.add_custom_button(
-							
 							__("Purchase Receipt"),
 							this.make_purchase_receipt,
 							__("Create")
@@ -494,7 +518,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 							__("Create")
 						);
 
-						if (flt(doc.per_billed) < 100 && doc.status != "Delivered") {
+					if (flt(doc.per_billed) < 100 && doc.status != "Delivered") {
 						this.frm.add_custom_button(
 							__("Payment"),
 							() => this.make_payment_entry(),

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1042,7 +1042,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 	}
 
-	due_date(doc) {
+	due_date(doc, cdt) {
 		// due_date is to be changed, payment terms template and/or payment schedule must
 		// be removed as due_date is automatically changed based on payment terms
 
@@ -1937,7 +1937,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					row_to_modify["cost_center"] = r.message.cost_center;
 				}
 			}
-			
+
 			this.frm.script_manager.copy_from_first_row("items", row_to_modify, ["expense_account", "income_account"]);
 		});
 


### PR DESCRIPTION
### Bug Description  
TDS (Tax Deducted at Source) was not being fetched from the supplier's tax configuration on Purchase Order and Purchase Invoice.  
Additionally, an error `cdt is not defined` occurred on the Purchase Invoice due to a missing reference in the inherited `transaction.js` file, which is shared across multiple transaction forms.

### Root Cause  
- The TDS was not being automatically loaded from the supplier configuration because there was no trigger to fetch it on supplier selection.  
- The `cdt` variable used in `transaction.js` was not defined within the Purchase Invoice context, leading to a runtime error.

**Steps to Reproduce:**  
1. Create a supplier with `Tax Withholding Category` set.  
2. Open a new Purchase Order or Purchase Invoice.  
3. Select the configured supplier.  
4. Observe: `Apply Tax Withholding Amount` checkbox is not checked.  
5. On Purchase Invoice, check console – `cdt is not defined` error will be appears.

**Actual/Observed Result:**  
- TDS not applied from supplier tax `Tax Withholding Category` from the tax section.  
- JavaScript error: `cdt is not defined` in console on PI.

**Expected Result:**  
- The field `Apply Tax Withholding Amount` should auto checked if supplier has Tax Withholding Category` set.  
- No runtime JS errors on Purchase Invoice.

### Fix Summary  
- Added an event trigger on supplier selection to fetch and apply the supplier’s TDS.  
- Handled the `cdt` reference safely in `transaction.js` to avoid errors when undefined.

### Affected Module  
- Purchase Order  
- Purchase Invoice

### Test Cases Covered  
None

### Linked Issue  
Fixes #2579