### PR TITLE
test: Fix fiscal year overlap error during test setup by isolating fiscal year creation

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -8077,14 +8077,16 @@ def create_fiscal_year(company):
 	import frappe
 
 	current_date = datetime.today().date()
-	# Fetch all enabled fiscal years
-	existing_fy = frappe.get_all(
-		"Fiscal Year", filters={"disabled": 0}, fields=["name", "year_start_date", "year_end_date"]
+
+	matching_fy_list = frappe.get_all(
+		"Fiscal Year",
+		filters={
+			"disabled": 0,
+			"year_start_date": ["<=", current_date],
+			"year_end_date": [">=", current_date],
+		},
+		fields=["name", "year_start_date", "year_end_date"],
 	)
-
-	# Filter fiscal years where current date falls between start and end
-	matching_fy_list = [fy for fy in existing_fy if fy.year_start_date <= current_date <= fy.year_end_date]
-
 	is_company = False
 	if len(matching_fy_list) > 0:
 		for fy in matching_fy_list:
@@ -8097,9 +8099,15 @@ def create_fiscal_year(company):
 				break
 
 		if not is_company:
-			fiscal_year = frappe.get_doc("Fiscal Year", matching_fy_list[0]["name"])
-			fiscal_year.append("companies", {"company": company})
-			fiscal_year.save()
+			for rows in matching_fy_list:
+				try:
+					fiscal_year = frappe.get_doc("Fiscal Year", rows.name)
+					fiscal_year.append("companies", {"company": company})
+					fiscal_year.save()
+					break
+				except Exception as e:
+					print(f"Failed to get Fiscal Year {fy['name']}: {e}")
+					continue
 
 	else:
 		# No fiscal year includes current date — create a new one

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -4,14 +4,23 @@
 
 import json
 import random
+from datetime import date
+from io import BytesIO
+
 import frappe
+from frappe.query_builder import DocType
+
 # import pandas as pd
 from frappe.tests.utils import FrappeTestCase, change_settings, if_app_installed
-from frappe.utils import add_days, flt, getdate, nowdate, add_years, today, get_year_start, get_year_ending
-from frappe.utils.data import today
-from datetime import date
-from frappe.query_builder import DocType
+from frappe.utils import add_days, add_years, flt, get_year_ending, get_year_start, getdate, nowdate, today
+
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+	create_company_and_supplier as create_data,
+)
+from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
 from erpnext.accounts.party import get_due_date_from_template
 from erpnext.buying.doctype.purchase_order.purchase_order import (
 	make_inter_company_sales_order,
@@ -20,32 +29,31 @@ from erpnext.buying.doctype.purchase_order.purchase_order import (
 from erpnext.buying.doctype.purchase_order.purchase_order import (
 	make_purchase_invoice as make_pi_from_po,
 )
+from erpnext.buying.doctype.purchase_order.purchase_order import (
+	make_purchase_receipt as make_purchase_receipt_aganist_mr,
+)
+from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
+	make_supplier_quotation_from_rfq,
+)
+from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+from erpnext.buying.doctype.supplier_quotation.supplier_quotation import (
+	make_purchase_order as create_po_aganist_sq,
+)
 from erpnext.controllers.accounts_controller import InvalidQtyError, update_child_qty_rate
-
-from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.item.test_item import create_item, make_item
 from erpnext.stock.doctype.material_request.material_request import (
 	make_purchase_order,
+	make_request_for_quotation,
 	make_stock_entry,
 	make_supplier_quotation,
 	raise_work_orders,
-	make_request_for_quotation
 )
 from erpnext.stock.doctype.material_request.test_material_request import make_material_request
+from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 	make_purchase_invoice as make_pi_from_pr,
 )
-from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
-from erpnext.stock.doctype.item.test_item import create_item
-from erpnext.buying.doctype.supplier.test_supplier import create_supplier
-from erpnext.buying.doctype.supplier_quotation.supplier_quotation import make_purchase_order as create_po_aganist_sq
-from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt as make_purchase_receipt_aganist_mr
-from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
-from erpnext.buying.doctype.request_for_quotation.request_for_quotation import make_supplier_quotation_from_rfq
-from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
-from io import BytesIO
-from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
-from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
 
 
 class TestPurchaseOrder(FrappeTestCase):
@@ -951,7 +959,7 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		frappe.db.set_single_value("Selling Settings", "maintain_same_sales_rate", 1)
 		frappe.db.set_single_value("Buying Settings", "maintain_same_rate", 1)
-		get_or_create_fiscal_year('_Test Company with perpetual inventory')
+		get_or_create_fiscal_year("_Test Company with perpetual inventory")
 		prepare_data_for_internal_transfer()
 		supplier = "_Test Internal Supplier 2"
 
@@ -1078,13 +1086,13 @@ class TestPurchaseOrder(FrappeTestCase):
 		# Test - 3: Items should be updated as the Subcontracting Order is cancelled
 		self.assertEqual(po.items[0].qty, 30)
 		self.assertEqual(po.items[0].fg_item_qty, 30)
-	
+
 	def test_new_sc_flow(self):
 		from erpnext.buying.doctype.purchase_order.purchase_order import make_subcontracting_order
-		
+
 		po = create_po_for_sc_testing()
 		sco = make_subcontracting_order(po.name)
-		
+
 		sco.items[0].qty = 5
 		sco.items.pop(1)
 		sco.items[1].qty = 25
@@ -1093,56 +1101,56 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		# Test - 1: Quantity of Service Items should change based on change in Quantity of its corresponding Finished Goods Item
 		self.assertEqual(sco.service_items[0].qty, 5)
-		
+
 		# Test - 2: Subcontracted Quantity for the PO Items of each line item should be updated accordingly
 		po.reload()
 		self.assertEqual(po.items[0].subcontracted_quantity, 5)
 		self.assertEqual(po.items[1].subcontracted_quantity, 0)
 		self.assertEqual(po.items[2].subcontracted_quantity, 12.5)
-		
+
 		# Test - 3: Amount for both FG Item and its Service Item should be updated correctly based on change in Quantity
 		self.assertEqual(sco.items[0].amount, 2000)
 		self.assertEqual(sco.service_items[0].amount, 500)
-		
+
 		# Test - 4: Service Items should be removed if its corresponding Finished Good line item is deleted
 		self.assertEqual(len(sco.service_items), 2)
-		
+
 		# Test - 5: Service Item quantity calculation should be based upon conversion factor calculated from its corresponding PO Item
 		self.assertEqual(sco.service_items[1].qty, 12.5)
-		
+
 		sco = make_subcontracting_order(po.name)
-		
+
 		sco.items[0].qty = 6
-		
+
 		# Test - 6: Saving document should not be allowed if Quantity exceeds available Subcontracting Quantity of any Purchase Order Item
 		self.assertRaises(frappe.ValidationError, sco.save)
-		
+
 		sco.items[0].qty = 5
 		sco.items.pop()
 		sco.items.pop()
 		sco.save()
 		sco.submit()
-		
+
 		sco = make_subcontracting_order(po.name)
-		
+
 		# Test - 7: Since line item 1 is now fully subcontracted, new SCO should by default only have the remaining 2 line items
 		self.assertEqual(len(sco.items), 2)
-		
+
 		sco.items.pop(0)
 		sco.save()
 		sco.submit()
-		
+
 		# Test - 8: Subcontracted Quantity for each PO Item should be subtracted if SCO gets cancelled
 		po.reload()
 		self.assertEqual(po.items[2].subcontracted_quantity, 25)
 		sco.cancel()
 		po.reload()
 		self.assertEqual(po.items[2].subcontracted_quantity, 12.5)
-		
+
 		sco = make_subcontracting_order(po.name)
 		sco.save()
 		sco.submit()
-		
+
 		# Test - 8: Since this PO is now fully subcontracted, creating a new SCO from it should throw error
 		self.assertRaises(frappe.ValidationError, make_subcontracting_order, po.name)
 
@@ -1211,25 +1219,33 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(po.per_billed, 100)
 
 	def test_create_purchase_receipt(self):
-		po = create_purchase_order(rate=10000,qty=10)
+		po = create_purchase_order(rate=10000, qty=10)
 		po.submit()
 
 		pr = create_pr_against_po(po.name, received_qty=10)
-		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "_Test Warehouse - _TC"}, "actual_qty")
-		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':pr.name})
+		bin_qty = frappe.db.get_value(
+			"Bin", {"item_code": "_Test Item", "warehouse": "_Test Warehouse - _TC"}, "actual_qty"
+		)
+		sle = frappe.get_doc("Stock Ledger Entry", {"voucher_no": pr.name})
 		self.assertEqual(sle.qty_after_transaction, bin_qty)
 		self.assertEqual(sle.warehouse, po.get("items")[0].warehouse)
 
-		#if account setup in company
-		if frappe.db.exists('GL Entry',{'account': 'Stock Received But Not Billed - _TC'}):
-			gl_temp_credit = frappe.db.get_value('GL Entry',{'voucher_no':pr.name, 'account': 'Stock Received But Not Billed - _TC'},'credit')
+		# if account setup in company
+		if frappe.db.exists("GL Entry", {"account": "Stock Received But Not Billed - _TC"}):
+			gl_temp_credit = frappe.db.get_value(
+				"GL Entry",
+				{"voucher_no": pr.name, "account": "Stock Received But Not Billed - _TC"},
+				"credit",
+			)
 			self.assertEqual(gl_temp_credit, 100000)
 
-		#if account setup in company
-		if frappe.db.exists('GL Entry',{'account': 'Stock In Hand - _TC'}):
-			gl_stock_debit = frappe.db.get_value('GL Entry',{'voucher_no':pr.name, 'account': 'Stock In Hand - _TC'},'debit')
+		# if account setup in company
+		if frappe.db.exists("GL Entry", {"account": "Stock In Hand - _TC"}):
+			gl_stock_debit = frappe.db.get_value(
+				"GL Entry", {"voucher_no": pr.name, "account": "Stock In Hand - _TC"}, "debit"
+			)
 			self.assertEqual(gl_stock_debit, 100000)
-	
+
 	def test_single_po_pi_TC_B_001(self):
 		# Scenario : PO => PR => 1PI
 		get_company_supplier = create_data()
@@ -1238,22 +1254,24 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-3"
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 6,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 6,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -1273,14 +1291,16 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_mr_pi_TC_B_002(self):
 		from erpnext.stock.doctype.item.test_item import make_item
+
 		make_item("Testing-31")
 		# MR =>  PO => PR => PI
-		mr_dict_list = [{
-				"company" : "_Test Company",
-				"item_code" : "Testing-31",
-				"warehouse" : "Stores - _TC",
-				"qty" : 6,
-				"rate" : 100,
+		mr_dict_list = [
+			{
+				"company": "_Test Company",
+				"item_code": "Testing-31",
+				"warehouse": "Stores - _TC",
+				"qty": 6,
+				"rate": 100,
 			},
 		]
 
@@ -1296,23 +1316,24 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_mr_pi_TC_B_003(self):
 		# MR => RFQ => SQ => PO => PR => PI
-		item = make_test_item("Testing-31")
+		make_test_item("Testing-31")
 		args = frappe._dict()
-		args['mr'] = [{
-				"company" : "_Test Company",
-				"item_code" : "Testing-31",
-				"warehouse" : "Stores - _TC",
-				"qty" : 2,
-				"rate" : 100,
+		args["mr"] = [
+			{
+				"company": "_Test Company",
+				"item_code": "Testing-31",
+				"warehouse": "Stores - _TC",
+				"qty": 2,
+				"rate": 100,
 			},
 		]
 
-		doc_mr = make_material_request(**args['mr'][0])
+		doc_mr = make_material_request(**args["mr"][0])
 		self.assertEqual(doc_mr.docstatus, 1)
 
 		doc_rfq = make_test_rfq(doc_mr.name)
-		doc_sq= make_test_sq(doc_rfq.name, 100)
-		doc_po = make_test_po(doc_sq.name, type='Supplier Quotation')
+		doc_sq = make_test_sq(doc_rfq.name, 100)
+		doc_po = make_test_po(doc_sq.name, type="Supplier Quotation")
 		doc_pr = make_test_pr(doc_po.name)
 		doc_pi = make_test_pi(doc_pr.name)
 
@@ -1322,33 +1343,31 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_multi_po_pr_TC_B_008(self):
 		# Scenario : 2PO => 2PR => 1PI
-		args = frappe._dict()
-		purchase_order_list = [{
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
-			"qty" : 3,
-			"rate" : 100,
-		},
-		{
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
-			"qty" : 3,
-			"rate" : 100,
-		}]
+		purchase_order_list = [
+			{
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 3,
+				"rate": 100,
+			},
+			{
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 3,
+				"rate": 100,
+			},
+		]
 
 		pur_receipt_name_list = []
-		pur_order_dict = frappe._dict({
-			"total_amount" : 0,
-			"total_qty" : 0
-		})
+		pur_order_dict = frappe._dict({"total_amount": 0, "total_qty": 0})
 
 		for order in purchase_order_list:
 			doc_po = create_purchase_order(**order)
-			pur_order_dict.update({"total_amount" : pur_order_dict.total_amount + doc_po.grand_total })
-			pur_order_dict.update({"total_qty" : pur_order_dict.total_qty + doc_po.total_qty })
-			
+			pur_order_dict.update({"total_amount": pur_order_dict.total_amount + doc_po.grand_total})
+			pur_order_dict.update({"total_qty": pur_order_dict.total_qty + doc_po.total_qty})
+
 			self.assertEqual(doc_po.docstatus, 1)
 
 			doc_pr = make_pr_for_po(doc_po.name)
@@ -1358,65 +1377,67 @@ class TestPurchaseOrder(FrappeTestCase):
 			pur_receipt_name_list.append(doc_pr.name)
 
 		item_dict = [
-					{"item_code" : "_Test Item",
-					"warehouse" : "Stores - _TC",
-					"qty" : 3,
-					"rate" : 100,
-					"purchase_receipt":pur_receipt_name_list[1]
-					}]
-		
-		doc_pi = make_pi_against_pr(pur_receipt_name_list[0], item_dict_list = item_dict)
+			{
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 3,
+				"rate": 100,
+				"purchase_receipt": pur_receipt_name_list[1],
+			}
+		]
+
+		doc_pi = make_pi_against_pr(pur_receipt_name_list[0], item_dict_list=item_dict)
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.total_qty, pur_order_dict.total_qty)
 		self.assertEqual(doc_pi.grand_total, pur_order_dict.total_amount)
 
 	def test_multi_po_single_pr_pi_TC_B_007(self):
 		# Scenario : 2PO => 1PR => 1PI
-		args = frappe._dict()
-		purchase_order_list = [{
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
-			"qty" : 3,
-			"rate" : 100,
-		},
-		{
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
-			"qty" : 3,
-			"rate" : 100,
-		}]
+		purchase_order_list = [
+			{
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 3,
+				"rate": 100,
+			},
+			{
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 3,
+				"rate": 100,
+			},
+		]
 
 		pur_order_name_list = []
-		pur_order_dict = frappe._dict({
-			"total_amount" : 0,
-			"total_qty" : 0
-		})
+		pur_order_dict = frappe._dict({"total_amount": 0, "total_qty": 0})
 
 		for order in purchase_order_list:
 			doc_po = create_purchase_order(**order)
-			pur_order_dict.update({"total_amount" : pur_order_dict.total_amount + doc_po.grand_total })
-			pur_order_dict.update({"total_qty" : pur_order_dict.total_qty + doc_po.total_qty })
-			
+			pur_order_dict.update({"total_amount": pur_order_dict.total_amount + doc_po.grand_total})
+			pur_order_dict.update({"total_qty": pur_order_dict.total_qty + doc_po.total_qty})
+
 			self.assertEqual(doc_po.docstatus, 1)
 			pur_order_name_list.append(doc_po.name)
 
 		item_dict = [
-					{"item_code" : "_Test Item",
-					"warehouse" : "Stores - _TC",
-					"qty" : 3,
-					"rate" : 100,
-					"purchase_receipt":pur_order_name_list[1]
-					}]
+			{
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 3,
+				"rate": 100,
+				"purchase_receipt": pur_order_name_list[1],
+			}
+		]
 
-		doc_pr = make_pr_for_po(pur_order_name_list[0], item_dict_list = item_dict)
+		doc_pr = make_pr_for_po(pur_order_name_list[0], item_dict_list=item_dict)
 
 		doc_pi = make_pi_against_pr(doc_pr.name)
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.total_qty, pur_order_dict.total_qty)
 		self.assertEqual(doc_pi.grand_total, pur_order_dict.total_amount)
-	
+
 	def test_single_po_multi_pr_pi_TC_B_006(self):
 		# Scenario : 1PO => 2PR => 2PI
 		get_company_supplier = create_data()
@@ -1426,46 +1447,44 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-3"
 		get_or_create_fiscal_year(company)
 
-
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 6,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 6,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
 
-		pur_invoice_dict = frappe._dict({
-			"total_amount" : 0,
-			"total_qty" : 0
-		})
+		pur_invoice_dict = frappe._dict({"total_amount": 0, "total_qty": 0})
 		pur_receipt_qty = [3, 3]
 
 		for received_qty in pur_receipt_qty:
 			doc_pr = make_pr_for_po(po.name, received_qty)
 			self.assertEqual(doc_pr.docstatus, 1)
-			
+
 			doc_pi = make_pi_against_pr(doc_pr.name)
 			self.assertEqual(doc_pi.docstatus, 1)
 
-			pur_invoice_dict.update({"total_amount" : pur_invoice_dict.total_amount + doc_pi.grand_total })
-			pur_invoice_dict.update({"total_qty" : pur_invoice_dict.total_qty + doc_pi.total_qty })
-		
+			pur_invoice_dict.update({"total_amount": pur_invoice_dict.total_amount + doc_pi.grand_total})
+			pur_invoice_dict.update({"total_qty": pur_invoice_dict.total_qty + doc_pi.total_qty})
+
 		self.assertEqual(po.total_qty, pur_invoice_dict.total_qty)
 		self.assertEqual(po.grand_total, pur_invoice_dict.total_amount)
-	
+
 	def test_single_po_pi_multi_pr_TC_B_005(self):
 		# Scenario : 1PO => 2PR => 1PI
 		get_company_supplier = create_data()
@@ -1474,22 +1493,24 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-3"
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 6,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 6,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -1500,49 +1521,58 @@ class TestPurchaseOrder(FrappeTestCase):
 		for received_qty in pur_receipt_qty:
 			doc_pr = make_pr_for_po(po.name, received_qty)
 			self.assertEqual(doc_pr.docstatus, 1)
-			
+
 			pur_receipt_name_list.append(doc_pr.name)
-		
+
 		item_dict = [
 			{
-				"item_code" : item.item_code,
-				"warehouse" : warehouse,
-				"qty" : 3,
-				"rate" : 100,
-				"purchase_receipt":pur_receipt_name_list[1]
+				"item_code": item.item_code,
+				"warehouse": warehouse,
+				"qty": 3,
+				"rate": 100,
+				"purchase_receipt": pur_receipt_name_list[1],
 			}
 		]
 
-		doc_pi = make_pi_against_pr(pur_receipt_name_list[0], item_dict_list= item_dict)
+		doc_pi = make_pi_against_pr(pur_receipt_name_list[0], item_dict_list=item_dict)
 
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(po.total_qty, doc_pi.total_qty)
 		self.assertEqual(po.grand_total, doc_pi.grand_total)
-	
+
 	def test_create_purchase_receipt_partial_TC_SCK_037(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
 		create_company()
-		create_item("_Test Item",warehouse="Stores - _TC")
+		create_item("_Test Item", warehouse="Stores - _TC")
 		create_supplier(supplier_name="_Test Supplier")
-		get_or_create_fiscal_year('_Test Company')
-		po = create_purchase_order(rate=10000,qty=10,warehouse = "Stores - _TC")
+		get_or_create_fiscal_year("_Test Company")
+		po = create_purchase_order(rate=10000, qty=10, warehouse="Stores - _TC")
 		po.submit()
 
 		pr = create_pr_against_po(po.name, received_qty=5)
 
-		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "Stores - _TC"}, "actual_qty")
-		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':pr.name})
+		bin_qty = frappe.db.get_value(
+			"Bin", {"item_code": "_Test Item", "warehouse": "Stores - _TC"}, "actual_qty"
+		)
+		sle = frappe.get_doc("Stock Ledger Entry", {"voucher_no": pr.name})
 		self.assertEqual(sle.qty_after_transaction, bin_qty)
 		self.assertEqual(sle.warehouse, po.get("items")[0].warehouse)
 
-		#if account setup in company
-		if frappe.db.exists('GL Entry',{'account': 'Stock Received But Not Billed - _TC'}):
-			gl_temp_credit = frappe.db.get_value('GL Entry',{'voucher_no':pr.name, 'account': 'Stock Received But Not Billed - _TC'},'credit')
+		# if account setup in company
+		if frappe.db.exists("GL Entry", {"account": "Stock Received But Not Billed - _TC"}):
+			gl_temp_credit = frappe.db.get_value(
+				"GL Entry",
+				{"voucher_no": pr.name, "account": "Stock Received But Not Billed - _TC"},
+				"credit",
+			)
 			self.assertEqual(gl_temp_credit, 50000)
 
-		#if account setup in company
-		if frappe.db.exists('GL Entry',{'account': 'Stock In Hand - _TC'}):
-			gl_stock_debit = frappe.db.get_value('GL Entry',{'voucher_no':pr.name, 'account': 'Stock In Hand - _TC'},'debit')
+		# if account setup in company
+		if frappe.db.exists("GL Entry", {"account": "Stock In Hand - _TC"}):
+			gl_stock_debit = frappe.db.get_value(
+				"GL Entry", {"voucher_no": pr.name, "account": "Stock In Hand - _TC"}, "debit"
+			)
 			self.assertEqual(gl_stock_debit, 50000)
 
 	def test_pi_return_TC_B_043(self):
@@ -1550,7 +1580,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import check_gl_entries
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import get_qty_after_transaction
 
-		po = create_purchase_order(		
+		po = create_purchase_order(
 			warehouse="Finished Goods - _TC",
 			rate=130,
 			qty=1,
@@ -1595,18 +1625,14 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_payment_entry_TC_B_037(self):
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import check_gl_entries
+
 		get_company_and_supplier = get_company_or_supplier()
 		company = get_company_and_supplier.get("company")
 		supplier = get_company_and_supplier.get("supplier")
 		warehouse = "Stores - TC-5"
 
-		po = create_purchase_order(		
-			warehouse = warehouse,
-			rate = 30,
-			qty = 1,
-			company = company,
-			supplier = supplier,
-			currency = "INR"
+		po = create_purchase_order(
+			warehouse=warehouse, rate=30, qty=1, company=company, supplier=supplier, currency="INR"
 		)
 
 		self.assertEqual(po.status, "To Receive and Bill")
@@ -1640,22 +1666,24 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_12")
 		warehouse = "Stores - TC-3"
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 1,
-					"rate": 130,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 1,
+						"rate": 130,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.status, "To Receive and Bill")
@@ -1676,38 +1704,41 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(po_status, "Completed")
 		pr_status = frappe.db.get_value("Purchase Receipt", pr.name, "status")
 		self.assertEqual(pr_status, "Completed")
-		
+
 		pi.cancel()
 		self.assertEqual(pi.status, "Cancelled")
 		po_status = frappe.db.get_value("Purchase Order", po.name, "status")
 		self.assertEqual(po_status, "To Bill")
 		pr_status = frappe.db.get_value("Purchase Receipt", pr.name, "status")
 		self.assertEqual(pr_status, "To Bill")
+
 	def test_purchase_invoice_return_TC_B_042(self):
 		from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import make_debit_note
+
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_test_item("test_itemss")
 		warehouse = "Stores - TC-3"
 
-
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 1,
-					"rate": 130,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 1,
+						"rate": 130,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 
@@ -1719,7 +1750,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi.bill_no = "test_bill_1122"
 		pi.save()
 		pi.submit()
-		
+
 		pi_return = make_debit_note(pi.name)
 		pi_return.update_outstanding_for_self = 0
 		pi_return.update_billed_amount_in_purchase_receipt = 0
@@ -1727,28 +1758,23 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi_return.submit()
 		self.assertEqual(pi_return.status, "Return")
 		pi_status = frappe.db.get_value("Purchase Invoice", pi.name, "status")
-		self.assertEqual(pi_status, "Debit Note Issued")  
+		self.assertEqual(pi_status, "Debit Note Issued")
 
 	def test_50_50_payment_terms_TC_B_044(self):
-		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
 
-		po = create_purchase_order(		
-			warehouse="Finished Goods - _TC",
-			rate=130,
-			qty=1,
-			do_not_save=1
-		)
+		po = create_purchase_order(warehouse="Finished Goods - _TC", rate=130, qty=1, do_not_save=1)
 		po.payment_terms_template = "_Test Payment Term Template"
 		po.save()
 		po.submit()
 
-		pe = get_payment_entry("Purchase Order", po.name, party_amount=po.grand_total/2)
+		pe = get_payment_entry("Purchase Order", po.name, party_amount=po.grand_total / 2)
 		pe.save()
 		pe.submit()
-	
+
 		po_advance_paid = frappe.db.get_value("Purchase Order", po.name, "advance_paid")
-		self.assertTrue(po_advance_paid, po.grand_total/2)
+		self.assertTrue(po_advance_paid, po.grand_total / 2)
 
 		pr = make_purchase_receipt(po.name)
 		pr.save()
@@ -1759,8 +1785,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi.set_advances()
 		pi.save()
 		pi.submit()
-		
-		
+
 		po_status = frappe.db.get_value("Purchase Order", po.name, "status")
 		self.assertEqual(po_status, "Completed")
 
@@ -1768,33 +1793,39 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi_status, "Paid")
 
 	def test_status_po_on_pi_cancel_TC_B_038(self):
-		from erpnext.accounts.doctype.unreconcile_payment.unreconcile_payment import payment_reconciliation_record_on_unreconcile,create_unreconcile_doc_for_selection
+		from erpnext.accounts.doctype.unreconcile_payment.unreconcile_payment import (
+			create_unreconcile_doc_for_selection,
+			payment_reconciliation_record_on_unreconcile,
+		)
+
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-3"
 		get_or_create_fiscal_year(company)
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 500,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 500,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
-		
+
 		pi = make_pi_from_po(po.name)
 		pi.update_stock = 1
 		pi.bill_no = "test_bill"
@@ -1807,83 +1838,102 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		before_pi_cancel_status = frappe.db.get_value("Purchase Order", po.name, "status")
 		self.assertEqual(before_pi_cancel_status, "Completed")
-		
+
 		header = {
-			"company":company,
-			"unreconcile":1,
-			"clearing_date":"2025-01-07",
-			"party_type":"Supplier",
-			"party": supplier
+			"company": company,
+			"unreconcile": 1,
+			"clearing_date": "2025-01-07",
+			"party_type": "Supplier",
+			"party": supplier,
 		}
-		selection = {"company":company,"voucher_type":"Payment Entry","voucher_no":f"{pe.name}","against_voucher_type":"Purchase Invoice","against_voucher_no":f"{pi.name}","allocated_amount":pi.rounded_total}
-		allocation = [{"reference_type":"Payment Entry","reference_name":pe.name,"invoice_type":"Purchase Invoice","invoice_number":pi.name,"allocated_amount":pi.rounded_total}]
-		payment_reconciliation_record_on_unreconcile(header=header,allocation=allocation)
-		create_unreconcile_doc_for_selection(selections = json.dumps([selection]))
-		
+		selection = {
+			"company": company,
+			"voucher_type": "Payment Entry",
+			"voucher_no": f"{pe.name}",
+			"against_voucher_type": "Purchase Invoice",
+			"against_voucher_no": f"{pi.name}",
+			"allocated_amount": pi.rounded_total,
+		}
+		allocation = [
+			{
+				"reference_type": "Payment Entry",
+				"reference_name": pe.name,
+				"invoice_type": "Purchase Invoice",
+				"invoice_number": pi.name,
+				"allocated_amount": pi.rounded_total,
+			}
+		]
+		payment_reconciliation_record_on_unreconcile(header=header, allocation=allocation)
+		create_unreconcile_doc_for_selection(selections=json.dumps([selection]))
+
 		pi.reload()
 		pi.cancel()
 		after_pi_cancel_status = frappe.db.get_value("Purchase Order", po.name, "status")
 		self.assertEqual(after_pi_cancel_status, "To Receive and Bill")
 
-
 	def test_full_payment_request_TC_B_030(self):
 		# Scenario : PO => Payment Request
-		
+
 		po_data = {
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
-			"qty" : 6,
-			"rate" : 100,
+			"company": "_Test Company",
+			"item_code": "_Test Item",
+			"warehouse": "Stores - _TC",
+			"qty": 6,
+			"rate": 100,
 		}
-		
+
 		doc_po = create_purchase_order(**po_data)
 		self.assertEqual(doc_po.docstatus, 1)
-		
+
 		args = frappe._dict()
 		args = {
-				"dt": doc_po.doctype,
-				"dn": doc_po.name,
-				"recipient_id": doc_po.contact_email,
-				"payment_request_type": 'Outward',
-				"party_type":  "Supplier",
-				"party":  doc_po.supplier,
-				"party_name": doc_po.supplier_name
-			}
+			"dt": doc_po.doctype,
+			"dn": doc_po.name,
+			"recipient_id": doc_po.contact_email,
+			"payment_request_type": "Outward",
+			"party_type": "Supplier",
+			"party": doc_po.supplier,
+			"party_name": doc_po.supplier_name,
+		}
 		dict_pr = make_payment_request(**args)
 		doc_pr = frappe.get_doc("Payment Request", dict_pr.name)
 		doc_pr.submit()
 		self.assertEqual(doc_pr.docstatus, 1)
 		self.assertEqual(doc_pr.reference_name, doc_po.name)
 		self.assertEqual(doc_pr.grand_total, doc_po.grand_total)
+
 	def test_po_to_partial_pr_TC_B_031(self):
-		item = make_test_item("Testing-31")
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": "_Test Supplier 1",
-			"company": "_Test Company",
-			"schedule_date": frappe.utils.nowdate(),
-			"items": [
-				{
-					"item_code": "Testing-31",
-					"qty": 6,
-					"rate": 100,
-					"warehouse": "Stores - _TC",
-				}
-			]
-		})
+		make_test_item("Testing-31")
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": "_Test Supplier 1",
+				"company": "_Test Company",
+				"schedule_date": frappe.utils.nowdate(),
+				"items": [
+					{
+						"item_code": "Testing-31",
+						"qty": 6,
+						"rate": 100,
+						"warehouse": "Stores - _TC",
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 
-		payment_request = frappe.get_doc({
-			"doctype": "Payment Request",
-			"reference_doctype": "Purchase Order",
-			"reference_name": po.name,
-			"payment_request_type": "Outward",
-			"party_type": "Supplier",
-			"party": po.supplier,
-			"grand_total": 300,
-		})
+		payment_request = frappe.get_doc(
+			{
+				"doctype": "Payment Request",
+				"reference_doctype": "Purchase Order",
+				"reference_name": po.name,
+				"payment_request_type": "Outward",
+				"party_type": "Supplier",
+				"party": po.supplier,
+				"grand_total": 300,
+			}
+		)
 
 		payment_request.insert()
 		payment_request.submit()
@@ -1891,7 +1941,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(payment_request.payment_request_type, "Outward")
 		self.assertEqual(payment_request.grand_total, 300)
 		self.assertEqual(payment_request.reference_name, po.name)
-	
+
 	def test_purchase_invoice_return_TC_B_032(self):
 		frappe.set_user("Administrator")
 		company = "_Test Company"
@@ -1902,53 +1952,55 @@ class TestPurchaseOrder(FrappeTestCase):
 		rate = 100
 		amount = qty * rate
 
-		purchase_invoice = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"company": company,
-			"supplier": supplier,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": target_warehouse,
-					"qty": qty,
-					"rate": rate,
-					"amount": amount,
-				}
-			],
-			"update_stock": 1,
-		})
+		purchase_invoice = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"company": company,
+				"supplier": supplier,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"warehouse": target_warehouse,
+						"qty": qty,
+						"rate": rate,
+						"amount": amount,
+					}
+				],
+				"update_stock": 1,
+			}
+		)
 		purchase_invoice.bill_no = "test_bill_1122"
 		purchase_invoice.taxes_and_charges = ""
 		purchase_invoice.taxes = []
 		purchase_invoice.insert()
 		purchase_invoice.submit()
-		
 
-		purchase_invoice_return = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"company": company,
-			"supplier": supplier,
-			"is_return": 1,
-			"currency": "INR",
-			"return_against": purchase_invoice.name,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": target_warehouse,
-					"qty": -qty,
-					"rate": rate,
-					"amount": amount,
-				}
-			],
-			"update_stock": 1,
-		})
+		purchase_invoice_return = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"company": company,
+				"supplier": supplier,
+				"is_return": 1,
+				"currency": "INR",
+				"return_against": purchase_invoice.name,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"warehouse": target_warehouse,
+						"qty": -qty,
+						"rate": rate,
+						"amount": amount,
+					}
+				],
+				"update_stock": 1,
+			}
+		)
 		purchase_invoice_return.bill_no = "test_bill_1122"
 		purchase_invoice_return.taxes_and_charges = ""
 		purchase_invoice_return.taxes = []
 		purchase_invoice_return.insert()
 		purchase_invoice_return.submit()
-		
 
 		gl_entries = frappe.get_all(
 			"GL Entry",
@@ -1999,44 +2051,47 @@ class TestPurchaseOrder(FrappeTestCase):
 		amount = original_qty * rate
 		return_amount = return_qty * rate
 
-		purchase_invoice = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"company": company,
-			"supplier": supplier,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": target_warehouse,
-					"qty": original_qty,
-					"rate": rate,
-					"amount": amount,
-				}
-			],
-			"update_stock": 1,
-		})
+		purchase_invoice = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"company": company,
+				"supplier": supplier,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"warehouse": target_warehouse,
+						"qty": original_qty,
+						"rate": rate,
+						"amount": amount,
+					}
+				],
+				"update_stock": 1,
+			}
+		)
 		purchase_invoice.insert()
 		purchase_invoice.submit()
-		
 
-		purchase_invoice_return = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"company": company,
-			"supplier": supplier,
-			"is_return": 1,
-			"currency": "INR",
-			"return_against": purchase_invoice.name,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": target_warehouse,
-					"qty": -return_qty,
-					"rate": rate,
-					"amount": return_amount,
-				}
-			],
-			"update_stock": 1,
-		})
+		purchase_invoice_return = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"company": company,
+				"supplier": supplier,
+				"is_return": 1,
+				"currency": "INR",
+				"return_against": purchase_invoice.name,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"warehouse": target_warehouse,
+						"qty": -return_qty,
+						"rate": rate,
+						"amount": return_amount,
+					}
+				],
+				"update_stock": 1,
+			}
+		)
 		purchase_invoice_return.insert()
 		purchase_invoice_return.submit()
 
@@ -2079,50 +2134,51 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertTrue(stock_decrease_passed)
 
 	def test_pr_to_lcv_add_value_to_stock_TC_B_034(self):
-		frappe.db.set_value("Company", "_Test Company", {"enable_perpetual_inventory":1, "stock_received_but_not_billed": "Stock Adjustment - _TC"})
+		frappe.db.set_value(
+			"Company",
+			"_Test Company",
+			{"enable_perpetual_inventory": 1, "stock_received_but_not_billed": "Stock Adjustment - _TC"},
+		)
 		item = make_test_item("Testing-31")
 		create_supplier(supplier_name="_Test Supplier 1")
 		create_supplier(supplier_name="_Test Supplier")
 		get_or_create_fiscal_year("_Test Company")
 		# Step 1: Create Purchase Receipt
 		company = "_Test Company"
-		supplier = "_Test Supplier 1"
-		doc_pr = frappe.get_doc({
-			"doctype": "Purchase Receipt",
-			"company": "_Test Company",
-			"supplier": "_Test Supplier",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": "Stores - _TC",
-					"qty": 10,
-					"rate": 100,
-				}
-			]
-		})
+		doc_pr = frappe.get_doc(
+			{
+				"doctype": "Purchase Receipt",
+				"company": "_Test Company",
+				"supplier": "_Test Supplier",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"warehouse": "Stores - _TC",
+						"qty": 10,
+						"rate": 100,
+					}
+				],
+			}
+		)
 		doc_pr.insert()
 		doc_pr.submit()
 		self.assertEqual(doc_pr.docstatus, 1)
-		account = frappe.db.get_value("Account", {"company": company,'account_type':'Tax'}, "name")
-		doc_lcv = frappe.get_doc({
-			"doctype": "Landed Cost Voucher",
-			"company": "_Test Company",
-			"purchase_receipts": [
-				{
-					"receipt_document_type": "Purchase Receipt",
-					"receipt_document": doc_pr.name,
-					"supplier": doc_pr.supplier,
-					"grand_total": doc_pr.grand_total
-				}
-			],
-			"taxes": [
-				{
-					"expense_account": account,
-					"amount": 500,
-					"description": "test_description"
-				}
-			]
-		})
+		account = frappe.db.get_value("Account", {"company": company, "account_type": "Tax"}, "name")
+		doc_lcv = frappe.get_doc(
+			{
+				"doctype": "Landed Cost Voucher",
+				"company": "_Test Company",
+				"purchase_receipts": [
+					{
+						"receipt_document_type": "Purchase Receipt",
+						"receipt_document": doc_pr.name,
+						"supplier": doc_pr.supplier,
+						"grand_total": doc_pr.grand_total,
+					}
+				],
+				"taxes": [{"expense_account": account, "amount": 500, "description": "test_description"}],
+			}
+		)
 		doc_lcv.insert()
 		doc_lcv.submit()
 		self.assertEqual(doc_lcv.docstatus, 1)
@@ -2130,13 +2186,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		# Validate Stock Ledger Entries
 		stock_ledger_entries = frappe.get_all(
 			"Stock Ledger Entry",
-			filters={
-				"voucher_no": doc_pr.name,
-				"warehouse": "Stores - _TC",
-				"item_code": item.item_code
-			},
+			filters={"voucher_no": doc_pr.name, "warehouse": "Stores - _TC", "item_code": item.item_code},
 			fields=["valuation_rate"],
-			order_by="creation desc"
+			order_by="creation desc",
 		)
 		self.assertGreater(len(stock_ledger_entries), 0)
 
@@ -2145,14 +2197,13 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		# Validate GL Entries
 		gl_entries = frappe.get_all(
-			"GL Entry",
-			filters={"voucher_no": doc_pr.name},
-			fields=["account", "debit", "credit"]
+			"GL Entry", filters={"voucher_no": doc_pr.name}, fields=["account", "debit", "credit"]
 		)
 		self.assertGreater(len(gl_entries), 0)
 
 	def test_po_and_pi_with_pricing_rule_with_TC_B_048(self):
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import get_or_create_price_list
+
 		frappe.set_user("Administrator")
 		company = "_Test Company"
 		target_warehouse = "Stores - _TC"
@@ -2162,45 +2213,41 @@ class TestPurchaseOrder(FrappeTestCase):
 		item.is_purchase_item = 1
 		item.save()
 
-		item_price_doc = frappe.get_doc({
-			"doctype": "Item Price",
-			"price_list": get_or_create_price_list(),
-			"item_code": item.item_code,
-			"price_list_rate": item_price
-		}).insert(ignore_if_duplicate=1)
+		frappe.get_doc(
+			{
+				"doctype": "Item Price",
+				"price_list": get_or_create_price_list(),
+				"item_code": item.item_code,
+				"price_list_rate": item_price,
+			}
+		).insert(ignore_if_duplicate=1)
 
-		pricing_rule = frappe.get_doc({
-			"doctype": "Pricing Rule",
-			"title": "10% Discount",
-			"company": company,
-			"apply_on": "Item Code",
-			"items":[
-				{
-					"item_code":item.item_code
-				}
-			],
-			"rate_or_discount": "Discount Percentage",
-			"discount_percentage": 10,
-			"selling": 0,
-			"buying": 1
-		}).insert(ignore_if_duplicate=1)
+		frappe.get_doc(
+			{
+				"doctype": "Pricing Rule",
+				"title": "10% Discount",
+				"company": company,
+				"apply_on": "Item Code",
+				"items": [{"item_code": item.item_code}],
+				"rate_or_discount": "Discount Percentage",
+				"discount_percentage": 10,
+				"selling": 0,
+				"buying": 1,
+			}
+		).insert(ignore_if_duplicate=1)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date":today(),
-			"currency": "INR",
-			"buying_price_list": get_or_create_price_list(),
-			"set_warehouse": target_warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": target_warehouse,
-					"qty": 1
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"buying_price_list": get_or_create_price_list(),
+				"set_warehouse": target_warehouse,
+				"items": [{"item_code": item.item_code, "warehouse": target_warehouse, "qty": 1}],
+			}
+		)
 		po.insert()
 		po.submit()
 
@@ -2226,12 +2273,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-5"
 		tax_category = "test_category_1"
 		if not frappe.db.exists("Tax Category", tax_category):
-			tax_category = frappe.get_doc(
-				{
-					"doctype": "Tax Category",
-					"title": "test_category_1"
-				}
-			).insert()
+			tax_category = frappe.get_doc({"doctype": "Tax Category", "title": "test_category_1"}).insert()
 
 		purchase_tax = frappe.get_doc(
 			{
@@ -2241,43 +2283,50 @@ class TestPurchaseOrder(FrappeTestCase):
 				"tax_category": tax_category,
 				"taxes": [
 					{
-						"category":"Total",
-						"add_deduct_tax":"Add",
-						"charge_type":"On Net Total",
-						"account_head":"Cash - TC-5",
-						"rate":100,
-						"description":"GST"
+						"category": "Total",
+						"add_deduct_tax": "Add",
+						"charge_type": "On Net Total",
+						"account_head": "Cash - TC-5",
+						"rate": 100,
+						"description": "GST",
 					}
-				]
+				],
 			}
 		).insert(ignore_if_duplicate=1)
 
-		po = create_purchase_order(company = company, item_code = item.item_code, warehouse = warehouse, supplier = supplier, do_not_submit=True)
+		po = create_purchase_order(
+			company=company,
+			item_code=item.item_code,
+			warehouse=warehouse,
+			supplier=supplier,
+			do_not_submit=True,
+		)
 		po.currency = "INR"
 		po.taxes_and_charges = purchase_tax.name
 		po.save()
 		po.submit()
-		self.assertEqual(po.docstatus,1)
+		self.assertEqual(po.docstatus, 1)
 
 		args = {
-				"dt": po.doctype,
-				"dn": po.name,
-				"payment_request_type": 'Outward',
-				"party_type":  "Supplier",
-				"party":  po.supplier,
-				"party_name": po.supplier_name
-			}
+			"dt": po.doctype,
+			"dn": po.name,
+			"payment_request_type": "Outward",
+			"party_type": "Supplier",
+			"party": po.supplier,
+			"party_name": po.supplier_name,
+		}
 		partly_pr = make_payment_request(**args)
 		doc_pr = frappe.get_doc("Payment Request", partly_pr.name)
 		# set half amount to be paid
 		doc_pr.grand_total = po.grand_total / 2
 		doc_pr.submit()
-		po_status = frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status,'To Receive and Bill')
-	
+		po_status = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status, "To Receive and Bill")
+
 	def test_po_to_pr_with_gst_fully_paid_TC_B_086(self):
 		# Scenario : PO => PR with GST Fully Paid
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
 		create_company()
 		create_supplier(supplier_name="_Test Supplier")
 		create_warehouse(
@@ -2285,45 +2334,49 @@ class TestPurchaseOrder(FrappeTestCase):
 			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
 			company="_Test Company",
 		)
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		create_item("_Test Item")
 		purchase_tax = frappe.new_doc("Purchase Taxes and Charges Template")
 		purchase_tax.title = "TEST"
 		purchase_tax.company = "_Test Company"
-		
-		purchase_tax.append("taxes",{
-			"category":"Total",
-			"add_deduct_tax":"Add",
-			"charge_type":"On Net Total",
-			"account_head":"Stock In Hand - _TC",
-			"rate":100,
-			"description":"GST"
-		})
+
+		purchase_tax.append(
+			"taxes",
+			{
+				"category": "Total",
+				"add_deduct_tax": "Add",
+				"charge_type": "On Net Total",
+				"account_head": "Stock In Hand - _TC",
+				"rate": 100,
+				"description": "GST",
+			},
+		)
 		purchase_tax.save()
 		po = create_purchase_order(do_not_submit=True)
 		po.taxes_and_charges = purchase_tax.name
 		po.save()
 		po.submit()
-		self.assertEqual(po.docstatus,1)
+		self.assertEqual(po.docstatus, 1)
 
 		args = {
-				"dt": po.doctype,
-				"dn": po.name,
-				"payment_request_type": 'Outward',
-				"party_type":  "Supplier",
-				"party":  po.supplier,
-				"party_name": po.supplier_name
-			}
+			"dt": po.doctype,
+			"dn": po.name,
+			"payment_request_type": "Outward",
+			"party_type": "Supplier",
+			"party": po.supplier,
+			"party_name": po.supplier_name,
+		}
 		partly_pr = make_payment_request(**args)
 		doc_pr = frappe.get_doc("Payment Request", partly_pr.name)
-		doc_pr.grand_total = po.grand_total 
+		doc_pr.grand_total = po.grand_total
 		doc_pr.submit()
-		po_status = frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status,'To Receive and Bill')
-	
+		po_status = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status, "To Receive and Bill")
+
 	def test_po_to_pr_to_pi_fully_paid_TC_B_087(self):
-		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
+
 		create_company()
 		create_supplier(supplier_name="_Test Supplier")
 		create_warehouse(
@@ -2332,20 +2385,23 @@ class TestPurchaseOrder(FrappeTestCase):
 			company="_Test Company",
 		)
 		create_item("_Test Item")
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 
 		purchase_tax = frappe.new_doc("Purchase Taxes and Charges Template")
 		purchase_tax.title = "TEST"
 		purchase_tax.company = "_Test Company"
-		
-		purchase_tax.append("taxes",{
-			"category":"Total",
-			"add_deduct_tax":"Add",
-			"charge_type":"On Net Total",
-			"account_head":"Stock In Hand - _TC",
-			"rate":100,
-			"description":"GST"
-		})
+
+		purchase_tax.append(
+			"taxes",
+			{
+				"category": "Total",
+				"add_deduct_tax": "Add",
+				"charge_type": "On Net Total",
+				"account_head": "Stock In Hand - _TC",
+				"rate": 100,
+				"description": "GST",
+			},
+		)
 
 		purchase_tax.save()
 
@@ -2353,15 +2409,15 @@ class TestPurchaseOrder(FrappeTestCase):
 		po.taxes_and_charges = purchase_tax.name
 		po.save()
 		po.submit()
-		po_status_before = frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status_before,'To Receive and Bill')
+		po_status_before = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status_before, "To Receive and Bill")
 
 		pr = make_purchase_receipt(po.name)
 		pr.save()
 		pr.submit()
 
-		po_status_after_pr = frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status_after_pr,'To Bill')
+		po_status_after_pr = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status_after_pr, "To Bill")
 
 		pi = make_purchase_invoice(pr.name)
 		pi.is_paid = 1
@@ -2371,25 +2427,25 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi.save()
 		pi.submit()
 
-		pi_status = frappe.db.get_value("Purchase Invoice",pi.name,'status')
-		self.assertEqual(pi_status,'Paid')
+		pi_status = frappe.db.get_value("Purchase Invoice", pi.name, "status")
+		self.assertEqual(pi_status, "Paid")
 
-		po_status_after_paid =  frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status_after_paid,'Completed')
-	
+		po_status_after_paid = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status_after_paid, "Completed")
+
 	def test_po_to_pr_to_pi_partly_paid_TC_B_089(self):
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company_and_supplier as create_data,
+		)
+
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-3"
-		tax_category = frappe.get_doc(
-			{
-				"doctype": "Tax Category",
-				"title": "test_category"
-			}
-		).insert(ignore_if_duplicate=1)
+		tax_category = frappe.get_doc({"doctype": "Tax Category", "title": "test_category"}).insert(
+			ignore_if_duplicate=1
+		)
 
 		purchase_tax = frappe.get_doc(
 			{
@@ -2399,30 +2455,36 @@ class TestPurchaseOrder(FrappeTestCase):
 				"tax_category": tax_category,
 				"taxes": [
 					{
-						"category":"Total",
-						"add_deduct_tax":"Add",
-						"charge_type":"On Net Total",
-						"account_head":"Cash - TC-3",
-						"rate":100,
-						"description":"GST"
+						"category": "Total",
+						"add_deduct_tax": "Add",
+						"charge_type": "On Net Total",
+						"account_head": "Cash - TC-3",
+						"rate": 100,
+						"description": "GST",
 					}
-				]
+				],
 			}
 		).insert(ignore_if_duplicate=1)
 
-		po = create_purchase_order(company = company, item_code = item.item_code, warehouse = warehouse, supplier = supplier, do_not_submit=True)
+		po = create_purchase_order(
+			company=company,
+			item_code=item.item_code,
+			warehouse=warehouse,
+			supplier=supplier,
+			do_not_submit=True,
+		)
 		po.taxes_and_charges = purchase_tax.name
 		po.save()
 		po.submit()
-		po_status_before = frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status_before,'To Receive and Bill')
+		po_status_before = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status_before, "To Receive and Bill")
 
 		pr = make_purchase_receipt(po.name)
 		pr.save()
 		pr.submit()
 
-		po_status_after_pr = frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status_after_pr,'To Bill')
+		po_status_after_pr = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status_after_pr, "To Bill")
 
 		pi = make_purchase_invoice(pr.name)
 		pi.is_paid = 1
@@ -2433,21 +2495,21 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi.save()
 		pi.submit()
 
-		pi_status = frappe.db.get_value("Purchase Invoice",pi.name,'status')
-		self.assertEqual(pi_status,'Partly Paid')
+		pi_status = frappe.db.get_value("Purchase Invoice", pi.name, "status")
+		self.assertEqual(pi_status, "Partly Paid")
 
-		po_status_after_paid =  frappe.db.get_value("Purchase Order",po.name,'status')
-		self.assertEqual(po_status_after_paid,'Completed')
+		po_status_after_paid = frappe.db.get_value("Purchase Order", po.name, "status")
+		self.assertEqual(po_status_after_paid, "Completed")
 
 	def test_po_return_TC_B_043(self):
 		# Scenario : PO => PR => PI => PI(Return)
-		args = frappe._dict()
+		frappe._dict()
 		po_data = {
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
-			"qty" : 6,
-			"rate" : 100,
+			"company": "_Test Company",
+			"item_code": "_Test Item",
+			"warehouse": "Stores - _TC",
+			"qty": 6,
+			"rate": 100,
 		}
 
 		doc_po = create_purchase_order(**po_data)
@@ -2464,8 +2526,8 @@ class TestPurchaseOrder(FrappeTestCase):
 		doc_returned_pi = make_return_pi(doc_pi.name)
 		self.assertEqual(doc_returned_pi.total_qty, -doc_po.total_qty)
 		doc_pi.reload()
-		self.assertEqual(doc_pi.status, 'Debit Note Issued')
-		self.assertEqual(doc_returned_pi.status, 'Return')
+		self.assertEqual(doc_pi.status, "Debit Note Issued")
+		self.assertEqual(doc_returned_pi.status, "Return")
 
 	def test_po_full_payment_TC_B_045(self):
 		# Scenario : PO => Payment Entry => PR => PI => PI(Return)
@@ -2475,13 +2537,13 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("_test_item")
 		warehouse = "Stores - TC-3"
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
-			"warehouse" : warehouse,
-			"qty" : 6,
-			"rate" : 100,
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": warehouse,
+			"qty": 6,
+			"rate": 100,
 			"supplier": supplier,
-			"uom": "Nos"
+			"uom": "Nos",
 		}
 
 		doc_po = create_purchase_order(**po_data)
@@ -2496,19 +2558,20 @@ class TestPurchaseOrder(FrappeTestCase):
 		doc_pr = make_pr_for_po(doc_po.name)
 		self.assertEqual(doc_pr.docstatus, 1)
 
-		doc_pi = make_pi_against_pr(doc_pr.name, args={"is_paid" : 1, "cash_bank_account" : doc_pe.paid_from})
+		doc_pi = make_pi_against_pr(doc_pr.name, args={"is_paid": 1, "cash_bank_account": doc_pe.paid_from})
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.items[0].qty, doc_po.items[0].qty)
 		self.assertEqual(doc_pi.grand_total, doc_po.grand_total)
 
 		doc_pi.reload()
 		doc_po.reload()
-		self.assertEqual(doc_pi.status, 'Paid')
-		self.assertEqual(doc_po.status, 'Completed')
+		self.assertEqual(doc_pi.status, "Paid")
+		self.assertEqual(doc_po.status, "Completed")
 
 	def test_po_with_pricing_rule_TC_B_046(self):
 		# Scenario : PO => Pricing Rule => PR => PI
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import get_or_create_price_list
+
 		get_data = get_company_or_supplier()
 		company = get_data.get("company")
 		supplier = get_data.get("supplier")
@@ -2516,13 +2579,13 @@ class TestPurchaseOrder(FrappeTestCase):
 		price_list = get_or_create_price_list()
 
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
-			"warehouse" : "Stores - TC-5",
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": "Stores - TC-5",
 			"supplier": supplier,
 			"schedule_date": today(),
-			"qty" : 1,
-			"currency":"INR",
+			"qty": 1,
+			"currency": "INR",
 			"buying_price_list": price_list,
 		}
 
@@ -2540,17 +2603,15 @@ class TestPurchaseOrder(FrappeTestCase):
 			"supplier": supplier,
 			"buying": 1,
 			"currency": "INR",
-
 			"min_qty": 1,
 			"min_amt": 100,
 			"valid_from": today(),
 			"rate_or_discount": "Discount Percentage",
 			"discount_percentage": 10,
 			"price_list": price_list,
-			"company" : company,
-
+			"company": company,
 		}
-		if not frappe.db.exists('Pricing Rule', {'title': 'Discount on _Test Item'}):
+		if not frappe.db.exists("Pricing Rule", {"title": "Discount on _Test Item"}):
 			rule = frappe.get_doc(pricing_rule_record)
 			rule.insert()
 
@@ -2559,14 +2620,14 @@ class TestPurchaseOrder(FrappeTestCase):
 				"doctype": "Item Price",
 				"price_list": price_list,
 				"item_code": item.item_code,
-				"price_list_rate": 130
+				"price_list_rate": 130,
 			}
 		).insert()
 
 		doc_po = create_purchase_order(**po_data)
 		doc_po_item = doc_po.items[0]
 		self.assertEqual(doc_po_item.discount_percentage, 10)
-		self.assertEqual(doc_po_item.rate, 117)  
+		self.assertEqual(doc_po_item.rate, 117)
 		self.assertEqual(doc_po_item.amount, 117)
 
 		doc_pr = make_pr_for_po(doc_po.name)
@@ -2576,20 +2637,21 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi_item.rate, 117)
 		self.assertEqual(pi_item.amount, 117)
 		frappe.delete_doc_if_exists("Pricing Rule", "Discount on _Test Item")
-		
+
 	def setUp(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
-		create_company()
-		validate_fiscal_year('_Test Company')
-		create_company_and_suppliers()
 
+		create_company()
+		validate_fiscal_year("_Test Company")
+		create_company_and_suppliers()
 
 	def tearDown(self):
 		frappe.db.rollback()
 
 	def test_po_with_pricing_rule_TC_B_047(self):
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import get_or_create_price_list
-		# Scenario : PO => Pricing Rule => PR 
+
+		# Scenario : PO => Pricing Rule => PR
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
@@ -2598,13 +2660,13 @@ class TestPurchaseOrder(FrappeTestCase):
 		price_list = get_or_create_price_list()
 		get_or_create_fiscal_year(company)
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
-			"warehouse" : warehouse,
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": warehouse,
 			"supplier": supplier,
 			"schedule_date": today(),
-			"qty" : 1,
-			"currency":"INR",
+			"qty": 1,
+			"currency": "INR",
 			"buying_price_list": price_list,
 		}
 
@@ -2616,23 +2678,21 @@ class TestPurchaseOrder(FrappeTestCase):
 				{
 					"item_code": item.item_code,
 				}
-				],
+			],
 			"price_or_product_discount": "Price",
 			"applicable_for": "Supplier",
 			"supplier": supplier,
 			"buying": 1,
 			"currency": "INR",
-
 			"min_qty": 1,
 			"min_amt": 100,
 			"valid_from": today(),
 			"rate_or_discount": "Discount Percentage",
 			"discount_percentage": 10,
 			"price_list": price_list,
-			"company" : company,
-
+			"company": company,
 		}
-		if not frappe.db.exists('Pricing Rule', {'title': 'Discount on _Test Item'}):
+		if not frappe.db.exists("Pricing Rule", {"title": "Discount on _Test Item"}):
 			rule = frappe.get_doc(pricing_rule_record)
 			rule.insert()
 
@@ -2651,10 +2711,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(po_item.rate, 117)
 		self.assertEqual(po_item.amount, 117)
 
-
 		doc_pr = make_pr_for_po(doc_po.name)
 		pr_item = doc_pr.items[0]
-		self.assertEqual(pr_item.rate, 117) 
+		self.assertEqual(pr_item.rate, 117)
 		self.assertEqual(pr_item.amount, 117)
 		frappe.delete_doc_if_exists("Pricing Rule", "Discount on _Test Item")
 
@@ -2662,33 +2721,38 @@ class TestPurchaseOrder(FrappeTestCase):
 		# Scenario : PO => PR => PI [With Additional Discount]
 
 		po_data = {
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
+			"company": "_Test Company",
+			"item_code": "_Test Item",
+			"warehouse": "Stores - _TC",
 			"supplier": "_Test Supplier",
 			"schedule_date": "2025-01-13",
-			"qty" : 1,
-			"rate" : 10000,
-			"apply_discount_on" : "Net Total",
-			"additional_discount_percentage" :10 ,
-			"do_not_submit":1
+			"qty": 1,
+			"rate": 10000,
+			"apply_discount_on": "Net Total",
+			"additional_discount_percentage": 10,
+			"do_not_submit": 1,
 		}
 
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax IGST"
 		acc.parent_account = "Tax Assets - _TC"
 		acc.company = "_Test Company"
-		account_name = frappe.db.exists("Account", {"account_name" : "Input Tax IGST","company": "_Test Company" })
+		account_name = frappe.db.exists(
+			"Account", {"account_name": "Input Tax IGST", "company": "_Test Company"}
+		)
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
 
 		doc_po = create_purchase_order(**po_data)
-		doc_po.append("taxes", {
-					"charge_type": "On Net Total",
-					"account_head": account_name,
-					"rate": 12,
-					"description": "Input GST",
-				})
+		doc_po.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": account_name,
+				"rate": 12,
+				"description": "Input GST",
+			},
+		)
 		doc_po.submit()
 		self.assertEqual(doc_po.discount_amount, 1000)
 		self.assertEqual(doc_po.grand_total, 10080)
@@ -2700,43 +2764,50 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(doc_pi.grand_total, 10080)
 
 		# Accounting Ledger Checks
-		pi_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"])
+		pi_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"]
+		)
 
 		# PI Ledger Validation
 		pi_total = sum(entry["debit"] for entry in pi_gl_entries)
-		self.assertEqual(pi_total, 10080) 
+		self.assertEqual(pi_total, 10080)
 
 	def test_po_additional_discount_TC_B_055(self):
 		# Scenario : PO => PI [With Additional Discount]
 
 		po_data = {
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
+			"company": "_Test Company",
+			"item_code": "_Test Item",
+			"warehouse": "Stores - _TC",
 			"supplier": "_Test Supplier",
 			"schedule_date": "2025-01-13",
-			"qty" : 1,
-			"rate" : 10000,
-			"apply_discount_on" : "Net Total",
-			"additional_discount_percentage" :10 ,
-			"do_not_submit":1
+			"qty": 1,
+			"rate": 10000,
+			"apply_discount_on": "Net Total",
+			"additional_discount_percentage": 10,
+			"do_not_submit": 1,
 		}
 
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax IGST"
 		acc.parent_account = "Tax Assets - _TC"
 		acc.company = "_Test Company"
-		account_name = frappe.db.exists("Account", {"account_name" : "Input Tax IGST","company": "_Test Company" })
+		account_name = frappe.db.exists(
+			"Account", {"account_name": "Input Tax IGST", "company": "_Test Company"}
+		)
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
 
 		doc_po = create_purchase_order(**po_data)
-		doc_po.append("taxes", {
-					"charge_type": "On Net Total",
-					"account_head": account_name,
-					"rate": 12,
-					"description": "Input GST",
-				})
+		doc_po.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": account_name,
+				"rate": 12,
+				"description": "Input GST",
+			},
+		)
 		doc_po.submit()
 		self.assertEqual(doc_po.discount_amount, 1000)
 		self.assertEqual(doc_po.grand_total, 10080)
@@ -2748,43 +2819,50 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(doc_pi.grand_total, 10080)
 
 		# Accounting Ledger Checks
-		pi_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"])
+		pi_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"]
+		)
 
 		# PI Ledger Validation
 		pi_total = sum(entry["debit"] for entry in pi_gl_entries)
-		self.assertEqual(pi_total, 10080) 
+		self.assertEqual(pi_total, 10080)
 
 	def test_po_additional_discount_TC_B_058(self):
 		# Scenario : PO => PR => PI [With Additional Discount on Grand Total]
 
 		po_data = {
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
+			"company": "_Test Company",
+			"item_code": "_Test Item",
+			"warehouse": "Stores - _TC",
 			"supplier": "_Test Supplier",
 			"schedule_date": "2025-01-13",
-			"qty" : 1,
-			"rate" : 10000,
-			"apply_discount_on" : "Grand Total",
-			"additional_discount_percentage" :10 ,
-			"do_not_submit":1
+			"qty": 1,
+			"rate": 10000,
+			"apply_discount_on": "Grand Total",
+			"additional_discount_percentage": 10,
+			"do_not_submit": 1,
 		}
 
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax IGST"
 		acc.parent_account = "Tax Assets - _TC"
 		acc.company = "_Test Company"
-		account_name = frappe.db.exists("Account", {"account_name" : "Input Tax IGST","company": "_Test Company" })
+		account_name = frappe.db.exists(
+			"Account", {"account_name": "Input Tax IGST", "company": "_Test Company"}
+		)
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
 
 		doc_po = create_purchase_order(**po_data)
-		doc_po.append("taxes", {
-					"charge_type": "On Net Total",
-					"account_head": account_name,
-					"rate": 12,
-					"description": "Input GST",
-				})
+		doc_po.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": account_name,
+				"rate": 12,
+				"description": "Input GST",
+			},
+		)
 		doc_po.submit()
 		self.assertEqual(doc_po.discount_amount, 1120)
 		self.assertEqual(doc_po.grand_total, 10080)
@@ -2796,43 +2874,50 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(doc_pi.grand_total, 10080)
 
 		# Accounting Ledger Checks
-		pi_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"])
+		pi_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"]
+		)
 
 		# PI Ledger Validation
 		pi_total = sum(entry["debit"] for entry in pi_gl_entries)
-		self.assertEqual(pi_total, 10080) 
+		self.assertEqual(pi_total, 10080)
 
 	def test_po_additional_discount_TC_B_061(self):
 		# Scenario : PO => PI [With Additional Discount]
 
 		po_data = {
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
+			"company": "_Test Company",
+			"item_code": "_Test Item",
+			"warehouse": "Stores - _TC",
 			"supplier": "_Test Supplier",
 			"schedule_date": "2025-01-13",
-			"qty" : 1,
-			"rate" : 10000,
-			"apply_discount_on" : "Grand Total",
-			"additional_discount_percentage" :10 ,
-			"do_not_submit":1
+			"qty": 1,
+			"rate": 10000,
+			"apply_discount_on": "Grand Total",
+			"additional_discount_percentage": 10,
+			"do_not_submit": 1,
 		}
 
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax IGST"
 		acc.parent_account = "Tax Assets - _TC"
 		acc.company = "_Test Company"
-		account_name = frappe.db.exists("Account", {"account_name" : "Input Tax IGST","company": "_Test Company" })
+		account_name = frappe.db.exists(
+			"Account", {"account_name": "Input Tax IGST", "company": "_Test Company"}
+		)
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
 
 		doc_po = create_purchase_order(**po_data)
-		doc_po.append("taxes", {
-					"charge_type": "On Net Total",
-					"account_head": account_name,
-					"rate": 12,
-					"description": "Input GST",
-				})
+		doc_po.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": account_name,
+				"rate": 12,
+				"description": "Input GST",
+			},
+		)
 		doc_po.submit()
 		self.assertEqual(doc_po.discount_amount, 1120)
 		self.assertEqual(doc_po.grand_total, 10080)
@@ -2844,43 +2929,50 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(doc_pi.grand_total, 10080)
 
 		# Accounting Ledger Checks
-		pi_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"])
+		pi_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pi.name}, fields=["account", "debit", "credit"]
+		)
 
 		# PI Ledger Validation
 		pi_total = sum(entry["debit"] for entry in pi_gl_entries)
-		self.assertEqual(pi_total, 10080) 
+		self.assertEqual(pi_total, 10080)
 
 	def test_po_additional_discount_TC_B_063(self):
 		# Scenario : PO => PI [With Additional Discount]
 
 		po_data = {
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
+			"company": "_Test Company",
+			"item_code": "_Test Item",
+			"warehouse": "Stores - _TC",
 			"supplier": "_Test Supplier",
 			"schedule_date": "2025-01-13",
-			"qty" : 1,
-			"rate" : 10000,
-			"apply_discount_on" : "Grand Total",
-			"additional_discount_percentage" :10 ,
-			"do_not_submit":1
+			"qty": 1,
+			"rate": 10000,
+			"apply_discount_on": "Grand Total",
+			"additional_discount_percentage": 10,
+			"do_not_submit": 1,
 		}
 
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax IGST"
 		acc.parent_account = "Tax Assets - _TC"
 		acc.company = "_Test Company"
-		account_name = frappe.db.exists("Account", {"account_name" : "Input Tax IGST","company": "_Test Company" })
+		account_name = frappe.db.exists(
+			"Account", {"account_name": "Input Tax IGST", "company": "_Test Company"}
+		)
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
 
 		doc_po = create_purchase_order(**po_data)
-		doc_po.append("taxes", {
-					"charge_type": "On Net Total",
-					"account_head": account_name,
-					"rate": 12,
-					"description": "Input GST",
-				})
+		doc_po.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": account_name,
+				"rate": 12,
+				"description": "Input GST",
+			},
+		)
 		doc_po.submit()
 		self.assertEqual(doc_po.discount_amount, 1120)
 		self.assertEqual(doc_po.grand_total, 10080)
@@ -2896,21 +2988,18 @@ class TestPurchaseOrder(FrappeTestCase):
 		item.is_sales_item = 0
 		item.save()
 
-		pi = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": target_warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": target_warehouse,
-					"qty": 1,
-					"rate": item_price
-				}
-			]
-		})
+		pi = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": target_warehouse,
+				"items": [
+					{"item_code": item.item_code, "warehouse": target_warehouse, "qty": 1, "rate": item_price}
+				],
+			}
+		)
 		pi.bill_no = "test_bill_1122"
 		pi.insert(ignore_permissions=True)
 		self.assertEqual(len(pi.items), 1)
@@ -2926,54 +3015,58 @@ class TestPurchaseOrder(FrappeTestCase):
 	def test_partial_pr_pi_flow_TC_B_103(self):
 		# Scenario : PO > PR > PI
 		from frappe.desk.query_report import run
-		item_1= create_item("_Test Items")
-		item_2= create_item("Books")
+
+		item_1 = create_item("_Test Items")
+		item_2 = create_item("Books")
 		supplier = create_supplier(supplier_name="_Test Supplier")
 		company = "_Test Company"
 		if not frappe.db.exists("Company", company):
 			company = frappe.new_doc("Company")
 			company.company_name = company
-			company.country="India",
-			company.default_currency= "INR",
+			company.country = ("India",)
+			company.default_currency = ("INR",)
 			company.save()
 		else:
-			company = frappe.get_doc("Company", company) 
+			company = frappe.get_doc("Company", company)
 		warehouse = create_warehouse("Stores - _TC")
 		po_data = {
 			"doctype": "Purchase Order",
 			"supplier": supplier.name,
-			"company" : company.name,
+			"company": company.name,
 			"transaction_date": today(),
-			"warehouse" : warehouse,
-			"items":[
+			"warehouse": warehouse,
+			"items": [
 				{
 					"item_code": item_1.item_code,
 					"qty": 10,
 					"rate": 100,
 					"warehouse": warehouse,
-					"schedule_date": today()
+					"schedule_date": today(),
 				},
 				{
 					"item_code": item_2.item_code,
 					"qty": 5,
 					"rate": 500,
 					"warehouse": warehouse,
-					"schedule_date": add_days(today(), 1)
-				}
-			]
-		} 
+					"schedule_date": add_days(today(), 1),
+				},
+			],
+		}
 		doc_po = frappe.get_doc(po_data)
 		doc_po.insert()
 		taxes = create_taxes_interstate()
 		for tax in taxes:
 			doc_po.append("taxes", tax)
 		doc_po.submit()
-		purchase_order_analysis = run("Purchase Order Analysis",
-								 		filters={"company":doc_po.company,
-												"from_date": doc_po.schedule_date, 
-												"to_date": doc_po.schedule_date,
-												"name":doc_po.name
-												})
+		purchase_order_analysis = run(
+			"Purchase Order Analysis",
+			filters={
+				"company": doc_po.company,
+				"from_date": doc_po.schedule_date,
+				"to_date": doc_po.schedule_date,
+				"name": doc_po.name,
+			},
+		)
 		result_list = purchase_order_analysis.get("result", [])
 		for result in result_list:
 			if isinstance(result, dict):
@@ -3002,12 +3095,15 @@ class TestPurchaseOrder(FrappeTestCase):
 				item.qty = 5
 		pr.save()
 		pr.submit()
-		purchase_order_analysis_2 = run("Purchase Order Analysis",
-								 		filters={"company":doc_po.company,
-												"from_date": doc_po.schedule_date, 
-												"to_date": doc_po.schedule_date,
-												"name":doc_po.name
-												})
+		purchase_order_analysis_2 = run(
+			"Purchase Order Analysis",
+			filters={
+				"company": doc_po.company,
+				"from_date": doc_po.schedule_date,
+				"to_date": doc_po.schedule_date,
+				"name": doc_po.name,
+			},
+		)
 		result_list_2 = purchase_order_analysis_2.get("result", [])
 		result_list_2 = purchase_order_analysis_2.get("result", [])
 		for result_2 in result_list_2:
@@ -3044,46 +3140,53 @@ class TestPurchaseOrder(FrappeTestCase):
 		if not frappe.db.exists("Company", company):
 			company = frappe.new_doc("Company")
 			company.company_name = company
-			company.country="India",
-			company.default_currency= "INR",
+			company.country = ("India",)
+			company.default_currency = ("INR",)
 			company.save()
 		else:
-			company = frappe.get_doc("Company", company) 
+			company = frappe.get_doc("Company", company)
 		item = create_item("Test Item")
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Environmental Cess a/c"
 		acc.parent_account = "Indirect Expenses - _TC"
 		acc.account_type = "Chargeable"
 		acc.company = company.name
-		account_name_cess = frappe.db.exists("Account", {"account_name": "Environmental Cess a/c", "company": company.name})
+		account_name_cess = frappe.db.exists(
+			"Account", {"account_name": "Environmental Cess a/c", "company": company.name}
+		)
 		if not account_name_cess:
 			account_name_cess = acc.insert(ignore_permissions=True)
-		
+
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax CGST"
 		acc.parent_account = "Tax Assets - _TC"
 		acc.company = company.name
-		account_name = frappe.db.exists("Account", {"account_name" : "Input Tax CGST","company": company.name })
+		account_name = frappe.db.exists(
+			"Account", {"account_name": "Input Tax CGST", "company": company.name}
+		)
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
-		
+
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax SGST"
 		acc.parent_account = "Tax Assets - _TC"
 		acc.company = company.name
-		account_name = frappe.db.exists("Account", {"account_name" : "Input Tax SGST","company": company.name })
+		account_name = frappe.db.exists(
+			"Account", {"account_name": "Input Tax SGST", "company": company.name}
+		)
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
 
 		taxes = create_taxes_interstate()
-		taxes.append({
-			"charge_type": "On Previous Row Total",
-			"account_head": account_name_cess,
-			"rate": 5,
-			"description": "Environmental Cess",
-			"row_id":2,
-			"category": "Total"
-		}
+		taxes.append(
+			{
+				"charge_type": "On Previous Row Total",
+				"account_head": account_name_cess,
+				"rate": 5,
+				"description": "Environmental Cess",
+				"row_id": 2,
+				"category": "Total",
+			}
 		)
 		po_data = {
 			"company": company.name,
@@ -3092,7 +3195,7 @@ class TestPurchaseOrder(FrappeTestCase):
 			"item_code": item.item_code,
 			"qty": 10,
 			"rate": 100,
-			"do_not_submit" : 1
+			"do_not_submit": 1,
 		}
 		doc_po = create_purchase_order(**po_data)
 		for tax in taxes:
@@ -3116,35 +3219,39 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-5"
 
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Net Weight Shipping Rule",
-			"calculate_based_on": "Fixed",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-5",
-			"cost_center": "Main - TC-5",
-			"shipping_amount": 200
-		}).insert(ignore_if_duplicate=1)
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Net Weight Shipping Rule",
+				"calculate_based_on": "Fixed",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-5",
+				"cost_center": "Main - TC-5",
+				"shipping_amount": 200,
+			}
+		).insert(ignore_if_duplicate=1)
 
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 1,
-					"rate": 3000,
-					"warehouse": warehouse,
-				}
-			],
-			"shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 1,
+						"rate": 3000,
+						"warehouse": warehouse,
+					}
+				],
+				"shipping_rule": shipping_rule.name,
+			}
+		)
 		po.insert()
 		po.submit()
 
@@ -3157,29 +3264,35 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.submit()
 		self.assertEqual(pr.status, "To Bill")
 
-		sle = frappe.get_all("Stock Ledger Entry", filters={"voucher_no": pr.name}, fields=['actual_qty', 'item_code'])
+		sle = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_no": pr.name}, fields=["actual_qty", "item_code"]
+		)
 		self.assertEqual(len(sle), 1)
-		self.assertEqual(sle[0]['actual_qty'], 1)
+		self.assertEqual(sle[0]["actual_qty"], 1)
 
-		gl_entries_pr = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		for gl in gl_entries_pr:
-			if gl['account'] == "Stock In Hand - TC-5":
-				self.assertEqual(gl['debit'], 3200)
-			elif gl['account'] == "Stock Received But Not Billed - TC-5":
-				self.assertEqual(gl['credit'], 3000)
-			elif gl['account'] == "_Test Account Shipping Charges - TC-5":
-				self.assertEqual(gl['credit'], 200)
+			if gl["account"] == "Stock In Hand - TC-5":
+				self.assertEqual(gl["debit"], 3200)
+			elif gl["account"] == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(gl["credit"], 3000)
+			elif gl["account"] == "_Test Account Shipping Charges - TC-5":
+				self.assertEqual(gl["credit"], 200)
 
 		pi = make_purchase_invoice(pr.name)
 		pi.insert()
 		pi.submit()
 		self.assertEqual(pi.status, "Unpaid")
-		gl_entries_pi = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		for gl_entry in gl_entries_pi:
-			if gl_entry['account'] == "Creditors - TC-5":
-				self.assertEqual(gl_entry['credit'], 3200)
-			elif gl_entry['account'] == "Stock Received But Not Billed - TC-5":
-				self.assertEqual(gl_entry['debit'], 3000)
+			if gl_entry["account"] == "Creditors - TC-5":
+				self.assertEqual(gl_entry["credit"], 3200)
+			elif gl_entry["account"] == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(gl_entry["debit"], 3000)
 
 		po.reload()
 		pr.reload()
@@ -3188,10 +3301,7 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_po_pi_pr_flow_TC_B_067(self):
 		# Scenario : PO => PI => PR [With Shipping Rule]
-		args = {
-					"calculate_based_on" : "Fixed",
-					"shipping_amount" : 200
-				}
+		args = {"calculate_based_on": "Fixed", "shipping_amount": 200}
 		doc_shipping_rule = create_shipping_rule("Buying", "_Test Shipping Rule _TC", args)
 		item = create_item("_Test Item")
 		supplier = create_supplier(supplier_name="_Test Supplier PO")
@@ -3199,32 +3309,31 @@ class TestPurchaseOrder(FrappeTestCase):
 		if not frappe.db.exists("Company", company):
 			company = frappe.new_doc("Company")
 			company.company_name = company
-			company.country="India",
-			company.default_currency= "INR",
+			company.country = ("India",)
+			company.default_currency = ("INR",)
 			company.save()
 		else:
 			company = frappe.get_doc("Company", company)
 		po_data = {
-			"company" : company.name,
-			"supplier":supplier.name,
-			"item_code" : item.item_code,
-			"warehouse" : create_warehouse("Stores - _TC", company=company.name),
-			"qty" : 1,
-			"rate" : 3000,
-			"shipping_rule" :doc_shipping_rule.name
-
+			"company": company.name,
+			"supplier": supplier.name,
+			"item_code": item.item_code,
+			"warehouse": create_warehouse("Stores - _TC", company=company.name),
+			"qty": 1,
+			"rate": 3000,
+			"shipping_rule": doc_shipping_rule.name,
 		}
-		
+
 		doc_po = create_purchase_order(**po_data)
 		self.assertEqual(doc_po.docstatus, 1)
 
 		doc_pi = make_pi_direct_aganist_po(doc_po.name)
 		self.assertEqual(doc_pi.docstatus, 1)
-		
+
 		doc_pr = make_pr_form_pi(doc_pi.name)
 		doc_po.reload()
-		self.assertEqual(doc_po.status, 'Completed')
-		self.assertEqual(doc_pr.status, 'Completed')
+		self.assertEqual(doc_po.status, "Completed")
+		self.assertEqual(doc_pr.status, "Completed")
 
 	@if_app_installed("india_compliance")
 	def test_inter_state_CGST_and_SGST_TC_B_097(self):
@@ -3235,13 +3344,13 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("_test_item")
 		tax_account = create_or_get_purchase_taxes_template(company)
 		po = create_purchase_order(
-			company = company,
-			supplier = supplier,
+			company=company,
+			supplier=supplier,
 			qty=1,
-			rate = 100,
-			warehouse = warehouse,
-			item_code = item.item_code,
-			do_not_save=True
+			rate=100,
+			warehouse=warehouse,
+			item_code=item.item_code,
+			do_not_save=True,
 		)
 		taxes = [
 			{
@@ -3249,59 +3358,64 @@ class TestPurchaseOrder(FrappeTestCase):
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('sgst_account'),
-				"description": "SGST"
+				"account_head": tax_account.get("sgst_account"),
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('cgst_account'),
-				"description": "CGST"
-			}
+				"account_head": tax_account.get("cgst_account"),
+				"description": "CGST",
+			},
 		]
 		for tax in taxes:
 			po.append("taxes", tax)
 		po.save()
 		po.submit()
 		po.reload()
-	
+
 		self.assertEqual(po.grand_total, 118)
-	
+
 		pr = make_purchase_receipt(po.name)
 		pr.insert()
 		pr.submit()
 		pr.reload()
-		account_entries = frappe.db.get_all('GL Entry',{'voucher_type':'Purchase Receipt','voucher_no':pr.name},['account','debit','credit'])
+		account_entries = frappe.db.get_all(
+			"GL Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["account", "debit", "credit"],
+		)
 		for entries in account_entries:
-			if entries.account == 'Stock In Hand - TC-5':
+			if entries.account == "Stock In Hand - TC-5":
 				self.assertEqual(entries.debit, 100)
-			if entries.account == 'Stock Received But Not Billed - TC-5':
+			if entries.account == "Stock Received But Not Billed - TC-5":
 				self.assertEqual(entries.credit, 100)
 
-		stock_entries = frappe.db.get_value('Stock Ledger Entry',{'voucher_no':pr.name},'item_code')
-		self.assertEqual(stock_entries,pr.items[0].item_code)
+		stock_entries = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": pr.name}, "item_code")
+		self.assertEqual(stock_entries, pr.items[0].item_code)
 
 		pi = make_pi_from_pr(pr.name)
 		pi.save()
 		pi.submit()
 
-		account_entries_pi = frappe.db.get_all('GL Entry',{'voucher_no':pi.name},['account','debit','credit'])
+		account_entries_pi = frappe.db.get_all(
+			"GL Entry", {"voucher_no": pi.name}, ["account", "debit", "credit"]
+		)
 		for entries in account_entries_pi:
-			if entries.account == 'Input Tax SGST - TC-5':
+			if entries.account == "Input Tax SGST - TC-5":
 				self.assertEqual(entries.debit, 9)
-			if entries.account == 'Input Tax CGST - TC-5':
+			if entries.account == "Input Tax CGST - TC-5":
 				self.assertEqual(entries.debit, 9)
-			if entries.account == 'Stock Received But Not Billed - TC-5':
-				self.assertEqual(entries.debit,100)
-			if entries.account == 'Creditors - TC-5':
+			if entries.account == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(entries.debit, 100)
+			if entries.account == "Creditors - TC-5":
 				self.assertEqual(entries.credit, 118.0)
-
-	
 
 	def test_outer_state_IGST_TC_B_098(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
 		create_company()
 		company = "_Test Company"
 		if not frappe.db.exists("Tax Category", "Out-State"):
@@ -3309,41 +3423,47 @@ class TestPurchaseOrder(FrappeTestCase):
 			tax_category.title = "Out-State"
 			tax_category.save()
 
-		exists_purchase_tax = frappe.db.get_value('Purchase Taxes and Charges Template',{'company':company,'tax_category':'Out-State'},'name')
+		exists_purchase_tax = frappe.db.get_value(
+			"Purchase Taxes and Charges Template", {"company": company, "tax_category": "Out-State"}, "name"
+		)
 		if exists_purchase_tax is None:
 			purchase_tax_and_template = frappe.new_doc("Purchase Taxes and Charges Template")
-			purchase_tax_and_template.title = 'Test'
+			purchase_tax_and_template.title = "Test"
 			purchase_tax_and_template.company = company
-			purchase_tax_and_template.tax_category = 'Out-State'
-			purchase_tax_and_template.append("taxes", {
-				'category': 'Total',
-				'add_deduct_tax':'Add',
-				'rate': 18,
-				'account_head': 'Stock In Hand - _TC',
-				'description':'test'
-
-			})
+			purchase_tax_and_template.tax_category = "Out-State"
+			purchase_tax_and_template.append(
+				"taxes",
+				{
+					"category": "Total",
+					"add_deduct_tax": "Add",
+					"rate": 18,
+					"account_head": "Stock In Hand - _TC",
+					"description": "test",
+				},
+			)
 			purchase_tax_and_template.save()
 
 			purchase_tax = purchase_tax_and_template.name
 		else:
 			purchase_tax = exists_purchase_tax
 
-		get_or_create_fiscal_year('_Test Company')
-		
+		get_or_create_fiscal_year("_Test Company")
+
 		create_supplier(supplier_name="_Test Registered Supplier")
 		warehouse = create_warehouse(
 			warehouse_name="_Test Warehouse - _TC",
 			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
 			company=company,
 		)
-		create_item("_Test Item",warehouse=warehouse)
-		po = create_purchase_order(supplier='_Test Registered Supplier',qty=1,rate = 100, do_not_save=True)
+		create_item("_Test Item", warehouse=warehouse)
+		po = create_purchase_order(supplier="_Test Registered Supplier", qty=1, rate=100, do_not_save=True)
 		po.save()
-		
-		p =  frappe.db.get_all("Account",{'company':po.company},["name"])
-	
-		purchase_tax_and_value = frappe.db.get_value('Purchase Taxes and Charges Template',{'company':po.company,'tax_category':'Out-State'},'name')
+
+		purchase_tax_and_value = frappe.db.get_value(
+			"Purchase Taxes and Charges Template",
+			{"company": po.company, "tax_category": "Out-State"},
+			"name",
+		)
 		po.taxes_and_charges = purchase_tax_and_value
 		po.save()
 		po.submit()
@@ -3353,39 +3473,47 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.taxes_and_charges = purchase_tax
 		pr.save()
 
-		frappe.db.set_value('Company',pr.company,'enable_perpetual_inventory',1)
-		frappe.db.set_value('Company',pr.company,'enable_provisional_accounting_for_non_stock_items',1)
-		frappe.db.set_value('Company',pr.company,'stock_received_but_not_billed','Stock Received But Not Billed - _TC')
-		frappe.db.set_value('Company',pr.company,'default_inventory_account','Stock In Hand - _TC')
-		frappe.db.set_value('Company',pr.company,'default_provisional_account','Stock In Hand - _TC')
+		frappe.db.set_value("Company", pr.company, "enable_perpetual_inventory", 1)
+		frappe.db.set_value("Company", pr.company, "enable_provisional_accounting_for_non_stock_items", 1)
+		frappe.db.set_value(
+			"Company", pr.company, "stock_received_but_not_billed", "Stock Received But Not Billed - _TC"
+		)
+		frappe.db.set_value("Company", pr.company, "default_inventory_account", "Stock In Hand - _TC")
+		frappe.db.set_value("Company", pr.company, "default_provisional_account", "Stock In Hand - _TC")
 
 		pr.submit()
 		pr.reload()
-		
-		account_entries = frappe.db.get_all('GL Entry',{'voucher_type':'Purchase Receipt','voucher_no':pr.name},['account','debit','credit'])
+
+		account_entries = frappe.db.get_all(
+			"GL Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["account", "debit", "credit"],
+		)
 		for entries in account_entries:
-			if entries.account == 'Stock In Hand - _TC':
+			if entries.account == "Stock In Hand - _TC":
 				self.assertEqual(entries.debit, 100)
-			if entries.account == 'Stock Received But Not Billed - _TC':
+			if entries.account == "Stock Received But Not Billed - _TC":
 				self.assertEqual(entries.credit, 100)
 
-		stock_entries = frappe.db.get_value('Stock Ledger Entry',{'voucher_no':pr.name},'item_code')
-		self.assertEqual(stock_entries,pr.items[0].item_code)
-		self.assertEqual(pr.status,'To Bill')
+		stock_entries = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": pr.name}, "item_code")
+		self.assertEqual(stock_entries, pr.items[0].item_code)
+		self.assertEqual(pr.status, "To Bill")
 		pi = make_pi_from_pr(pr.name)
 		pi.save()
 		pi.submit()
 
-		account_entries_pi = frappe.db.get_all('GL Entry',{'voucher_no':pi.name},['account','debit','credit'])
+		account_entries_pi = frappe.db.get_all(
+			"GL Entry", {"voucher_no": pi.name}, ["account", "debit", "credit"]
+		)
 		for entries in account_entries_pi:
-			if entries.account == 'Input Tax IGST - _TC':
+			if entries.account == "Input Tax IGST - _TC":
 				self.assertEqual(entries.debit, 18)
-			if entries.account == 'Stock Received But Not Billed - _TC':
-				self.assertEqual(entries.debit,100)
-			if entries.account == 'Creditors - _TC':
+			if entries.account == "Stock Received But Not Billed - _TC":
+				self.assertEqual(entries.debit, 100)
+			if entries.account == "Creditors - _TC":
 				self.assertEqual(entries.credit, 118.0)
 		pi.reload()
-		self.assertEqual(pi.status,'Unpaid')
+		self.assertEqual(pi.status, "Unpaid")
 
 	def test_po_ignore_pricing_rule_TC_B_049(self):
 		get_details = get_company_or_supplier()
@@ -3395,45 +3523,47 @@ class TestPurchaseOrder(FrappeTestCase):
 		item_price = 130
 		item = make_test_item("_test_item__")
 
-		existing_price = frappe.db.exists("Item Price", {"item_code": item.item_code, "price_list": "Standard Buying"})
+		existing_price = frappe.db.exists(
+			"Item Price", {"item_code": item.item_code, "price_list": "Standard Buying"}
+		)
 		if not existing_price:
-			item_price_doc = frappe.get_doc({
-				"doctype": "Item Price",
-				"price_list": "Standard Buying",
-				"item_code": item.item_code,
-				"price_list_rate": item_price
-			}).insert()
-
-
-		existing_pricing_rule = frappe.db.exists("Pricing Rule", {"title": "10% Discount", "company": company})
-		if not existing_pricing_rule:
-			pricing_rule = frappe.get_doc({
-				"doctype": "Pricing Rule",
-				"title": "10% Discount",
-				"company": company,
-				"apply_on": "Item Code",
-				"items": [{"item_code": item.item_code}],
-				"rate_or_discount": "Discount Percentage",
-				"discount_percentage": 10,
-				"selling": 0,
-				"buying": 1
-			}).insert()
-
-
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date":today(),
-			"set_warehouse": warehouse,
-			"items": [
+			frappe.get_doc(
 				{
+					"doctype": "Item Price",
+					"price_list": "Standard Buying",
 					"item_code": item.item_code,
-					"warehouse": warehouse,
-					"qty": 1
+					"price_list_rate": item_price,
 				}
-			]
-		})
+			).insert()
+
+		existing_pricing_rule = frappe.db.exists(
+			"Pricing Rule", {"title": "10% Discount", "company": company}
+		)
+		if not existing_pricing_rule:
+			frappe.get_doc(
+				{
+					"doctype": "Pricing Rule",
+					"title": "10% Discount",
+					"company": company,
+					"apply_on": "Item Code",
+					"items": [{"item_code": item.item_code}],
+					"rate_or_discount": "Discount Percentage",
+					"discount_percentage": 10,
+					"selling": 0,
+					"buying": 1,
+				}
+			).insert()
+
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"items": [{"item_code": item.item_code, "warehouse": warehouse, "qty": 1}],
+			}
+		)
 		po.insert()
 
 		self.assertEqual(len(po.items), 1)
@@ -3446,10 +3576,11 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_po_pr_pi_multiple_flow_TC_B_065(self):
 		# Scenario : PO=>2PR=>2PI
-		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
 		get_company_supplier = get_company_or_supplier()
-		supplier = create_supplier(supplier_name="_Test Supplier 1", default_currency="INR")	
+		supplier = create_supplier(supplier_name="_Test Supplier 1", default_currency="INR")
 		company = get_company_supplier.get("company")
 		warehouse = create_warehouse("_Test Warehouse 556", company=company)
 		supplier = get_company_supplier.get("supplier")
@@ -3465,125 +3596,119 @@ class TestPurchaseOrder(FrappeTestCase):
 				"shipping_rule_type": "Buying",
 				"account": "Cash - TC-5",
 				"cost_center": "Main - TC-5",
-				"shipping_amount": 200
+				"shipping_amount": 200,
 			}
 		).insert(ignore_if_duplicate=1)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"company": company,
-			"supplier": supplier,
-			"set_posting_time": 1,
-			"posting_date": today(),
-			"schedule_date": add_days(today(), 5),
-			"shipping_rule": doc_shipping_rule.name,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": warehouse,
-					"qty": 4,
-					"rate": 3000
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"company": company,
+				"supplier": supplier,
+				"set_posting_time": 1,
+				"posting_date": today(),
+				"schedule_date": add_days(today(), 5),
+				"shipping_rule": doc_shipping_rule.name,
+				"items": [{"item_code": item.item_code, "warehouse": warehouse, "qty": 4, "rate": 3000}],
+			}
+		)
 		po.insert()
 		po.submit()
 
-		self.assertEqual(po.grand_total, 12002.33, "Grand Total should include Shipping Rule (12000 + 200 = 12200).")
+		self.assertEqual(
+			po.grand_total, 12002.33, "Grand Total should include Shipping Rule (12000 + 200 = 12200)."
+		)
 		self.assertEqual(po.status, "To Receive and Bill", "PO status should be 'To Receive and Bill'.")
 
-		pr_1 = frappe.get_doc({
-			"doctype": "Purchase Receipt",
-			"purchase_order": po.name,
-			"company": company,
-			"supplier": supplier,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": warehouse,
-					"qty": 2,
-					"rate": 3000
-				}
-			]
-		})
+		pr_1 = frappe.get_doc(
+			{
+				"doctype": "Purchase Receipt",
+				"purchase_order": po.name,
+				"company": company,
+				"supplier": supplier,
+				"currency": "INR",
+				"items": [{"item_code": item.item_code, "warehouse": warehouse, "qty": 2, "rate": 3000}],
+			}
+		)
 		pr_1.insert()
 		pr_1.submit()
 
 		sle_pr_1 = get_sle(pr_1.name)
-		self.assertEqual(sle_pr_1[0]['actual_qty'], 2)
+		self.assertEqual(sle_pr_1[0]["actual_qty"], 2)
 		gl_entries_pr_1 = get_gl_entries(pr_1.name)
 		for gl_entry_pr in gl_entries_pr_1:
-			if gl_entry_pr['account'] == "Stock In Hand - TC-5":
-				self.assertEqual(gl_entry_pr['debit'], 6200)
-			elif gl_entry_pr['account'] == "Cash - TC-5":
-				self.assertEqual(gl_entry_pr['credit'], 200)
+			if gl_entry_pr["account"] == "Stock In Hand - TC-5":
+				self.assertEqual(gl_entry_pr["debit"], 6200)
+			elif gl_entry_pr["account"] == "Cash - TC-5":
+				self.assertEqual(gl_entry_pr["credit"], 200)
 		pi_1 = make_pi_against_pr(pr_1.name)
 		self.assertEqual(pi_1.status, "Unpaid")
 
-		pi_1 = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"purchase_receipt": pr_1.name,
-			"supplier": supplier,
-			"currency": "INR",
-			"company": company,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 2,
-					"rate": 3000
-				}
-			]
-		})
+		pi_1 = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"purchase_receipt": pr_1.name,
+				"supplier": supplier,
+				"currency": "INR",
+				"company": company,
+				"items": [{"item_code": item.item_code, "qty": 2, "rate": 3000}],
+			}
+		)
 		pi_1.insert()
 		pi_1.submit()
 
-		gl_entries_pi_1 = frappe.get_all("GL Entry", filters={"voucher_no": pi_1.name}, fields=["account", "debit", "credit"])
-		expected_gl_entries_pi_1 = [{'account': 'Stock Received But Not Billed - TC-5', 'debit': 6000.0, 'credit': 0.0}, {'account': 'Creditors - TC-5', 'debit': 0.0, 'credit': 6000.0}]
+		gl_entries_pi_1 = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi_1.name}, fields=["account", "debit", "credit"]
+		)
+		expected_gl_entries_pi_1 = [
+			{"account": "Stock Received But Not Billed - TC-5", "debit": 6000.0, "credit": 0.0},
+			{"account": "Creditors - TC-5", "debit": 0.0, "credit": 6000.0},
+		]
 		self.assertEqual(gl_entries_pi_1, expected_gl_entries_pi_1)
 		pr_1.reload()
 		self.assertEqual(pr_1.status, "Completed")
 
-		pr_2 = frappe.get_doc({
-			"doctype": "Purchase Receipt",
-			"purchase_order": po.name,
-			"company": company,
-			"supplier": supplier,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": warehouse,
-					"qty": 2,
-					"rate": 3000
-				}
-			]
-		})
+		pr_2 = frappe.get_doc(
+			{
+				"doctype": "Purchase Receipt",
+				"purchase_order": po.name,
+				"company": company,
+				"supplier": supplier,
+				"currency": "INR",
+				"items": [{"item_code": item.item_code, "warehouse": warehouse, "qty": 2, "rate": 3000}],
+			}
+		)
 		pr_2.insert()
 		pr_2.submit()
 
-		gl_entries_pr_2 = frappe.get_all("GL Entry", filters={"voucher_no": pr_2.name}, fields=["account", "debit", "credit"])
-		expected_gle2= [{'account': 'Stock Received But Not Billed - TC-5', 'debit': 0.0, 'credit': 6000.0}, {'account': '_Test Warehouse 556 - TC-5', 'debit': 6000.0, 'credit': 0.0}]
+		gl_entries_pr_2 = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr_2.name}, fields=["account", "debit", "credit"]
+		)
+		expected_gle2 = [
+			{"account": "Stock Received But Not Billed - TC-5", "debit": 0.0, "credit": 6000.0},
+			{"account": "_Test Warehouse 556 - TC-5", "debit": 6000.0, "credit": 0.0},
+		]
 		self.assertEqual(gl_entries_pr_2, expected_gle2)
-		pi_2 = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"purchase_receipt": pr_2.name,
-			"supplier": supplier,
-			"currency": "INR",
-			"company": company,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 2,
-					"rate": 3000
-				}
-			]
-		})
+		pi_2 = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"purchase_receipt": pr_2.name,
+				"supplier": supplier,
+				"currency": "INR",
+				"company": company,
+				"items": [{"item_code": item.item_code, "qty": 2, "rate": 3000}],
+			}
+		)
 		pi_2.insert()
 		pi_2.submit()
 
-		gl_entries_pi_2 = frappe.get_all("GL Entry", filters={"voucher_no": pi_2.name}, fields=["account", "debit", "credit"])
-		expected_gle_2=[{'account': 'Stock Received But Not Billed - TC-5', 'debit': 6000.0, 'credit': 0.0}, {'account': 'Creditors - TC-5', 'debit': 0.0, 'credit': 6000.0}]
+		gl_entries_pi_2 = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi_2.name}, fields=["account", "debit", "credit"]
+		)
+		expected_gle_2 = [
+			{"account": "Stock Received But Not Billed - TC-5", "debit": 6000.0, "credit": 0.0},
+			{"account": "Creditors - TC-5", "debit": 0.0, "credit": 6000.0},
+		]
 		self.assertEqual(gl_entries_pi_2, expected_gle_2)
 		pr_2.reload()
 		po.reload()
@@ -3599,32 +3724,30 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		self.assertEqual(len(po.items), 1)
 
-
 	def test_po_to_pi_with_deferred_expense_TC_B_094(self):
 		get_company_supplier = get_company_or_supplier()
 		company = get_company_supplier.get("company")
 		supplier = get_company_supplier.get("supplier")
 		target_warehouse = "Stores - TC-5"
-		frappe.db.set_value('Company', company, 'default_deferred_expense_account', 'Cash - TC-5')
+		frappe.db.set_value("Company", company, "default_deferred_expense_account", "Cash - TC-5")
 
 		item = make_test_item("_test_expense")
 		item.is_stock_item = 0
 		item.enable_deferred_expense = 1
 		item.save()
 
-		po = frappe.get_doc({
-			'doctype': 'Purchase Order',
-			'supplier': supplier,
-			'company': company,
-			'schedule_date': today(),
-			'currency': 'INR',
-			'items': [{
-				'item_code': item.item_code,
-				'qty': 1,
-				'rate': 1000,
-				'warehouse': target_warehouse
-			}]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{"item_code": item.item_code, "qty": 1, "rate": 1000, "warehouse": target_warehouse}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -3632,7 +3755,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pi = make_pi_from_po(po.name)
 		pi.bill_no = "test_bill_1122"
 		pi.insert(ignore_permissions=True)
-		item = frappe.get_doc('Item', item.item_code)
+		item = frappe.get_doc("Item", item.item_code)
 		pi.items[0].enable_deferred_expense = item.enable_deferred_expense
 		pi.save()
 		self.assertEqual(pi.items[0].enable_deferred_expense, 1)
@@ -3641,6 +3764,7 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_po_with_actual_account_type_TC_B_133(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
 		create_company()
 		create_supplier(supplier_name="_Test Supplier")
 		create_warehouse(
@@ -3649,51 +3773,58 @@ class TestPurchaseOrder(FrappeTestCase):
 			company="_Test Company",
 		)
 		create_item("_Test Item")
-		get_or_create_fiscal_year('_Test Company')
-		po = create_purchase_order(qty=10,rate = 1000, do_not_save=True)
+		get_or_create_fiscal_year("_Test Company")
+		po = create_purchase_order(qty=10, rate=1000, do_not_save=True)
 		po.save()
-		exists_purchase_tax = frappe.db.get_value('Purchase Taxes and Charges Template',{'company':"_Test Company",'tax_category':'In-State'},'name')
+		exists_purchase_tax = frappe.db.get_value(
+			"Purchase Taxes and Charges Template",
+			{"company": "_Test Company", "tax_category": "In-State"},
+			"name",
+		)
 		if exists_purchase_tax is None:
-
 			purchase_tax_template = frappe.new_doc("Purchase Taxes and Charges Template")
-			purchase_tax_template.title = 'Test'
+			purchase_tax_template.title = "Test"
 			purchase_tax_template.company = po.company
-			purchase_tax_template.tax_category = 'In-State'
-			value_list = [{
-				'category': 'Total',
-				'add_deduct_tax':'Add',
-				'charge_type':'On Net Total',
-				'account_head': 'Stock In Hand - _TC',
-				'description':'test',
-				"tax_amount":100,
-				"rate":9
-			},
-			{
-				'category': 'Total',
-				'add_deduct_tax':'Add',
-				'charge_type':'On Net Total',
-				'account_head': 'Stock In Hand - _TC',
-				'description':'test',
-				"tax_amount":100,
-				"rate":9
-			}]
+			purchase_tax_template.tax_category = "In-State"
+			value_list = [
+				{
+					"category": "Total",
+					"add_deduct_tax": "Add",
+					"charge_type": "On Net Total",
+					"account_head": "Stock In Hand - _TC",
+					"description": "test",
+					"tax_amount": 100,
+					"rate": 9,
+				},
+				{
+					"category": "Total",
+					"add_deduct_tax": "Add",
+					"charge_type": "On Net Total",
+					"account_head": "Stock In Hand - _TC",
+					"description": "test",
+					"tax_amount": 100,
+					"rate": 9,
+				},
+			]
 			for items in value_list:
 				purchase_tax_template.append("taxes", items)
 			purchase_tax_template.save()
 			purchase_tax = purchase_tax_template.name
 		else:
 			purchase_tax = exists_purchase_tax
-		
+
 		po.taxes_and_charges = purchase_tax
 		po.save()
-		account = frappe.db.get_all("Account",{'company':po.company},["name"])
-	
-		po.append('taxes',{
-			'charge_type':'Actual',
-			'account_head' : 'Freight and Forwarding Charges - _TC',
-			'description': 'Freight and Forwarding Charges',
-			'tax_amount' : 100
-		})
+
+		po.append(
+			"taxes",
+			{
+				"charge_type": "Actual",
+				"account_head": "Freight and Forwarding Charges - _TC",
+				"description": "Freight and Forwarding Charges",
+				"tax_amount": 100,
+			},
+		)
 		po.save()
 		po.submit()
 		self.assertEqual(po.grand_total, 11900)
@@ -3702,46 +3833,53 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr = make_purchase_receipt(po.name)
 		pr.save()
 
-		frappe.db.set_value('Company',pr.company,'enable_perpetual_inventory',1)
-		frappe.db.set_value('Company',pr.company,'enable_provisional_accounting_for_non_stock_items',1)
-		frappe.db.set_value('Company',pr.company,'stock_received_but_not_billed','Stock Received But Not Billed - _TC')
-		frappe.db.set_value('Company',pr.company,'default_inventory_account','Stock In Hand - _TC')
-		frappe.db.set_value('Company',pr.company,'default_provisional_account','Stock In Hand - _TC')
+		frappe.db.set_value("Company", pr.company, "enable_perpetual_inventory", 1)
+		frappe.db.set_value("Company", pr.company, "enable_provisional_accounting_for_non_stock_items", 1)
+		frappe.db.set_value(
+			"Company", pr.company, "stock_received_but_not_billed", "Stock Received But Not Billed - _TC"
+		)
+		frappe.db.set_value("Company", pr.company, "default_inventory_account", "Stock In Hand - _TC")
+		frappe.db.set_value("Company", pr.company, "default_provisional_account", "Stock In Hand - _TC")
 
 		pr.submit()
 		self.assertEqual(po.grand_total, po.grand_total)
 		self.assertEqual(po.taxes_and_charges_added, po.taxes_and_charges_added)
 
-
-		account_entries_pr = frappe.db.get_all('GL Entry',{'voucher_type':'Purchase Receipt','voucher_no':pr.name},['account','debit','credit'])
+		account_entries_pr = frappe.db.get_all(
+			"GL Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["account", "debit", "credit"],
+		)
 		for entries in account_entries_pr:
-			if entries.account == 'Stock Received But Not Billed - _TC':
-				self.assertEqual(entries.credit,pr.total)
-			if entries.account == 'Stock In Hand - _TC':
-				self.assertEqual(entries.debit,pr.total)
+			if entries.account == "Stock Received But Not Billed - _TC":
+				self.assertEqual(entries.credit, pr.total)
+			if entries.account == "Stock In Hand - _TC":
+				self.assertEqual(entries.debit, pr.total)
 
-		stock_entries_item = frappe.db.get_value('Stock Ledger Entry',{'voucher_no':pr.name},'item_code')
-		stock_entries_qty = frappe.db.get_value('Stock Ledger Entry',{'voucher_no':pr.name},'actual_qty')
-		self.assertEqual(stock_entries_item,pr.items[0].item_code)
-		self.assertEqual(stock_entries_qty,pr.items[0].qty)
+		stock_entries_item = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": pr.name}, "item_code")
+		stock_entries_qty = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": pr.name}, "actual_qty")
+		self.assertEqual(stock_entries_item, pr.items[0].item_code)
+		self.assertEqual(stock_entries_qty, pr.items[0].qty)
 
 		pi = make_pi_from_pr(pr.name)
 		pi.save()
 		pi.submit()
 
-		account_entries_pi = frappe.db.get_all('GL Entry',{'voucher_no':pi.name},['account','debit','credit'])
-		
+		account_entries_pi = frappe.db.get_all(
+			"GL Entry", {"voucher_no": pi.name}, ["account", "debit", "credit"]
+		)
+
 		for entries in account_entries_pi:
-			if entries.account == 'Freight and Forwarding Charges - _TC':
+			if entries.account == "Freight and Forwarding Charges - _TC":
 				self.assertEqual(entries.debit, 100)
-			if entries.account == 'Input Tax SGST - _TC':
+			if entries.account == "Input Tax SGST - _TC":
 				self.assertEqual(entries.debit, 900)
-			if entries.account == 'Input Tax CGST - _TC':
+			if entries.account == "Input Tax CGST - _TC":
 				self.assertEqual(entries.debit, 900)
-			if entries.account == 'Stock Received But Not Billed - _TC':
-				self.assertEqual(entries.debit,10000)
-			if entries.account == 'Creditors - _TC':
-				self.assertEqual(entries.credit,11900)
+			if entries.account == "Stock Received But Not Billed - _TC":
+				self.assertEqual(entries.debit, 10000)
+			if entries.account == "Creditors - _TC":
+				self.assertEqual(entries.credit, 11900)
 
 	@if_app_installed("india_compliance")
 	def test_po_with_on_net_total_account_type_TC_B_134(self):
@@ -3752,9 +3890,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		tax_account = create_or_get_purchase_taxes_template(company)
 		item = make_test_item("test_item")
 		parking_charges_account = create_new_account(
-			account_name='Parking Charges Account',
-			company=company,
-			parent_account = 'Indirect Expenses - TC-5'
+			account_name="Parking Charges Account", company=company, parent_account="Indirect Expenses - TC-5"
 		)
 		po = frappe.get_doc(
 			{
@@ -3763,14 +3899,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				"supplier": supplier,
 				"set_warehouse": warehouse,
 				"currency": "INR",
-				"items": [
-					{
-						"item_code": item.item_code,
-						"schedule_date": today(),
-						"qty": 10,
-						"rate": 100
-					}
-				]
+				"items": [{"item_code": item.item_code, "schedule_date": today(), "qty": 10, "rate": 100}],
 			}
 		)
 		taxes = [
@@ -3779,23 +3908,23 @@ class TestPurchaseOrder(FrappeTestCase):
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('sgst_account'),
-				"description": "SGST"
+				"account_head": tax_account.get("sgst_account"),
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('cgst_account'),
-				"description": "CGST"
+				"account_head": tax_account.get("cgst_account"),
+				"description": "CGST",
 			},
 			{
-				'charge_type':'On Net Total',
-				'account_head' : parking_charges_account,
-				'description': parking_charges_account,
-				'rate' : 5
-			}
+				"charge_type": "On Net Total",
+				"account_head": parking_charges_account,
+				"description": parking_charges_account,
+				"rate": 5,
+			},
 		]
 		for tax in taxes:
 			po.append("taxes", tax)
@@ -3806,70 +3935,80 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr = make_purchase_receipt(po.name)
 		pr.save()
 
-		frappe.db.set_value("Company",company,
+		frappe.db.set_value(
+			"Company",
+			company,
 			{
-				'enable_perpetual_inventory': 1,
-				'enable_provisional_accounting_for_non_stock_items': 1,
-				'stock_received_but_not_billed': 'Stock Received But Not Billed - TC-5',
-				'default_inventory_account': 'Stock In Hand - TC-5',
-				'default_provisional_account': 'Stock In Hand - TC-5'
-			}
+				"enable_perpetual_inventory": 1,
+				"enable_provisional_accounting_for_non_stock_items": 1,
+				"stock_received_but_not_billed": "Stock Received But Not Billed - TC-5",
+				"default_inventory_account": "Stock In Hand - TC-5",
+				"default_provisional_account": "Stock In Hand - TC-5",
+			},
 		)
 
 		pr.submit()
 		self.assertEqual(po.grand_total, po.grand_total)
 		self.assertEqual(po.taxes_and_charges_added, po.taxes_and_charges_added)
 
-		account_entries_pr = frappe.db.get_all('GL Entry',{'voucher_type':'Purchase Receipt','voucher_no':pr.name},['account','debit','credit'])
+		account_entries_pr = frappe.db.get_all(
+			"GL Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["account", "debit", "credit"],
+		)
 
 		for entries in account_entries_pr:
-			if entries.account == 'Stock Received But Not Billed - TC-5':
-				self.assertEqual(entries.credit,1000)
-			if entries.account == 'Stock In Hand - TC-5':
-				self.assertEqual(entries.debit,1000)
-	
+			if entries.account == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(entries.credit, 1000)
+			if entries.account == "Stock In Hand - TC-5":
+				self.assertEqual(entries.debit, 1000)
 
-		stock_entries_item = frappe.db.get_value('Stock Ledger Entry',{'voucher_no':pr.name},'item_code')
-		stock_entries_qty = frappe.db.get_value('Stock Ledger Entry',{'voucher_no':pr.name},'actual_qty')
-		self.assertEqual(stock_entries_item,pr.items[0].item_code)
-		self.assertEqual(stock_entries_qty,pr.items[0].qty)
+		stock_entries_item = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": pr.name}, "item_code")
+		stock_entries_qty = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": pr.name}, "actual_qty")
+		self.assertEqual(stock_entries_item, pr.items[0].item_code)
+		self.assertEqual(stock_entries_qty, pr.items[0].qty)
 
 		pi = make_pi_from_pr(pr.name)
 		pi.bill_no = "test_bill_1122"
 		pi.save()
 		pi.submit()
 
-		account_entries_pi = frappe.db.get_all('GL Entry',{'voucher_no':pi.name},['account','debit','credit'])
+		account_entries_pi = frappe.db.get_all(
+			"GL Entry", {"voucher_no": pi.name}, ["account", "debit", "credit"]
+		)
 
 		for entries in account_entries_pi:
-			if entries.account == 'Parking Charges Account - TC-5':
+			if entries.account == "Parking Charges Account - TC-5":
 				self.assertEqual(entries.debit, 50)
-			if entries.account == 'Input Tax SGST - TC-5':
+			if entries.account == "Input Tax SGST - TC-5":
 				self.assertEqual(entries.debit, 90)
-			if entries.account == 'Input Tax CGST - TC-5':
+			if entries.account == "Input Tax CGST - TC-5":
 				self.assertEqual(entries.debit, 90)
-			if entries.account == 'Stock Received But Not Billed - TC-5':
-				self.assertEqual(entries.debit,1000)
-			if entries.account == 'Creditors - TC-5':
-				self.assertEqual(entries.credit,1230)
-	
+			if entries.account == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(entries.debit, 1000)
+			if entries.account == "Creditors - TC-5":
+				self.assertEqual(entries.credit, 1230)
+
 	def test_po_with_on_item_quntity_account_type_TC_B_135(self):
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company_and_supplier as create_data,
+		)
+
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item_1 = make_test_item("test_item")
 		item_2 = make_test_item("test_item_1")
 		warehouse = "Stores - TC-3"
-		parent_company_account = create_new_account(
-			account_name='Transportation Charges Account',
-			company =  get_company_supplier.get("parent_company"),
-			parent_account = 'Indirect Expenses - TC-1'
+		create_new_account(
+			account_name="Transportation Charges Account",
+			company=get_company_supplier.get("parent_company"),
+			parent_account="Indirect Expenses - TC-1",
 		)
 		transportation_chrages_account = create_new_account(
-			account_name='Transportation Charges Account',
+			account_name="Transportation Charges Account",
 			company=company,
-			parent_account = 'Indirect Expenses - TC-3'
+			parent_account="Indirect Expenses - TC-3",
 		)
 
 		po = frappe.get_doc(
@@ -3880,81 +4019,81 @@ class TestPurchaseOrder(FrappeTestCase):
 				"set_warehouse": warehouse,
 				"currency": "INR",
 				"items": [
-					{
-						"item_code": item_1.item_code,
-						"schedule_date": today(),
-						"qty": 10,
-						"rate": 100
-					},
-					{
-						"item_code": item_2.item_code,
-						"schedule_date": today(),
-						"qty": 5,
-						"rate": 200
-					}
+					{"item_code": item_1.item_code, "schedule_date": today(), "qty": 10, "rate": 100},
+					{"item_code": item_2.item_code, "schedule_date": today(), "qty": 5, "rate": 200},
 				],
 				"taxes": [
 					{
-						'charge_type':'On Item Quantity',
-						'account_head' : transportation_chrages_account,
-						'description': transportation_chrages_account,
-						'rate' : 20
+						"charge_type": "On Item Quantity",
+						"account_head": transportation_chrages_account,
+						"description": transportation_chrages_account,
+						"rate": 20,
 					}
-				]
+				],
 			}
 		)
 		po.insert()
 		po.submit()
-	
+
 		pr = make_purchase_receipt(po.name)
 		pr.save()
 		pr.submit()
 		self.assertEqual(po.grand_total, po.grand_total)
 		self.assertEqual(po.taxes_and_charges_added, po.taxes_and_charges_added)
 
-		frappe.db.set_value("Company", company,
+		frappe.db.set_value(
+			"Company",
+			company,
 			{
-				'enable_perpetual_inventory': 1,
-				'enable_provisional_accounting_for_non_stock_items': 1,
-				'stock_received_but_not_billed': 'Stock Received But Not Billed - TC-3',
-				'default_inventory_account': 'Stock In Hand - TC-3',
-				'default_provisional_account': 'Stock In Hand - TC-3'
-			}
+				"enable_perpetual_inventory": 1,
+				"enable_provisional_accounting_for_non_stock_items": 1,
+				"stock_received_but_not_billed": "Stock Received But Not Billed - TC-3",
+				"default_inventory_account": "Stock In Hand - TC-3",
+				"default_provisional_account": "Stock In Hand - TC-3",
+			},
 		)
 
-		account_entries_pr = frappe.db.get_all('GL Entry',{'voucher_type':'Purchase Receipt','voucher_no':pr.name},['account','debit','credit'])
+		account_entries_pr = frappe.db.get_all(
+			"GL Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["account", "debit", "credit"],
+		)
 
 		for entries in account_entries_pr:
-			if entries.account == 'Stock Received But Not Billed - TC-3':
-				self.assertEqual(entries.credit,2000)
-			if entries.account == 'Stock In Hand - TC-3':
-				self.assertEqual(entries.debit,2000)
-	
-		stock_entries = frappe.db.get_all('Stock Ledger Entry',{'voucher_no':pr.name},['item_code','actual_qty'])
+			if entries.account == "Stock Received But Not Billed - TC-3":
+				self.assertEqual(entries.credit, 2000)
+			if entries.account == "Stock In Hand - TC-3":
+				self.assertEqual(entries.debit, 2000)
+
+		stock_entries = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["item_code", "actual_qty"]
+		)
 		for entries in stock_entries:
 			if entries.item_code == pr.items[0].item_code:
-				self.assertEqual(entries.actual_qty,pr.items[0].qty)
+				self.assertEqual(entries.actual_qty, pr.items[0].qty)
 			if entries.item_code == pr.items[1].item_code:
-				self.assertEqual(entries.actual_qty,pr.items[1].qty)
-		
+				self.assertEqual(entries.actual_qty, pr.items[1].qty)
+
 		pi = make_pi_from_pr(pr.name)
 		pi.bill_no = "test_bill_1122"
 		pi.save()
 		pi.submit()
 
-		account_entries_pi = frappe.db.get_all('GL Entry',{'voucher_no':pi.name},['account','debit','credit'])
+		account_entries_pi = frappe.db.get_all(
+			"GL Entry", {"voucher_no": pi.name}, ["account", "debit", "credit"]
+		)
 
 		for entries in account_entries_pi:
-			if entries.account == 'Transportation Charges Account - TC-3':
+			if entries.account == "Transportation Charges Account - TC-3":
 				self.assertEqual(entries.debit, 300)
-			if entries.account == 'Input Tax SGST - TC-3':
+			if entries.account == "Input Tax SGST - TC-3":
 				self.assertEqual(entries.debit, 180)
-			if entries.account == 'Input Tax CGST - TC-3':
+			if entries.account == "Input Tax CGST - TC-3":
 				self.assertEqual(entries.debit, 180)
-			if entries.account == 'Stock Received But Not Billed - TC-3':
-				self.assertEqual(entries.debit,2000)
-			if entries.account == 'Creditors - TC-3':
-				self.assertEqual(entries.credit,2300)
+			if entries.account == "Stock Received But Not Billed - TC-3":
+				self.assertEqual(entries.debit, 2000)
+			if entries.account == "Creditors - TC-3":
+				self.assertEqual(entries.credit, 2300)
 
 	@if_app_installed("india_compliance")
 	def test_po_with_all_account_type_TC_B_136(self):
@@ -3964,24 +4103,20 @@ class TestPurchaseOrder(FrappeTestCase):
 		item_1 = make_test_item("test_item_1")
 		item_2 = make_test_item("test_item_2")
 		warehouse = "Stores - TC-5"
-		tax_template = create_or_get_purchase_taxes_template(company = company)
+		tax_template = create_or_get_purchase_taxes_template(company=company)
 
 		parking_charges_account = create_new_account(
-			account_name = 'Parking Charges Account',
-			company = company,
-			parent_account = "Indirect Expenses - TC-5"
+			account_name="Parking Charges Account", company=company, parent_account="Indirect Expenses - TC-5"
 		)
 
 		transportation_chrages_account = create_new_account(
-			account_name = 'Transportation Charges Account',
-			company = company,
-			parent_account = 'Cash In Hand - TC-5'
+			account_name="Transportation Charges Account",
+			company=company,
+			parent_account="Cash In Hand - TC-5",
 		)
 
 		output_cess_account = create_new_account(
-			account_name = 'Output Cess Account',
-			company = company,
-			parent_account = 'Cash In Hand - TC-5'
+			account_name="Output Cess Account", company=company, parent_account="Cash In Hand - TC-5"
 		)
 
 		po = frappe.get_doc(
@@ -3992,18 +4127,8 @@ class TestPurchaseOrder(FrappeTestCase):
 				"currency": "INR",
 				"set_warehouse": warehouse,
 				"items": [
-					{
-						"item_code": item_1.item_code,
-						"schedule_date": today(),
-						"qty": 10,
-						"rate": 100
-					},
-					{
-						"item_code": item_2.item_code,
-						"schedule_date": today(),
-						"qty": 5,
-						"rate": 200
-					}
+					{"item_code": item_1.item_code, "schedule_date": today(), "qty": 10, "rate": 100},
+					{"item_code": item_2.item_code, "schedule_date": today(), "qty": 5, "rate": 200},
 				],
 			}
 		)
@@ -4011,33 +4136,33 @@ class TestPurchaseOrder(FrappeTestCase):
 		po.insert()
 		taxes = [
 			{
-				'charge_type':'Actual',
-				'account_head' : 'Freight and Forwarding Charges - TC-5',
-				'description': 'Freight and Forwarding Charges',
-				'tax_amount' : 100
+				"charge_type": "Actual",
+				"account_head": "Freight and Forwarding Charges - TC-5",
+				"description": "Freight and Forwarding Charges",
+				"tax_amount": 100,
 			},
 			{
-				'charge_type':'On Net Total',
-				'account_head' : parking_charges_account,
-				'description': parking_charges_account,
-				'rate' : 5
+				"charge_type": "On Net Total",
+				"account_head": parking_charges_account,
+				"description": parking_charges_account,
+				"rate": 5,
 			},
 			{
-				'charge_type':'On Item Quantity',
-				'account_head' : transportation_chrages_account,
-				'description': transportation_chrages_account,
-				'rate' : 20
+				"charge_type": "On Item Quantity",
+				"account_head": transportation_chrages_account,
+				"description": transportation_chrages_account,
+				"rate": 20,
 			},
 			{
-				'charge_type':'On Previous Row Amount',
-				'account_head' : output_cess_account,
-				'description': output_cess_account,
-				'rate' : 5,
-				'row_id':5
-			}
+				"charge_type": "On Previous Row Amount",
+				"account_head": output_cess_account,
+				"description": output_cess_account,
+				"rate": 5,
+				"row_id": 5,
+			},
 		]
 		for tax in taxes:
-			po.append('taxes',tax)
+			po.append("taxes", tax)
 
 		po.submit()
 		pr = make_purchase_receipt(po.name)
@@ -4045,112 +4170,140 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.submit()
 		self.assertEqual(po.grand_total, po.grand_total)
 
-		frappe.db.set_value('Company', company,
+		frappe.db.set_value(
+			"Company",
+			company,
 			{
-				'enable_perpetual_inventory': 1,
-				'enable_provisional_accounting_for_non_stock_items': 1,
-				'stock_received_but_not_billed': 'Stock Received But Not Billed - TC-5',
-				'default_inventory_account': 'Stock In Hand - TC-5',
-				'default_provisional_account': 'Stock In Hand - TC-5'
-			}
+				"enable_perpetual_inventory": 1,
+				"enable_provisional_accounting_for_non_stock_items": 1,
+				"stock_received_but_not_billed": "Stock Received But Not Billed - TC-5",
+				"default_inventory_account": "Stock In Hand - TC-5",
+				"default_provisional_account": "Stock In Hand - TC-5",
+			},
 		)
-		
-		account_entries_pr = frappe.db.get_all('GL Entry',{'voucher_type':'Purchase Receipt','voucher_no':pr.name},['account','debit','credit'])
+
+		account_entries_pr = frappe.db.get_all(
+			"GL Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["account", "debit", "credit"],
+		)
 
 		for entries in account_entries_pr:
-			if entries.account == 'Stock Received But Not Billed - TC-5':
-				self.assertEqual(entries.credit,2000)
-			if entries.account == 'Stock In Hand - TC-5':
-				self.assertEqual(entries.debit,2000)
-	
-		stock_entries = frappe.db.get_all('Stock Ledger Entry',{'voucher_no':pr.name},['item_code','actual_qty'])
+			if entries.account == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(entries.credit, 2000)
+			if entries.account == "Stock In Hand - TC-5":
+				self.assertEqual(entries.debit, 2000)
+
+		stock_entries = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["item_code", "actual_qty"]
+		)
 		for entries in stock_entries:
 			if entries.item_code == pr.items[0].item_code:
-				self.assertEqual(entries.actual_qty,pr.items[0].qty)
+				self.assertEqual(entries.actual_qty, pr.items[0].qty)
 			if entries.item_code == pr.items[1].item_code:
-				self.assertEqual(entries.actual_qty,pr.items[1].qty)
-		
+				self.assertEqual(entries.actual_qty, pr.items[1].qty)
+
 		pi = make_pi_from_pr(pr.name)
 		pi.bill_no = "test_bill_1122"
 		pi.save()
 		pi.submit()
 
-		account_entries_pi = frappe.db.get_all('GL Entry',{'voucher_no':pi.name},['account','debit','credit'])
-		
+		account_entries_pi = frappe.db.get_all(
+			"GL Entry", {"voucher_no": pi.name}, ["account", "debit", "credit"]
+		)
+
 		for entries in account_entries_pi:
-			if entries.account == 'Transportation Charges Account - TC-5':
+			if entries.account == "Transportation Charges Account - TC-5":
 				self.assertEqual(entries.debit, 300)
-			if entries.account == 'Output Cess Account - TC-5':
+			if entries.account == "Output Cess Account - TC-5":
 				self.assertEqual(entries.debit, 15)
-			if entries.account == 'Parking Charges Account - TC-5':
+			if entries.account == "Parking Charges Account - TC-5":
 				self.assertEqual(entries.debit, 100)
-			if entries.account == 'Freight and Forwarding Charges - TC-5':
+			if entries.account == "Freight and Forwarding Charges - TC-5":
 				self.assertEqual(entries.debit, 100)
-			if entries.account == 'Input Tax SGST - TC-5':
+			if entries.account == "Input Tax SGST - TC-5":
 				self.assertEqual(entries.debit, 180)
-			if entries.account == 'Input Tax CGST - TC-5':
+			if entries.account == "Input Tax CGST - TC-5":
 				self.assertEqual(entries.debit, 180)
-			if entries.account == 'Stock Received But Not Billed - TC-5':
-				self.assertEqual(entries.debit,2000)
-			if entries.account == 'Creditors - TC-5':
-				self.assertEqual(entries.credit,2875)
+			if entries.account == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(entries.debit, 2000)
+			if entries.account == "Creditors - TC-5":
+				self.assertEqual(entries.credit, 2875)
 
 	def test_create_po_pr_partial_TC_SCK_046(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
 		create_company()
-		create_item("_Test Item",warehouse="Stores - _TC")
+		create_item("_Test Item", warehouse="Stores - _TC")
 		create_supplier(supplier_name="_Test Supplier")
 
-		get_or_create_fiscal_year('_Test Company')
-		po = create_purchase_order(rate=10000,qty=10,warehouse="Stores - _TC")
+		get_or_create_fiscal_year("_Test Company")
+		po = create_purchase_order(rate=10000, qty=10, warehouse="Stores - _TC")
 		po.submit()
 
 		pr = create_pr_against_po(po.name, received_qty=5)
-		
-		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "Stores - _TC"}, "actual_qty")
-	
-		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':pr.name})
+
+		bin_qty = frappe.db.get_value(
+			"Bin", {"item_code": "_Test Item", "warehouse": "Stores - _TC"}, "actual_qty"
+		)
+
+		sle = frappe.get_doc("Stock Ledger Entry", {"voucher_no": pr.name})
 		self.assertEqual(sle.qty_after_transaction, bin_qty)
 		self.assertEqual(sle.warehouse, po.get("items")[0].warehouse)
 
-		#if account setup in company
-		if frappe.db.exists('GL Entry',{'account': 'Stock Received But Not Billed - _TC'}):
-			gl_temp_credit = frappe.db.get_value('GL Entry',{'voucher_no':pr.name, 'account': 'Stock Received But Not Billed - _TC'},'credit')
+		# if account setup in company
+		if frappe.db.exists("GL Entry", {"account": "Stock Received But Not Billed - _TC"}):
+			gl_temp_credit = frappe.db.get_value(
+				"GL Entry",
+				{"voucher_no": pr.name, "account": "Stock Received But Not Billed - _TC"},
+				"credit",
+			)
 			self.assertEqual(gl_temp_credit, 50000)
 
-		#if account setup in company
-		if frappe.db.exists('GL Entry',{'account': 'Stock In Hand - _TC'}):
-			gl_stock_debit = frappe.db.get_value('GL Entry',{'voucher_no':pr.name, 'account': 'Stock In Hand - _TC'},'debit')
+		# if account setup in company
+		if frappe.db.exists("GL Entry", {"account": "Stock In Hand - _TC"}):
+			gl_stock_debit = frappe.db.get_value(
+				"GL Entry", {"voucher_no": pr.name, "account": "Stock In Hand - _TC"}, "debit"
+			)
 			self.assertEqual(gl_stock_debit, 50000)
 
-
 		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
 		return_pr = make_return_doc("Purchase Receipt", pr.name)
 		return_pr.get("items")[0].received_qty = -5
 		return_pr.submit()
 
-		bin_qty = frappe.db.get_value("Bin", {"item_code": "_Test Item", "warehouse": "Stores - _TC"}, "actual_qty")
-		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':return_pr.name})
+		bin_qty = frappe.db.get_value(
+			"Bin", {"item_code": "_Test Item", "warehouse": "Stores - _TC"}, "actual_qty"
+		)
+		sle = frappe.get_doc("Stock Ledger Entry", {"voucher_no": return_pr.name})
 		self.assertEqual(sle.qty_after_transaction, bin_qty)
 
-		#if account setup in company
+		# if account setup in company
 
-		if frappe.db.exists('GL Entry',{'account': 'Stock Received But Not Billed - _TC'}):
-			gl_temp_credit = frappe.db.get_value('GL Entry',{'voucher_no':return_pr.name, 'account': 'Stock Received But Not Billed - _TC'},'debit')
+		if frappe.db.exists("GL Entry", {"account": "Stock Received But Not Billed - _TC"}):
+			gl_temp_credit = frappe.db.get_value(
+				"GL Entry",
+				{"voucher_no": return_pr.name, "account": "Stock Received But Not Billed - _TC"},
+				"debit",
+			)
 			self.assertEqual(gl_temp_credit, 50000)
 
-		#if account setup in company
-		if frappe.db.exists('GL Entry',{'account': 'Stock In Hand - _TC'}):
-			gl_stock_debit = frappe.db.get_value('GL Entry',{'voucher_no':return_pr.name, 'account': 'Stock In Hand - _TC'},'credit')
+		# if account setup in company
+		if frappe.db.exists("GL Entry", {"account": "Stock In Hand - _TC"}):
+			gl_stock_debit = frappe.db.get_value(
+				"GL Entry", {"voucher_no": return_pr.name, "account": "Stock In Hand - _TC"}, "credit"
+			)
 			self.assertEqual(gl_stock_debit, 50000)
 
 	def test_create_po_pr_TC_SCK_177(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
 		create_company()
-		create_item("_Test Item",warehouse="Stores - _TC")
+		create_item("_Test Item", warehouse="Stores - _TC")
 		create_supplier(supplier_name="_Test Supplier")
-		po = create_purchase_order(qty=10,warehouse="Stores - _TC")
-		get_or_create_fiscal_year('_Test Company')
+		po = create_purchase_order(qty=10, warehouse="Stores - _TC")
+		get_or_create_fiscal_year("_Test Company")
 		po.submit()
 		frappe.db.set_value("Item", "_Test Item", "over_delivery_receipt_allowance", 10)
 		pr = make_purchase_receipt(po.name)
@@ -4162,19 +4315,27 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.insert()
 		pr.submit()
 
-		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':pr.name})
+		sle = frappe.get_doc("Stock Ledger Entry", {"voucher_no": pr.name})
 		self.assertEqual(sle.qty_after_transaction, 2)
 
 	def test_create_po_pr_return_pr_TC_SCK_178(self):
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+
 		get_or_create_fiscal_year("_Test Company")
 		create_company()
-		get_or_create_fiscal_year('_Test Company PO')
+		get_or_create_fiscal_year("_Test Company PO")
 		supplier = create_supplier(supplier_name="_Test Supplier PO")
 		item = create_item("_Test PO")
 		warehouse = create_warehouse("_Test warehouse - _PO", company="_Test Company PO")
 
-		po = create_purchase_order(qty=10,company="_Test Company PO",supplier=supplier,item=item.item_code,warehouse=warehouse,do_not_save=1)
+		po = create_purchase_order(
+			qty=10,
+			company="_Test Company PO",
+			supplier=supplier,
+			item=item.item_code,
+			warehouse=warehouse,
+			do_not_save=1,
+		)
 		po.save()
 		po.submit()
 
@@ -4188,17 +4349,18 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.insert()
 		pr.submit()
 
-		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':pr.name})
+		sle = frappe.get_doc("Stock Ledger Entry", {"voucher_no": pr.name})
 		self.assertEqual(sle.qty_after_transaction, 2)
 
 		pr.load_from_db()
 		from erpnext.controllers.sales_and_purchase_return import make_return_doc
-		return_pi = make_return_doc("Purchase Receipt", pr.name,return_against_rejected_qty=True)
+
+		return_pi = make_return_doc("Purchase Receipt", pr.name, return_against_rejected_qty=True)
 		return_pi.get("items")[0].qty = -2
 		return_pi.submit()
 		pr.reload()
 
-		sle = frappe.get_doc('Stock Ledger Entry',{'voucher_no':return_pi.name})
+		sle = frappe.get_doc("Stock Ledger Entry", {"voucher_no": return_pi.name})
 		self.assertEqual(sle.actual_qty, -2)
 
 	def test_tds_in_po_and_pi_TC_B_150(self):
@@ -4210,47 +4372,46 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-5"
 		tax_category = "test_tax_withholding_category"
 		if not frappe.db.exists("Tax Withholding Category", tax_category):
-			doc = frappe.get_doc({
-				"doctype": "Tax Withholding Category",
-				"name": tax_category,
-				"category_name": tax_category,
-				"rates": [
-					{
-						"from_date": get_year_start(getdate()),
-						"to_date": get_year_ending(getdate()),
-						"tax_withholding_rate": 2,
-						"single_threshold": 1000,
-						"cumulative_threshold": 100000
-					}
-				],
-				"accounts": [
-					{
-						"company": company,
-						"account": create_new_account("TDS Payable", company, "Duties and Taxes - TC-5", "Tax")
-					}
-				]
-			})
+			doc = frappe.get_doc(
+				{
+					"doctype": "Tax Withholding Category",
+					"name": tax_category,
+					"category_name": tax_category,
+					"rates": [
+						{
+							"from_date": get_year_start(getdate()),
+							"to_date": get_year_ending(getdate()),
+							"tax_withholding_rate": 2,
+							"single_threshold": 1000,
+							"cumulative_threshold": 100000,
+						}
+					],
+					"accounts": [
+						{
+							"company": company,
+							"account": create_new_account(
+								"TDS Payable", company, "Duties and Taxes - TC-5", "Tax"
+							),
+						}
+					],
+				}
+			)
 			doc.insert()
 			tax_category = doc.name
 
 		frappe.db.set_value("Supplier", supplier, "tax_withholding_category", tax_category)
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"apply_tds": 1,
-			"schedule_date":today(),
-			"currency": "INR",
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": warehouse,
-					"qty": 2,
-					"rate": 500
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"apply_tds": 1,
+				"schedule_date": today(),
+				"currency": "INR",
+				"set_warehouse": warehouse,
+				"items": [{"item_code": item.item_code, "warehouse": warehouse, "qty": 2, "rate": 500}],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.tax_withholding_category = tax_category
@@ -4274,7 +4435,11 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.items[0].qty, 2)
 		self.assertEqual(pi.items[0].rate, 500)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name, "company": company}, fields=["account", "debit", "credit"])
+		gl_entries = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_no": pi.name, "company": company},
+			fields=["account", "debit", "credit"],
+		)
 		self.assertTrue(gl_entries)
 
 		total_debit = sum(entry["debit"] for entry in gl_entries)
@@ -4287,45 +4452,46 @@ class TestPurchaseOrder(FrappeTestCase):
 		supplier = get_data.get("supplier")
 		item = make_test_item("__test_item_1")
 		target_warehouse = "Stores - TC-5"
-		tax_category = frappe.get_doc({
-			"doctype": "Tax Withholding Category",
-			"name": "test_tax_withholding_category",
-			"category_name": "test_tax_withholding_category",
-			"rates": [
-				{
-					"from_date": get_year_start(getdate()),
-					"to_date": get_year_ending(getdate()),
-					"tax_withholding_rate": 2,
-					"single_threshold": 1000,
-					"cumulative_threshold": 100000
-				}
-			],
-			"accounts": [
-				{
-					"company": company,
-					"account": self.create_account("TDS Payable", company, "INR", "Duties and Taxes - TC-5")
-				}
-			]
-		}).insert(ignore_if_duplicate=1)
+		tax_category = frappe.get_doc(
+			{
+				"doctype": "Tax Withholding Category",
+				"name": "test_tax_withholding_category",
+				"category_name": "test_tax_withholding_category",
+				"rates": [
+					{
+						"from_date": get_year_start(getdate()),
+						"to_date": get_year_ending(getdate()),
+						"tax_withholding_rate": 2,
+						"single_threshold": 1000,
+						"cumulative_threshold": 100000,
+					}
+				],
+				"accounts": [
+					{
+						"company": company,
+						"account": self.create_account(
+							"TDS Payable", company, "INR", "Duties and Taxes - TC-5"
+						),
+					}
+				],
+			}
+		).insert(ignore_if_duplicate=1)
 		frappe.db.set_value("Supplier", supplier, "tax_withholding_category", tax_category.name)
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"apply_tds": 1,
-			"schedule_date":today(),
-			"set_warehouse": target_warehouse,
-			"taxes_and_charges": "",
-			"tax_withholding_category": tax_category,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"warehouse": target_warehouse,
-					"qty": 2,
-					"rate": 500
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"apply_tds": 1,
+				"schedule_date": today(),
+				"set_warehouse": target_warehouse,
+				"taxes_and_charges": "",
+				"tax_withholding_category": tax_category,
+				"items": [
+					{"item_code": item.item_code, "warehouse": target_warehouse, "qty": 2, "rate": 500}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.taxes[0].tax_amount, 20)
@@ -4340,27 +4506,33 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("Test Item with Putaway Rule")
 
 		if not frappe.db.exists("Putaway Rule", {"item_code": item.item_code, "warehouse": warehouse}):
-			frappe.get_doc({
-				"company": company,
-				"doctype": "Putaway Rule",
-				"item_code": item.item_code,
-				"warehouse": warehouse,
-				"capacity": 20,
-				"priority": 1,
-			}).insert(ignore_if_duplicate=1)
+			frappe.get_doc(
+				{
+					"company": company,
+					"doctype": "Putaway Rule",
+					"item_code": item.item_code,
+					"warehouse": warehouse,
+					"capacity": 20,
+					"priority": 1,
+				}
+			).insert(ignore_if_duplicate=1)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [{
-				"item_code": item.item_code,
-				"qty": 20,
-				"warehouse": warehouse,
-			}],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 20,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.insert()
@@ -4372,18 +4544,14 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.taxes = []
 		pr.insert()
 		pr.submit()
-		self.assertEqual(pr.docstatus,1)
-		stock_ledger_entries = frappe.get_all("Stock Ledger Entry",
-			filters={
-				"voucher_no": pr.name
-			},
-			fields=[
-				"warehouse",
-				"actual_qty"
-			]
+		self.assertEqual(pr.docstatus, 1)
+		stock_ledger_entries = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_no": pr.name}, fields=["warehouse", "actual_qty"]
 		)
 
-		warehouse_qty = sum(entry.actual_qty for entry in stock_ledger_entries if entry.warehouse == warehouse)
+		warehouse_qty = sum(
+			entry.actual_qty for entry in stock_ledger_entries if entry.warehouse == warehouse
+		)
 		self.assertEqual(warehouse_qty, 20)
 		pi = make_purchase_invoice(pr.name)
 		pi.bill_no = "test_bill_1122"
@@ -4402,82 +4570,77 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-3"
 
 		remove_existing_shipping_rules()
-	
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Net Weight Shipping Rule",
-			"calculate_based_on": "Fixed",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-3",
-			"cost_center": "Main - TC-3",
-			"conditions": [
-				{
-					"from_value": 10,
-					"to_value": 1000,
-					"shipping_amount": 200
-				}
-			]
-		})
+
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Net Weight Shipping Rule",
+				"calculate_based_on": "Fixed",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-3",
+				"cost_center": "Main - TC-3",
+				"conditions": [{"from_value": 10, "to_value": 1000, "shipping_amount": 200}],
+			}
+		)
 		shipping_rule.insert(ignore_permissions=True)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 1,
-					"rate": 130,
-					"warehouse": warehouse,
-				}
-			],
-			"shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 1,
+						"rate": 130,
+						"warehouse": warehouse,
+					}
+				],
+				"shipping_rule": shipping_rule.name,
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
 
-		args = {
-			"mode_of_payment" : "Cash",
-			"reference_no" : "For Testing"
-		}
+		args = {"mode_of_payment": "Cash", "reference_no": "For Testing"}
 
 		# pe = make_payment_entry(po.doctype, po.name, po.grand_total, args )
 		pe = get_payment_entry(po.doctype, po.name)
 		pe.insert(ignore_permissions=True)
 		pe.submit()
-		
+
 		pr = make_pr_for_po(po.name)
 		self.assertEqual(pr.docstatus, 1)
 
 		args = {
-			"mode_of_payment" : 'Cash',
-			"cash_bank_account" : pe.paid_from,
-			"paid_amount" : pe.base_received_amount,
-			"is_paid": 1
+			"mode_of_payment": "Cash",
+			"cash_bank_account": pe.paid_from,
+			"paid_amount": pe.base_received_amount,
+			"is_paid": 1,
 		}
 
 		pi = make_pi_against_pr(pr.name, args=args)
 		self.assertEqual(pi.docstatus, 1)
 		self.assertEqual(pi.items[0].qty, po.items[0].qty)
 		self.assertEqual(pi.grand_total, po.grand_total)
-		
+
 		po.reload()
-		self.assertEqual(po.status, 'Completed')
-		self.assertEqual(pi.status, 'Paid')
-	
+		self.assertEqual(po.status, "Completed")
+		self.assertEqual(pi.status, "Paid")
+
 	def test_po_shipping_rule_partial_payment_entry_TC_B_071(self):
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_test_item("_test_item")
 		warehouse = "Stores - TC-3"
-		
+
 		get_or_create_fiscal_year(company)
 		remove_existing_shipping_rules()
 
@@ -4490,63 +4653,63 @@ class TestPurchaseOrder(FrappeTestCase):
 				"shipping_rule_type": "Buying",
 				"account": "Cash - TC-3",
 				"cost_center": "Main - TC-3",
-				"shipping_amount": 200
+				"shipping_amount": 200,
 			}
 		).insert(ignore_if_duplicate=1)
 
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
-			"warehouse" : warehouse,
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": warehouse,
 			"supplier": supplier,
-			"qty" : 3,
-			"rate" : 12000,
-			"shipping_rule" :shipping_rule.name
+			"qty": 3,
+			"rate": 12000,
+			"shipping_rule": shipping_rule.name,
 		}
-		
+
 		doc_po = create_purchase_order(**po_data)
 		self.assertEqual(doc_po.docstatus, 1)
 
-		args = {
-			"mode_of_payment" : "Cash",
-			"reference_no" : "For Testing"
-		}
+		args = {"mode_of_payment": "Cash", "reference_no": "For Testing"}
 
 		cash_account = frappe.db.get_value(
-			"Mode of Payment Account", {"parent": 'Cash', "company": company}, "default_account"
+			"Mode of Payment Account", {"parent": "Cash", "company": company}, "default_account"
 		)
 		if not cash_account:
-			mop =  frappe.get_doc('Mode of Payment', 'Cash')
-			mop.append('accounts', {
-				'company': company,
-				'default_account': 'Cash - TC-3',
-			})
+			mop = frappe.get_doc("Mode of Payment", "Cash")
+			mop.append(
+				"accounts",
+				{
+					"company": company,
+					"default_account": "Cash - TC-3",
+				},
+			)
 			mop.save()
-		doc_pe = make_payment_entry(doc_po.doctype, doc_po.name, 6000, args )
-		
+		doc_pe = make_payment_entry(doc_po.doctype, doc_po.name, 6000, args)
+
 		doc_pr = make_pr_for_po(doc_po.name)
 		self.assertEqual(doc_pr.docstatus, 1)
 
 		args = {
-			"is_paid" : 1,
-			"mode_of_payment" : 'Cash',
-			"cash_bank_account" : doc_pe.paid_from,
-			"paid_amount" : doc_pe.base_received_amount
+			"is_paid": 1,
+			"mode_of_payment": "Cash",
+			"cash_bank_account": doc_pe.paid_from,
+			"paid_amount": doc_pe.base_received_amount,
 		}
 
 		doc_pi = make_pi_against_pr(doc_pr.name, args=args)
 		make_payment_entry(doc_pi.doctype, doc_pi.name, doc_pi.outstanding_amount)
-		
+
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.items[0].qty, doc_po.items[0].qty)
 		self.assertEqual(doc_pi.grand_total, doc_po.grand_total)
-		
+
 		doc_po.reload()
 		doc_pi.reload()
-		self.assertEqual(doc_po.status, 'Completed')
-		self.assertEqual(doc_pi.status, 'Paid')
+		self.assertEqual(doc_po.status, "Completed")
+		self.assertEqual(doc_pi.status, "Paid")
 		self.assertEqual(doc_pi.outstanding_amount, 0)
-	
+
 	def test_po_to_pi_with_Adv_payment_entry_TC_B_072(self):
 		# Scenario : PO => PE => PR => PI [With Adv Payment]
 		get_company_supplier = create_data()
@@ -4556,45 +4719,41 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-3"
 
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
-			"warehouse" : warehouse,
-			"qty" : 1,
-			"rate" : 3000,
-			"supplier" : supplier
-
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": warehouse,
+			"qty": 1,
+			"rate": 3000,
+			"supplier": supplier,
 		}
-		
+
 		doc_po = create_purchase_order(**po_data)
 		self.assertEqual(doc_po.docstatus, 1)
 
-		args = {
-			"mode_of_payment" : "Cash",
-			"reference_no" : "For Testing"
-		}
+		args = {"mode_of_payment": "Cash", "reference_no": "For Testing"}
 
 		doc_pe = make_payment_entry(doc_po.doctype, doc_po.name, doc_po.grand_total, args)
-		
+
 		doc_pr = make_pr_for_po(doc_po.name)
 		self.assertEqual(doc_pr.docstatus, 1)
 
 		args = {
-			"is_paid" : 1,
-			"mode_of_payment" : 'Cash',
-			"cash_bank_account" : doc_pe.paid_from,
-			"paid_amount" : doc_pe.base_received_amount
+			"is_paid": 1,
+			"mode_of_payment": "Cash",
+			"cash_bank_account": doc_pe.paid_from,
+			"paid_amount": doc_pe.base_received_amount,
 		}
 
 		doc_pi = make_pi_against_pr(doc_pr.name, args=args)
-		
+
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.items[0].qty, doc_po.items[0].qty)
 		self.assertEqual(doc_pi.grand_total, doc_po.grand_total)
-		
+
 		doc_po.reload()
-		self.assertEqual(doc_po.status, 'Completed')
-		self.assertEqual(doc_pi.status, 'Paid')
-	
+		self.assertEqual(doc_po.status, "Completed")
+		self.assertEqual(doc_pi.status, "Paid")
+
 	def test_po_to_pi_with_partial_payment_entry_TC_B_073(self):
 		# Scenario : PO => PE => PR => PI [With Adv Partial Payment]
 		get_data = get_company_or_supplier()
@@ -4603,42 +4762,42 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("_test_item_")
 		get_or_create_fiscal_year(company)
 		po_data = {
-			"company" : company,
-			"item_code" :item.item_code,
-			"warehouse" : "Stores - TC-5",
-			"qty" : 4,
-			"rate" : 3000,
-			"supplier": supplier
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": "Stores - TC-5",
+			"qty": 4,
+			"rate": 3000,
+			"supplier": supplier,
 		}
 
 		doc_po = create_purchase_order(**po_data)
 		self.assertEqual(doc_po.docstatus, 1)
 
-		args = {
-			"mode_of_payment" : "Cash",
-			"reference_no" : "For Testing"
-		}
+		args = {"mode_of_payment": "Cash", "reference_no": "For Testing"}
 
 		cash_account = frappe.db.get_value(
-			"Mode of Payment Account", {"parent": 'Cash', "company": company}, "default_account"
+			"Mode of Payment Account", {"parent": "Cash", "company": company}, "default_account"
 		)
 		if not cash_account:
-			mop =  frappe.get_doc('Mode of Payment', 'Cash')
-			mop.append('accounts', {
-				'company': company,
-				'default_account': 'Cash - TC-5',
-			})
+			mop = frappe.get_doc("Mode of Payment", "Cash")
+			mop.append(
+				"accounts",
+				{
+					"company": company,
+					"default_account": "Cash - TC-5",
+				},
+			)
 			mop.save()
 		doc_pe = make_payment_entry(doc_po.doctype, doc_po.name, 6000, args)
-		
+
 		doc_pr = make_pr_for_po(doc_po.name)
 		self.assertEqual(doc_pr.docstatus, 1)
 
 		args = {
-			"is_paid" : 1,
-			"mode_of_payment" : 'Cash',
-			"cash_bank_account" : doc_pe.paid_from,
-			"paid_amount" : doc_pe.base_received_amount
+			"is_paid": 1,
+			"mode_of_payment": "Cash",
+			"cash_bank_account": doc_pe.paid_from,
+			"paid_amount": doc_pe.base_received_amount,
 		}
 
 		doc_pi = make_pi_against_pr(doc_pr.name, args=args)
@@ -4647,11 +4806,11 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.items[0].qty, doc_po.items[0].qty)
 		self.assertEqual(doc_pi.grand_total, doc_po.grand_total)
-		
+
 		doc_po.reload()
 		doc_pi.reload()
-		self.assertEqual(doc_po.status, 'Completed')
-		self.assertEqual(doc_pi.status, 'Paid')
+		self.assertEqual(doc_po.status, "Completed")
+		self.assertEqual(doc_pi.status, "Paid")
 
 	@if_app_installed("india_compliance")
 	def test_po_to_pi_with_Adv_payment_entry_n_tax_TC_B_074(self):
@@ -4660,7 +4819,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		company = get_data.get("company")
 		supplier = get_data.get("supplier")
 		item = make_test_item("_test_item_")
-		
+
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax IGST"
 		acc.parent_account = "Tax Assets - TC-5"
@@ -4670,13 +4829,13 @@ class TestPurchaseOrder(FrappeTestCase):
 			account_name = acc.insert(ignore_permissions=True)
 
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
-			"warehouse" : "Stores - TC-5",
-			"qty" : 1,
-			"rate" : 3000,
-			"do_not_submit" : 1,
-			"supplier": supplier
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": "Stores - TC-5",
+			"qty": 1,
+			"rate": 3000,
+			"do_not_submit": 1,
+			"supplier": supplier,
 		}
 		doc_po = create_purchase_order(**po_data)
 		doc_po.append(
@@ -4686,37 +4845,34 @@ class TestPurchaseOrder(FrappeTestCase):
 				"account_head": account_name,
 				"rate": 18,
 				"description": "Input GST",
-			}
+			},
 		)
 		doc_po.submit()
 		self.assertEqual(doc_po.docstatus, 1)
 
-		args = {
-			"mode_of_payment" : "Cash",
-			"reference_no" : "For Testing"
-		}
+		args = {"mode_of_payment": "Cash", "reference_no": "For Testing"}
 
 		doc_pe = make_payment_entry(doc_po.doctype, doc_po.name, doc_po.grand_total, args)
-		
+
 		doc_pr = make_pr_for_po(doc_po.name)
 		self.assertEqual(doc_pr.docstatus, 1)
 
 		args = {
-			"is_paid" : 1,
-			"mode_of_payment" : 'Cash',
-			"cash_bank_account" : doc_pe.paid_from,
-			"paid_amount" : doc_pe.base_received_amount
+			"is_paid": 1,
+			"mode_of_payment": "Cash",
+			"cash_bank_account": doc_pe.paid_from,
+			"paid_amount": doc_pe.base_received_amount,
 		}
 
 		doc_pi = make_pi_against_pr(doc_pr.name, args=args)
-		
+
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.items[0].qty, doc_po.items[0].qty)
 		self.assertEqual(doc_pi.grand_total, doc_po.grand_total)
-		
+
 		doc_po.reload()
-		self.assertEqual(doc_po.status, 'Completed')
-		self.assertEqual(doc_pi.status, 'Paid')
+		self.assertEqual(doc_po.status, "Completed")
+		self.assertEqual(doc_pi.status, "Paid")
 
 	@if_app_installed("india_compliance")
 	def test_po_to_pi_with_partial_payment_entry_TC_B_075(self):
@@ -4727,20 +4883,20 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("_test_items_1")
 		get_or_create_fiscal_year(company)
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
-			"warehouse" : "Stores - TC-5",
-			"qty" : 4,
-			"rate" : 3000,
-			"do_not_submit" : 1,
-			"supplier": supplier
+			"company": company,
+			"item_code": item.item_code,
+			"warehouse": "Stores - TC-5",
+			"qty": 4,
+			"rate": 3000,
+			"do_not_submit": 1,
+			"supplier": supplier,
 		}
-		
+
 		acc = frappe.new_doc("Account")
 		acc.account_name = "Input Tax IGST"
 		acc.parent_account = "Tax Assets - TC-5"
 		acc.company = company
-		account_name = frappe.db.exists("Account", {"account_name" : acc.account_name, "company": company})
+		account_name = frappe.db.exists("Account", {"account_name": acc.account_name, "company": company})
 		if not account_name:
 			account_name = acc.insert(ignore_permissions=True)
 
@@ -4752,39 +4908,38 @@ class TestPurchaseOrder(FrappeTestCase):
 				"account_head": account_name,
 				"rate": 18,
 				"description": "Input GST",
-			}
+			},
 		)
 		doc_po.submit()
 
 		self.assertEqual(doc_po.docstatus, 1)
 		self.assertEqual(doc_po.base_taxes_and_charges_added, 2160)
-		
 
-		args = {
-			"mode_of_payment" : "Cash",
-			"reference_no" : "For Testing"
-		}
+		args = {"mode_of_payment": "Cash", "reference_no": "For Testing"}
 		cash_account = frappe.db.get_value(
-			"Mode of Payment Account", {"parent": 'Cash', "company": company}, "default_account"
+			"Mode of Payment Account", {"parent": "Cash", "company": company}, "default_account"
 		)
 		if not cash_account:
-			mop =  frappe.get_doc('Mode of Payment', 'Cash')
-			mop.append('accounts', {
-				'company': company,
-				'default_account': 'Cash - TC-5',
-			})
+			mop = frappe.get_doc("Mode of Payment", "Cash")
+			mop.append(
+				"accounts",
+				{
+					"company": company,
+					"default_account": "Cash - TC-5",
+				},
+			)
 			mop.save()
-			
+
 		doc_pe = make_payment_entry(doc_po.doctype, doc_po.name, 6000, args)
-		
+
 		doc_pr = make_pr_for_po(doc_po.name)
 		self.assertEqual(doc_pr.docstatus, 1)
 
 		args = {
-			"is_paid" : 1,
-			"mode_of_payment" : 'Cash',
-			"cash_bank_account" : doc_pe.paid_from,
-			"paid_amount" : doc_pe.base_received_amount
+			"is_paid": 1,
+			"mode_of_payment": "Cash",
+			"cash_bank_account": doc_pe.paid_from,
+			"paid_amount": doc_pe.base_received_amount,
 		}
 
 		doc_pi = make_pi_against_pr(doc_pr.name, args=args)
@@ -4793,16 +4948,17 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_pi.items[0].qty, doc_po.items[0].qty)
 		self.assertEqual(doc_pi.grand_total, doc_po.grand_total)
-		
+
 		doc_po.reload()
 		doc_pi.reload()
-		self.assertEqual(doc_po.status, 'Completed')
-		self.assertEqual(doc_pi.status, 'Paid')
+		self.assertEqual(doc_po.status, "Completed")
+		self.assertEqual(doc_pi.status, "Paid")
 
 	@if_app_installed("india_compliance")
 	def test_default_uom_with_po_pr_pi_TC_B_105(self):
 		# item as box => po => pr => pi with GST
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+
 		create_company()
 		company = "_Test Company"
 		supplier = "_Test Supplier"
@@ -4811,9 +4967,9 @@ class TestPurchaseOrder(FrappeTestCase):
 			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
 			company="_Test Company",
 		)
-		create_supplier(supplier_name = supplier,default_currency ="INR")
+		create_supplier(supplier_name=supplier, default_currency="INR")
 		item_code = "_Test Item"
-		create_item(item_code = item_code,valuation_rate=100)
+		create_item(item_code=item_code, valuation_rate=100)
 		gst_hsn_code = "11112222"
 		warehouse = "Stores - _TC"
 		tax_category_1 = "Test Tax Category"
@@ -4822,16 +4978,27 @@ class TestPurchaseOrder(FrappeTestCase):
 			tax_category.title = tax_category_1
 			tax_category.save()
 
-		frappe.db.set_value("Company", company, {"enable_perpetual_inventory":1, "stock_received_but_not_billed": "Stock Received But Not Billed - _TC"})
-		item_tax_template = frappe.db.get_value("Purchase Taxes and Charges Template",{"company": company,"tax_category":tax_category_1}, "name")
+		frappe.db.set_value(
+			"Company",
+			company,
+			{
+				"enable_perpetual_inventory": 1,
+				"stock_received_but_not_billed": "Stock Received But Not Billed - _TC",
+			},
+		)
+		item_tax_template = frappe.db.get_value(
+			"Purchase Taxes and Charges Template",
+			{"company": company, "tax_category": tax_category_1},
+			"name",
+		)
 		if frappe.db.exists("DocType", "GST HSN Code") and not frappe.db.exists("GST HSN Code", gst_hsn_code):
-			frappe.get_doc({
-				"doctype": "GST HSN Code",
-				"hsn_code": gst_hsn_code,
-				"taxes": [{
-					"item_tax_template": "GST 18% - _TC"
-				}]
-			}).insert()
+			frappe.get_doc(
+				{
+					"doctype": "GST HSN Code",
+					"hsn_code": gst_hsn_code,
+					"taxes": [{"item_tax_template": "GST 18% - _TC"}],
+				}
+			).insert()
 		taxes = [
 			{
 				"charge_type": "On Net Total",
@@ -4839,7 +5006,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				"category": "Total",
 				"rate": 9,
 				"account_head": "Stock In Hand - _TC",
-				"description": "SGST"
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
@@ -4847,38 +5014,35 @@ class TestPurchaseOrder(FrappeTestCase):
 				"category": "Total",
 				"rate": 9,
 				"account_head": "Stock In Hand - _TC",
-				"description": "CGST"
-			}
+				"description": "CGST",
+			},
 		]
 		if frappe.db.exists("Purchase Taxes and Charges Template", item_tax_template):
 			existing_templates = item_tax_template
 		else:
 			purchase_tax_template = frappe.new_doc("Purchase Taxes and Charges Template")
 			purchase_tax_template.company = company
-			purchase_tax_template.title ="test"
+			purchase_tax_template.title = "test"
 			purchase_tax_template.tax_category = tax_category
-			for tax  in taxes:
+			for tax in taxes:
 				purchase_tax_template.append("taxes", tax)
 			purchase_tax_template.insert()
 			purchase_tax_template.save()
 			existing_templates = purchase_tax_template.name
-	
-		get_or_create_fiscal_year('_Test Company')
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"company": company,
-			"supplier": supplier,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [{
-				"item_code": item_code,
-				"qty": 1,
-				"rate": 100,
-				"uom": "Box"
-			}],
-		})
-		
+
+		get_or_create_fiscal_year("_Test Company")
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"company": company,
+				"supplier": supplier,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [{"item_code": item_code, "qty": 1, "rate": 100, "uom": "Box"}],
+			}
+		)
+
 		po.insert()
 		po.taxes_and_charges = existing_templates
 		po.save()
@@ -4887,23 +5051,26 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(po.taxes_and_charges_added, 18)
 		self.assertEqual(po.grand_total, 118)
 
-		pr = frappe.get_doc({
-			"doctype": "Purchase Receipt",
-			"supplier": po.supplier,
-			"company": po.company,
-			"currency": po.currency,
-			"set_warehouse": po.set_warehouse,
-			"items": [{
-				"item_code": po.items[0].item_code,
-				"uom": po.items[0].uom,
-				"qty": po.items[0].qty,
-				"stock_uom": po.items[0].stock_uom,
-				"conversion_factor": po.items[0].conversion_factor,
-				"rate": po.items[0].rate,
-				"purchase_order": po.name,
-			}],
-			
-		})
+		pr = frappe.get_doc(
+			{
+				"doctype": "Purchase Receipt",
+				"supplier": po.supplier,
+				"company": po.company,
+				"currency": po.currency,
+				"set_warehouse": po.set_warehouse,
+				"items": [
+					{
+						"item_code": po.items[0].item_code,
+						"uom": po.items[0].uom,
+						"qty": po.items[0].qty,
+						"stock_uom": po.items[0].stock_uom,
+						"conversion_factor": po.items[0].conversion_factor,
+						"rate": po.items[0].rate,
+						"purchase_order": po.name,
+					}
+				],
+			}
+		)
 		pr.insert()
 		pr.taxes_and_charges = existing_templates
 		pr.submit()
@@ -4911,34 +5078,39 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.taxes_and_charges_added, 18)
 		self.assertEqual(pr.grand_total, 118)
 
-		get_pr_stock_ledger = frappe.db.get_all("Stock Ledger Entry",{"voucher_no": pr.name}, ['valuation_rate', 'actual_qty', 'warehouse'])
+		get_pr_stock_ledger = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["valuation_rate", "actual_qty", "warehouse"]
+		)
 
 		for stock_led in get_pr_stock_ledger:
-			self.assertEqual(stock_led.get('valuation_rate'), 100)
+			self.assertEqual(stock_led.get("valuation_rate"), 100)
 			self.assertEqual(stock_led.actual_qty, 1)
 			self.assertEqual(stock_led.warehouse, warehouse)
 
 		get_pr_gl_entries = frappe.db.get_all("GL Entry", {"voucher_no": pr.name})
 		self.assertTrue(get_pr_gl_entries)
 
-		pi = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"supplier": pr.supplier,
-			"company": pr.company,
-			"credit_to": 'Creditors - _TC',
-			"currency": pr.currency,
-			"items": [{
-				"item_code": pr.items[0].item_code,
-				"qty": pr.items[0].qty,
-				"uom": pr.items[0].uom,
-				"conversion_factor": pr.items[0].conversion_factor,
-				"rate": pr.items[0].rate,
-				"apply_tds": pr.items[0].apply_tds,
-				"purchase_order": po.name,
-				"purchase_receipt": pr.name
-			}],
-			
-		})
+		pi = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"supplier": pr.supplier,
+				"company": pr.company,
+				"credit_to": "Creditors - _TC",
+				"currency": pr.currency,
+				"items": [
+					{
+						"item_code": pr.items[0].item_code,
+						"qty": pr.items[0].qty,
+						"uom": pr.items[0].uom,
+						"conversion_factor": pr.items[0].conversion_factor,
+						"rate": pr.items[0].rate,
+						"apply_tds": pr.items[0].apply_tds,
+						"purchase_order": po.name,
+						"purchase_receipt": pr.name,
+					}
+				],
+			}
+		)
 		pi.insert(ignore_permissions=True)
 		pi.taxes_and_charges = existing_templates
 		pi.submit()
@@ -4949,18 +5121,14 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		gl_entries = frappe.get_all(
 			"GL Entry",
-			filters={
-				"voucher_type": "Purchase Invoice",
-				"voucher_no": pi.name,
-				"is_cancelled": 0
-			},
-			fields=["account", "debit", "credit"]
+			filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name, "is_cancelled": 0},
+			fields=["account", "debit", "credit"],
 		)
 
 		expected_entries = [
-			{'account': 'Stock In Hand - _TC', 'debit': 18.0, 'credit': 0.0},
-			{'account': 'Stock Received But Not Billed - _TC', 'debit': 100.0, 'credit': 0.0},
-			{'account': 'Creditors - _TC', 'debit': 0.0, 'credit': 118.0},
+			{"account": "Stock In Hand - _TC", "debit": 18.0, "credit": 0.0},
+			{"account": "Stock Received But Not Billed - _TC", "debit": 100.0, "credit": 0.0},
+			{"account": "Creditors - _TC", "debit": 0.0, "credit": 118.0},
 		]
 
 		for entry in expected_entries:
@@ -4977,33 +5145,37 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_with_fixed_shipping_rule")
 
 		# Create Shipping Rule with Fixed Amount
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Fixed Shipping Rule",
-			"calculate_based_on": "Fixed",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-3",
-			"cost_center": "Main - TC-3",
-			"shipping_amount": 500
-		}).insert(ignore_if_duplicate=1)
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Fixed Shipping Rule",
+				"calculate_based_on": "Fixed",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-3",
+				"cost_center": "Main - TC-3",
+				"shipping_amount": 500,
+			}
+		).insert(ignore_if_duplicate=1)
 
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"warehouse": target_warehouse,
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.shipping_rule = shipping_rule.name
@@ -5017,7 +5189,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.insert()
 		pr.submit()
 		self.assertEqual(pr.docstatus, 1)
-		get_pr_stock_ledger = frappe.db.get_all("Stock Ledger Entry",{"voucher_no": pr.name}, ['valuation_rate', 'actual_qty'])
+		get_pr_stock_ledger = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["valuation_rate", "actual_qty"]
+		)
 		self.assertTrue(get_pr_stock_ledger)
 
 		pi = make_purchase_invoice(pr.name)
@@ -5032,28 +5206,24 @@ class TestPurchaseOrder(FrappeTestCase):
 		pe.insert(ignore_permissions=True)
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(gl_entries_pr)
 
-		sle_pr = frappe.get_all("Stock Ledger Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		sle_pr = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(sle_pr)
-		gl_entries_pi = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		})
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name}
+		)
 		self.assertTrue(gl_entries_pi)
 		pi_outstanding = frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount")
 		self.assertEqual(pi_outstanding, 0)
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		})
+		gl_entries_pe = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Payment Entry", "voucher_no": pe.name}
+		)
 		self.assertTrue(gl_entries_pe)
 
 	def test_shipping_rule_net_total_pr_pi_pe_TC_B_107(self):
@@ -5063,38 +5233,38 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-3"
 		item = make_test_item("test_item_with_shipping_rule")
 
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Net Total Shipping Rule",
-			"calculate_based_on": "Net Total",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-3",
-			"cost_center": "Main - TC-3",
-			"conditions": [{
-				"from_value": 500,
-				"to_value": 2000,
-				"shipping_amount": 500
-			}]
-		}).insert(ignore_if_duplicate=1)
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Net Total Shipping Rule",
+				"calculate_based_on": "Net Total",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-3",
+				"cost_center": "Main - TC-3",
+				"conditions": [{"from_value": 500, "to_value": 2000, "shipping_amount": 500}],
+			}
+		).insert(ignore_if_duplicate=1)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-			# "shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+				# "shipping_rule": shipping_rule.name
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.shipping_rule = shipping_rule.name
@@ -5108,16 +5278,14 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.insert()
 		pr.submit()
 		self.assertEqual(pr.docstatus, 1)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(gl_entries_pr)
 
-		sle_pr = frappe.get_all("Stock Ledger Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		sle_pr = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(sle_pr)
 
 		pi = make_purchase_invoice(pr.name)
@@ -5128,21 +5296,19 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.taxes_and_charges_added, 500)
 		self.assertEqual(pi.grand_total, 1500)
 
-		gl_entries_pi = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		})
-		self.assertTrue(gl_entries_pi)	
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name}
+		)
+		self.assertTrue(gl_entries_pi)
 
 		pe = get_payment_entry(pi.doctype, pi.name)
 		pe.insert(ignore_permissions=True)
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
 
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		})
+		gl_entries_pe = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Payment Entry", "voucher_no": pe.name}
+		)
 		self.assertTrue(gl_entries_pe)
 
 		pi_outstanding = frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount")
@@ -5159,38 +5325,44 @@ class TestPurchaseOrder(FrappeTestCase):
 		item.save()
 
 		# Create Shipping Rule with calculation based on Net Weight
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Net Weight Shipping Rule",
-			"calculate_based_on": "Net Weight",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-3",
-			"cost_center": "Main - TC-3",
-			"conditions": [{
-				"from_value": 10,  # Net weight range
-				"to_value": 50,
-				"shipping_amount": 250
-			}]
-		}).insert(ignore_if_duplicate=1)
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Net Weight Shipping Rule",
+				"calculate_based_on": "Net Weight",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-3",
+				"cost_center": "Main - TC-3",
+				"conditions": [
+					{
+						"from_value": 10,  # Net weight range
+						"to_value": 50,
+						"shipping_amount": 250,
+					}
+				],
+			}
+		).insert(ignore_if_duplicate=1)
 
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,  # Total weight = 10 * 2.5 = 25 Kg
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,  # Total weight = 10 * 2.5 = 25 Kg
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.shipping_rule = shipping_rule.name
@@ -5218,13 +5390,14 @@ class TestPurchaseOrder(FrappeTestCase):
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
 
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		},fields=["account", "debit", "credit", "posting_date"])
+		gl_entries_pe = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_type": "Payment Entry", "voucher_no": pe.name},
+			fields=["account", "debit", "credit", "posting_date"],
+		)
 		self.assertTrue(gl_entries_pe)
 		self.assertEqual(gl_entries_pe[0].get("account"), "Cash - TC-3")
-		self.assertEqual(gl_entries_pe[0].get('credit'), 1250)
+		self.assertEqual(gl_entries_pe[0].get("credit"), 1250)
 		self.assertEqual(gl_entries_pe[1].get("account"), "Creditors - TC-3")
 		self.assertEqual(gl_entries_pe[1].get("debit"), 1250)
 
@@ -5238,34 +5411,38 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		remove_existing_shipping_rules()
 
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Fixed Shipping Rule",
-			"calculate_based_on": "Fixed",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-5",
-			"cost_center": "Main - TC-5",
-			"shipping_amount": 500
-		})
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Fixed Shipping Rule",
+				"calculate_based_on": "Fixed",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-5",
+				"cost_center": "Main - TC-5",
+				"shipping_amount": 500,
+			}
+		)
 		shipping_rule.insert(ignore_permissions=True)
-		tax_template = create_or_get_purchase_taxes_template(company = company)
+		tax_template = create_or_get_purchase_taxes_template(company=company)
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"warehouse": target_warehouse,
-				}
-			],
-			"shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"warehouse": target_warehouse,
+					}
+				],
+				"shipping_rule": shipping_rule.name,
+			}
+		)
 		po.taxes_and_charges = tax_template.get("purchase_tax_template")
 		po.insert()
 		po.submit()
@@ -5278,7 +5455,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.submit()
 		self.assertEqual(pr.docstatus, 1)
 
-		get_pr_stock_ledger = frappe.db.get_all("Stock Ledger Entry",{"voucher_no": pr.name}, ['valuation_rate', 'actual_qty'])
+		get_pr_stock_ledger = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["valuation_rate", "actual_qty"]
+		)
 		self.assertTrue(get_pr_stock_ledger)
 
 		# Create Purchase Invoice from Purchase Receipt
@@ -5294,28 +5473,24 @@ class TestPurchaseOrder(FrappeTestCase):
 		pe.insert(ignore_permissions=True)
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(gl_entries_pr)
 
-		sle_pr = frappe.get_all("Stock Ledger Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		sle_pr = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(sle_pr)
-		gl_entries_pi = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		})
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name}
+		)
 		self.assertTrue(gl_entries_pi)
 		pi_outstanding = frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount")
 		self.assertEqual(pi_outstanding, 0)
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		})
+		gl_entries_pe = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Payment Entry", "voucher_no": pe.name}
+		)
 		self.assertTrue(gl_entries_pe)
 
 	@if_app_installed("india_compliance")
@@ -5328,41 +5503,39 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		remove_existing_shipping_rules()
 
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Net Total Shipping Rule",
-			"calculate_based_on": "Net Total",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-5",
-			"cost_center": "Main - TC-5",
-			"conditions": [
-				{
-					"from_value": 500,
-					"to_value": 2000,
-					"shipping_amount": 500
-				}
-			]
-		})
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Net Total Shipping Rule",
+				"calculate_based_on": "Net Total",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-5",
+				"cost_center": "Main - TC-5",
+				"conditions": [{"from_value": 500, "to_value": 2000, "shipping_amount": 500}],
+			}
+		)
 
 		shipping_rule.insert(ignore_permissions=True)
-		tax_template = create_or_get_purchase_taxes_template(company = company)
+		tax_template = create_or_get_purchase_taxes_template(company=company)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = tax_template.get("purchase_tax_template")
 		po.shipping_rule = shipping_rule.name
 		po.insert()
@@ -5375,16 +5548,14 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.insert()
 		pr.submit()
 		self.assertEqual(pr.docstatus, 1)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(gl_entries_pr)
 
-		sle_pr = frappe.get_all("Stock Ledger Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		sle_pr = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(sle_pr)
 
 		pi = make_purchase_invoice(pr.name)
@@ -5395,21 +5566,19 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.taxes_and_charges_added, 680)
 		self.assertEqual(pi.grand_total, 1680)
 
-		gl_entries_pi = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		})
-		self.assertTrue(gl_entries_pi)	
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name}
+		)
+		self.assertTrue(gl_entries_pi)
 
 		pe = get_payment_entry(pi.doctype, pi.name)
 		pe.insert(ignore_permissions=True)
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
 
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		})
+		gl_entries_pe = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Payment Entry", "voucher_no": pe.name}
+		)
 		self.assertTrue(gl_entries_pe)
 
 		pi_outstanding = frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount")
@@ -5424,61 +5593,67 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-5"
 		item = make_test_item("test_item_with_net_weight_shipping_rule")
-		item.weight_uom = "Kg",
+		item.weight_uom = ("Kg",)
 		item.weight_per_unit = 2.5
 		item.save()
 
 		# Create Shipping Rule with calculation based on Net Weight
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "Net Weight Shipping Rule",
-			"calculate_based_on": "Net Weight",
-			"shipping_rule_type": "Buying",
-			"account": "Cash - TC-5",
-			"cost_center": "Main - TC-5",
-			"conditions": [{
-				"from_value": 10,  # Net weight range
-				"to_value": 50,
-				"shipping_amount": 250
-			}]
-		}).insert(ignore_if_duplicate=1)
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "Net Weight Shipping Rule",
+				"calculate_based_on": "Net Weight",
+				"shipping_rule_type": "Buying",
+				"account": "Cash - TC-5",
+				"cost_center": "Main - TC-5",
+				"conditions": [
+					{
+						"from_value": 10,  # Net weight range
+						"to_value": 50,
+						"shipping_amount": 250,
+					}
+				],
+			}
+		).insert(ignore_if_duplicate=1)
 
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,  # Total weight = 10 * 2.5 = 25 Kg
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-			"shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,  # Total weight = 10 * 2.5 = 25 Kg
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+				"shipping_rule": shipping_rule.name,
+			}
+		)
 		taxes = [
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_template.get('sgst_account'),
-				"description": "SGST"
+				"account_head": tax_template.get("sgst_account"),
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_template.get('cgst_account'),
-				"description": "CGST"
-			}
+				"account_head": tax_template.get("cgst_account"),
+				"description": "CGST",
+			},
 		]
 		for tax in taxes:
 			po.append("taxes", tax)
@@ -5508,13 +5683,14 @@ class TestPurchaseOrder(FrappeTestCase):
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
 
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		},fields=["account", "debit", "credit", "posting_date"])
+		gl_entries_pe = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_type": "Payment Entry", "voucher_no": pe.name},
+			fields=["account", "debit", "credit", "posting_date"],
+		)
 		self.assertTrue(gl_entries_pe)
 		self.assertEqual(gl_entries_pe[0].get("account"), "Cash - TC-5")
-		self.assertEqual(gl_entries_pe[0].get('credit'), 1430)
+		self.assertEqual(gl_entries_pe[0].get("credit"), 1430)
 		self.assertEqual(gl_entries_pe[1].get("account"), "Creditors - TC-5")
 		self.assertEqual(gl_entries_pe[1].get("debit"), 1430)
 
@@ -5528,42 +5704,44 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_with_fixed_shipping_rule")
 
 		# Create Shipping Rule with Fixed Amount
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "test_shipping_rule_restricted_country",
-			"calculate_based_on": "Fixed",
-			"shipping_rule_type": "Buying",
-			"account": "Creditors - TC-3",
-			"cost_center": "Main - TC-3",
-			"shipping_amount": 500,
-			"countries":[
-				{
-					"country": "Australia"
-				}
-			]
-		}).insert(ignore_if_duplicate=1)
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "test_shipping_rule_restricted_country",
+				"calculate_based_on": "Fixed",
+				"shipping_rule_type": "Buying",
+				"account": "Creditors - TC-3",
+				"cost_center": "Main - TC-3",
+				"shipping_amount": 500,
+				"countries": [{"country": "Australia"}],
+			}
+		).insert(ignore_if_duplicate=1)
 
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-			"shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+				"shipping_rule": shipping_rule.name,
+			}
+		)
 		with self.assertRaises(frappe.exceptions.ValidationError) as cm:
 			po.insert()
-		self.assertEqual(str(cm.exception), "Shipping rule not applicable for country India in Shipping Address")
+		self.assertEqual(
+			str(cm.exception), "Shipping rule not applicable for country India in Shipping Address"
+		)
 
 	@if_app_installed("india_compliance")
 	def test_shipping_rule_net_total_restricted_country_po_with_gst_TC_B_116(self):
@@ -5576,48 +5754,44 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		remove_existing_shipping_rules()
 
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "test_shipping_rule_restricted_country",
-			"calculate_based_on": "Net Total",
-			"shipping_rule_type": "Buying",
-			"account": "Creditors - TC-3",
-			"cost_center": "Main - TC-3",
-			"conditions": [
-				{
-					"from_value": 500,
-					"to_value": 2000,
-					"shipping_amount": 500
-				}
-			],
-			"countries": [
-				{
-					"country": "Australia"
-				}
-			]
-		})
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "test_shipping_rule_restricted_country",
+				"calculate_based_on": "Net Total",
+				"shipping_rule_type": "Buying",
+				"account": "Creditors - TC-3",
+				"cost_center": "Main - TC-3",
+				"conditions": [{"from_value": 500, "to_value": 2000, "shipping_amount": 500}],
+				"countries": [{"country": "Australia"}],
+			}
+		)
 		shipping_rule.insert(ignore_permissions=True)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item_code,
-					"qty": 10,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-			"shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item_code,
+						"qty": 10,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+				"shipping_rule": shipping_rule.name,
+			}
+		)
 		with self.assertRaises(frappe.exceptions.ValidationError) as cm:
 			po.insert()
-		self.assertEqual(str(cm.exception), "Shipping rule not applicable for country India in Shipping Address")
+		self.assertEqual(
+			str(cm.exception), "Shipping rule not applicable for country India in Shipping Address"
+		)
 
 	def test_shipping_rule_net_weight_restricted_country_po_with_gst_TC_B_117(self):
 		get_company_supplier = create_data()
@@ -5632,62 +5806,61 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		remove_existing_shipping_rules()
 
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "test_shipping_rule_restricted_country",
-			"calculate_based_on": "Net Weight",
-			"shipping_rule_type": "Buying",
-			"account": "Creditors - TC-3",
-			"cost_center": "Main - TC-3",
-			"conditions": [
-				{
-					"from_value": 10,
-					"to_value": 50,
-					"shipping_amount": 250
-				}
-			],
-			"countries": [
-				{
-					"country": "Australia"
-				}
-			]
-		})
+		shipping_rule = frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "test_shipping_rule_restricted_country",
+				"calculate_based_on": "Net Weight",
+				"shipping_rule_type": "Buying",
+				"account": "Creditors - TC-3",
+				"cost_center": "Main - TC-3",
+				"conditions": [{"from_value": 10, "to_value": 50, "shipping_amount": 250}],
+				"countries": [{"country": "Australia"}],
+			}
+		)
 
 		shipping_rule.insert(ignore_permissions=True)
 
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,  # Total weight = 10 * 2.5 = 25 Kg
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-			"shipping_rule": shipping_rule.name
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,  # Total weight = 10 * 2.5 = 25 Kg
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+				"shipping_rule": shipping_rule.name,
+			}
+		)
 		with self.assertRaises(frappe.exceptions.ValidationError) as cm:
 			po.insert()
-		self.assertEqual(str(cm.exception), "Shipping rule not applicable for country India in Shipping Address")
+		self.assertEqual(
+			str(cm.exception), "Shipping rule not applicable for country India in Shipping Address"
+		)
 
 	def test_closed_po_further_pi_pr_not_created_TC_B_131(self):
-		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
+
 		create_company()
 		create_supplier(supplier_name="_Test Supplier")
 		create_warehouse("_Test Warehouse - _TC")
 		create_item("_Test Item")
 
-		po = create_purchase_order(qty=10,Rate=1000, do_not_save=True)
+		po = create_purchase_order(qty=10, Rate=1000, do_not_save=True)
 		po.save()
-		tax_template = frappe.db.get_value('Purchase Taxes and Charges Template',{'company':po.company,'tax_category':'In-State'},'name')
+		tax_template = frappe.db.get_value(
+			"Purchase Taxes and Charges Template", {"company": po.company, "tax_category": "In-State"}, "name"
+		)
 		po.taxes_and_charges = tax_template
 		po.save()
 		po.submit()
@@ -5705,22 +5878,25 @@ class TestPurchaseOrder(FrappeTestCase):
 			pr.save()
 			pr.submit()
 			self.assertEqual(pr.docstatus, 1)
-	
+
 	def test_closed_pr_further_pi_not_created_TC_B_132(self):
-		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import update_purchase_receipt_status
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import update_purchase_receipt_status
+
 		create_company()
 		create_supplier(supplier_name="_Test Supplier")
 		create_warehouse(
 			warehouse_name="_Test Warehouse - _TC",
 			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
-			company="_Test Company"
+			company="_Test Company",
 		)
 		create_item("_Test Item")
-		get_or_create_fiscal_year('_Test Company')
-		po = create_purchase_order(qty=10,Rate=1000, do_not_save=True)
+		get_or_create_fiscal_year("_Test Company")
+		po = create_purchase_order(qty=10, Rate=1000, do_not_save=True)
 		po.save()
-		tax_template = frappe.db.get_value('Purchase Taxes and Charges Template',{'company':po.company,'tax_category':'In-State'},'name')
+		tax_template = frappe.db.get_value(
+			"Purchase Taxes and Charges Template", {"company": po.company, "tax_category": "In-State"}, "name"
+		)
 		po.taxes_and_charges = tax_template
 		po.save()
 		po.submit()
@@ -5729,7 +5905,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.save()
 		pr.submit()
 		self.assertEqual(pr.docstatus, 1)
-		update_purchase_receipt_status(docname = pr.name,status="Closed")
+		update_purchase_receipt_status(docname=pr.name, status="Closed")
 		pr.reload()
 		self.assertEqual(pr.status, "Closed")
 		if not frappe.db.exists("Purchase Receipt", {"name": pr.name, "status": "Closed"}):
@@ -5744,25 +5920,27 @@ class TestPurchaseOrder(FrappeTestCase):
 		target_warehouse = "Stores - TC-3"
 		item = make_test_item("testing_item_1122")
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"price_list_rate": 100,	
-					"margin_type": "Percentage",
-					"margin_rate_or_amount": 25,
-					"discount_amount": 10,
-					"warehouse": target_warehouse
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"price_list_rate": 100,
+						"margin_type": "Percentage",
+						"margin_rate_or_amount": 25,
+						"discount_amount": 10,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.insert()
@@ -5782,11 +5960,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 115)
 		self.assertEqual(flt(pr.items[0].amount), 1150)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
-		expected_pr_entries = {
-			"Stock In Hand - TC-3": 1150,
-			"Stock Received But Not Billed - TC-3": 1150
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pr_entries = {"Stock In Hand - TC-3": 1150, "Stock Received But Not Billed - TC-3": 1150}
 		for entry in gl_entries:
 			if entry["account"] in expected_pr_entries:
 				if entry["debit"]:
@@ -5804,11 +5981,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.items[0].rate, 115)
 		self.assertEqual(flt(pi.items[0].amount), 1150)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
-		expected_pi_entries = {
-			"Stock Received But Not Billed - TC-3": 1150,
-			"Creditors - TC-3": 1150
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pi_entries = {"Stock Received But Not Billed - TC-3": 1150, "Creditors - TC-3": 1150}
 		for entry in gl_entries:
 			if entry["account"] in expected_pi_entries:
 				if entry["debit"]:
@@ -5823,25 +5999,27 @@ class TestPurchaseOrder(FrappeTestCase):
 		target_warehouse = "Stores - TC-5"
 		item = make_test_item("Testing-31")
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"price_list_rate": 100,	
-					"margin_type": "Amount",
-					"margin_rate_or_amount": 50,
-					"discount_percentage": 10,
-					"warehouse": target_warehouse
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"price_list_rate": 100,
+						"margin_type": "Amount",
+						"margin_rate_or_amount": 50,
+						"discount_percentage": 10,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.insert()
@@ -5863,11 +6041,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 135)
 		self.assertEqual(flt(pr.items[0].amount), 1350)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
-		expected_pr_entries = {
-			"Stock In Hand - TC-5": 1350,
-			"Stock Received But Not Billed - TC-5": 1350
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pr_entries = {"Stock In Hand - TC-5": 1350, "Stock Received But Not Billed - TC-5": 1350}
 		for entry in gl_entries:
 			if entry["account"] in expected_pr_entries:
 				if entry["debit"]:
@@ -5888,11 +6065,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(flt(pi.items[0].amount), 1350)
 
 		# Validate accounting entries for PI
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
-		expected_pi_entries = {
-			"Stock Received But Not Billed - TC-5": 1350,
-			"Creditors - TC-5": 1350
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pi_entries = {"Stock Received But Not Billed - TC-5": 1350, "Creditors - TC-5": 1350}
 		for entry in gl_entries:
 			if entry["account"] in expected_pi_entries:
 				if entry["debit"]:
@@ -5907,25 +6083,27 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_3344")
 		target_warehouse = "Stores - TC-3"
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"price_list_rate": 100,	
-					"margin_type": "Percentage",
-					"margin_rate_or_amount": 30,
-					"discount_percentage": 10,
-					"warehouse": target_warehouse
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"price_list_rate": 100,
+						"margin_type": "Percentage",
+						"margin_rate_or_amount": 30,
+						"discount_percentage": 10,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.insert()
@@ -5944,11 +6122,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 117)
 		self.assertEqual(flt(pr.items[0].amount), 1170)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
-		expected_pr_entries = {
-			"Stock In Hand - TC-3": 1170,
-			"Stock Received But Not Billed - TC-3": 1170
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pr_entries = {"Stock In Hand - TC-3": 1170, "Stock Received But Not Billed - TC-3": 1170}
 		for entry in gl_entries:
 			if entry["account"] in expected_pr_entries:
 				if entry["debit"]:
@@ -5966,11 +6143,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.items[0].rate, 117)
 		self.assertEqual(flt(pi.items[0].amount), 1170)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
-		expected_pi_entries = {
-			"Stock Received But Not Billed - TC-3": 1170,
-			"Creditors - TC-3": 1170
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pi_entries = {"Stock Received But Not Billed - TC-3": 1170, "Creditors - TC-3": 1170}
 		for entry in gl_entries:
 			if entry["account"] in expected_pi_entries:
 				if entry["debit"]:
@@ -5985,24 +6161,26 @@ class TestPurchaseOrder(FrappeTestCase):
 		target_warehouse = "Stores - TC-3"
 		item = make_test_item("test_item_1122")
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"rate": 100,
-					"price_list_rate": 100,	
-					"margin_type": "Percentage",
-					"margin_rate_or_amount": 80,
-					"warehouse": target_warehouse
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"rate": 100,
+						"price_list_rate": 100,
+						"margin_type": "Percentage",
+						"margin_rate_or_amount": 80,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.insert()
@@ -6021,11 +6199,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 180)
 		self.assertEqual(flt(pr.items[0].amount), 1800)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
-		expected_pr_entries = {
-			"Stock In Hand - TC-3": 1800,
-			"Stock Received But Not Billed - TC-3": 1800
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pr_entries = {"Stock In Hand - TC-3": 1800, "Stock Received But Not Billed - TC-3": 1800}
 		for entry in gl_entries:
 			if entry["account"] in expected_pr_entries:
 				if entry["debit"]:
@@ -6043,11 +6220,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.items[0].rate, 180)
 		self.assertEqual(flt(pi.items[0].amount), 1800)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
-		expected_pi_entries = {
-			"Stock Received But Not Billed - TC-3": 1800,
-			"Creditors - TC-3": 1800
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pi_entries = {"Stock Received But Not Billed - TC-3": 1800, "Creditors - TC-3": 1800}
 		for entry in gl_entries:
 			if entry["account"] in expected_pi_entries:
 				if entry["debit"]:
@@ -6055,12 +6231,20 @@ class TestPurchaseOrder(FrappeTestCase):
 				if entry["credit"]:
 					self.assertEqual(entry["credit"], expected_pi_entries[entry["account"]])
 
-	@change_settings("Global Defaults", {"default_company": "_Test company with other country address", "country": "India", "default_currency": "INR"})
+	@change_settings(
+		"Global Defaults",
+		{
+			"default_company": "_Test company with other country address",
+			"country": "India",
+			"default_currency": "INR",
+		},
+	)
 	def test_shipping_rule_fixed_rate_restricted_country_po_pr_pi_pe_TC_B_112(self):
-		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
-		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
 		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
+		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
+
 		get_company_supplier = create_company_and_suppliers()
 		company = get_company_supplier.get("company")
 		supplier = get_company_supplier.get("supplier")
@@ -6068,51 +6252,51 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_with_fixed_shipping_rule")
 
 		# Create Shipping Rule with Fixed Amount
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "_Test shipping rule wtih country address",
-			"calculate_based_on": "Fixed",
-			"shipping_rule_type": "Buying",
-			"account": self.create_account("Cash", company, "AUD", "Cash In Hand - -TCNI_"),
-			"cost_center": "Main - -TCNI_",
-			"shipping_amount": 500,
-			"countries":[
-				{
-					"country": "Australia"
-				}
-			]
-		}).insert(ignore_if_duplicate=1)
+		frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "_Test shipping rule wtih country address",
+				"calculate_based_on": "Fixed",
+				"shipping_rule_type": "Buying",
+				"account": self.create_account("Cash", company, "AUD", "Cash In Hand - -TCNI_"),
+				"cost_center": "Main - -TCNI_",
+				"shipping_amount": 500,
+				"countries": [{"country": "Australia"}],
+			}
+		).insert(ignore_if_duplicate=1)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "AUD",
-			"conversion_rate": 53.352000000,
-			"price_list_currency": "",
-			"buying_price_list": "",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 100,
-					"rate": 100,
-					"warehouse": warehouse,
-				}
-			],
-			"taxes": [
-				{
-					"category": "Valuation and Total",
-					"add_deduct_tax": "Add",
-					"charge_type": "Actual",
-					"account_head": "Cash - -TCNI_",
-					"description": "Australia",
-					"tax_amount": 9.37
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "AUD",
+				"conversion_rate": 53.352000000,
+				"price_list_currency": "",
+				"buying_price_list": "",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 100,
+						"rate": 100,
+						"warehouse": warehouse,
+					}
+				],
+				"taxes": [
+					{
+						"category": "Valuation and Total",
+						"add_deduct_tax": "Add",
+						"charge_type": "Actual",
+						"account_head": "Cash - -TCNI_",
+						"description": "Australia",
+						"tax_amount": 9.37,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -6130,7 +6314,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.base_grand_total, 534019.91)
 		frappe.db.set_value("Account", "Creditors - -TCNI_", "account_currency", "AUD")
 		frappe.db.set_value("Supplier", supplier, "default_currency", "AUD")
-		get_pr_stock_ledger = frappe.db.get_all("Stock Ledger Entry",{"voucher_no": pr.name}, ['valuation_rate', 'actual_qty'])
+		get_pr_stock_ledger = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["valuation_rate", "actual_qty"]
+		)
 		self.assertTrue(get_pr_stock_ledger)
 
 		pi = make_purchase_invoice(pr.name)
@@ -6147,31 +6333,34 @@ class TestPurchaseOrder(FrappeTestCase):
 		pe.insert(ignore_permissions=True)
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(gl_entries_pr)
 
-		sle_pr = frappe.get_all("Stock Ledger Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		sle_pr = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(sle_pr)
-		gl_entries_pi = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		})
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name}
+		)
 		self.assertTrue(gl_entries_pi)
 		pi_outstanding = frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount")
 		self.assertEqual(pi_outstanding, 0)
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		})
+		gl_entries_pe = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Payment Entry", "voucher_no": pe.name}
+		)
 		self.assertTrue(gl_entries_pe)
 
-	@change_settings("Global Defaults", {"default_company": "_Test company with other country address", "country": "India", "default_currency": "INR"})
+	@change_settings(
+		"Global Defaults",
+		{
+			"default_company": "_Test company with other country address",
+			"country": "India",
+			"default_currency": "INR",
+		},
+	)
 	def test_shipping_rule_net_total_restricted_country_po_pr_pi_pe_TC_B_113(self):
 		get_company_supplier = create_company_and_suppliers()
 		company = get_company_supplier.get("company")
@@ -6180,67 +6369,55 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_with_fixed_shipping_rule")
 
 		# Create Shipping Rule with Fixed Amount
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "_Test shipping rule wtih country address",
-			"calculate_based_on": "Net Total",
-			"shipping_rule_type": "Buying",
-			"account": self.create_account("Cash", company, "AUD", "Cash In Hand - -TCNI_"),
-			"cost_center": "Main - -TCNI_",
-			"conditions": [
-				{
-					"from_value": 1,
-					"to_value": 99,
-					"shipping_amount": 1500
-				},
-				{
-					"from_value": 100,
-					"to_value": 199,
-					"shipping_amount": 1000
-				},
-				{
-					"from_value": 200,
-					"to_value": 9999,
-					"shipping_amount": 500
-				}
-			],
-			"countries":[
-				{
-					"country": "Australia"
-				}
-			]
-		}).insert(ignore_if_duplicate=1)
+		frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "_Test shipping rule wtih country address",
+				"calculate_based_on": "Net Total",
+				"shipping_rule_type": "Buying",
+				"account": self.create_account("Cash", company, "AUD", "Cash In Hand - -TCNI_"),
+				"cost_center": "Main - -TCNI_",
+				"conditions": [
+					{"from_value": 1, "to_value": 99, "shipping_amount": 1500},
+					{"from_value": 100, "to_value": 199, "shipping_amount": 1000},
+					{"from_value": 200, "to_value": 9999, "shipping_amount": 500},
+				],
+				"countries": [{"country": "Australia"}],
+			}
+		).insert(ignore_if_duplicate=1)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "AUD",
-			"conversion_rate": 53.352000000,
-			"price_list_currency": "",
-			"buying_price_list": "",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 1,
-					"rate": 3,
-					"warehouse": warehouse,
-				}
-			],
-			"taxes": [
-				{
-					"category": "Valuation and Total",
-					"add_deduct_tax": "Add",
-					"charge_type": "Actual",
-					"account_head": "Cash - -TCNI_",
-					"description": "Australia",
-					"tax_amount": 18.74
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "AUD",
+				"conversion_rate": 53.352000000,
+				"price_list_currency": "",
+				"buying_price_list": "",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 1,
+						"rate": 3,
+						"warehouse": warehouse,
+					}
+				],
+				"taxes": [
+					{
+						"category": "Valuation and Total",
+						"add_deduct_tax": "Add",
+						"charge_type": "Actual",
+						"account_head": "Cash - -TCNI_",
+						"description": "Australia",
+						"tax_amount": 18.74,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -6256,7 +6433,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.taxes_and_charges_added, 18.74)
 		self.assertEqual(pr.grand_total, 21.74)
 		self.assertEqual(pr.base_grand_total, 1159.87)
-		get_pr_stock_ledger = frappe.db.get_all("Stock Ledger Entry",{"voucher_no": pr.name}, ['valuation_rate', 'actual_qty'])
+		get_pr_stock_ledger = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["valuation_rate", "actual_qty"]
+		)
 		self.assertTrue(get_pr_stock_ledger)
 
 		frappe.db.set_value("Account", "Creditors - -TCNI_", "account_currency", "AUD")
@@ -6275,31 +6454,34 @@ class TestPurchaseOrder(FrappeTestCase):
 		pe.insert(ignore_permissions=True)
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(gl_entries_pr)
 
-		sle_pr = frappe.get_all("Stock Ledger Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		sle_pr = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(sle_pr)
-		gl_entries_pi = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		})
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name}
+		)
 		self.assertTrue(gl_entries_pi)
 		pi_outstanding = frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount")
 		self.assertEqual(pi_outstanding, 0)
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		})
+		gl_entries_pe = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Payment Entry", "voucher_no": pe.name}
+		)
 		self.assertTrue(gl_entries_pe)
 
-	@change_settings("Global Defaults", {"default_company": "_Test company with other country address", "country": "India", "default_currency": "INR"})
+	@change_settings(
+		"Global Defaults",
+		{
+			"default_company": "_Test company with other country address",
+			"country": "India",
+			"default_currency": "INR",
+		},
+	)
 	def test_shipping_rule_net_weight_restricted_country_po_pr_pi_pe_TC_B_114(self):
 		get_company_supplier = create_company_and_suppliers()
 		company = get_company_supplier.get("company")
@@ -6308,68 +6490,60 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_with_fixed_shipping_rule")
 
 		# Create Shipping Rule with Fixed Amount
-		shipping_rule = frappe.get_doc({
-			"doctype": "Shipping Rule",
-			"company": company,
-			"label": "_Test shipping rule wtih country address",
-			"calculate_based_on": "Net Weight",
-			"shipping_rule_type": "Buying",
-			"account": self.create_account("Cash", company, "AUD", "Cash In Hand - -TCNI_"),
-			"cost_center": "Main - -TCNI_",
-			"conditions": [
-				{
-					"from_value": 1,
-					"to_value": 9,
-					"shipping_amount": 100
-				},
-				{
-					"from_value": 10,
-					"to_value": 0,
-					"shipping_amount": 120
-				}
-			],
-			"countries":[
-				{
-					"country": "Australia"
-				}
-			]
-		}).insert(ignore_if_duplicate=1)
+		frappe.get_doc(
+			{
+				"doctype": "Shipping Rule",
+				"company": company,
+				"label": "_Test shipping rule wtih country address",
+				"calculate_based_on": "Net Weight",
+				"shipping_rule_type": "Buying",
+				"account": self.create_account("Cash", company, "AUD", "Cash In Hand - -TCNI_"),
+				"cost_center": "Main - -TCNI_",
+				"conditions": [
+					{"from_value": 1, "to_value": 9, "shipping_amount": 100},
+					{"from_value": 10, "to_value": 0, "shipping_amount": 120},
+				],
+				"countries": [{"country": "Australia"}],
+			}
+		).insert(ignore_if_duplicate=1)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "AUD",
-			"conversion_rate": 53.352000000,
-			"price_list_currency": "",
-			"buying_price_list": "",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 15,
-					"rate": 1.87,
-					"warehouse": warehouse,
-				}
-			],
-			"taxes": [
-				{
-					"category": "Valuation and Total",
-					"add_deduct_tax": "Add",
-					"charge_type": "Actual",
-					"account_head": "Cash - -TCNI_",
-					"description": "Australia",
-					"tax_amount": 2.25
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "AUD",
+				"conversion_rate": 53.352000000,
+				"price_list_currency": "",
+				"buying_price_list": "",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 15,
+						"rate": 1.87,
+						"warehouse": warehouse,
+					}
+				],
+				"taxes": [
+					{
+						"category": "Valuation and Total",
+						"add_deduct_tax": "Add",
+						"charge_type": "Actual",
+						"account_head": "Cash - -TCNI_",
+						"description": "Australia",
+						"tax_amount": 2.25,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
 		self.assertEqual(po.taxes_and_charges_added, 2.25)
 		self.assertEqual(po.grand_total, 30.30)
-		self.assertEqual(po.base_grand_total,  1616.57)
+		self.assertEqual(po.base_grand_total, 1616.57)
 
 		pr = make_purchase_receipt(po.name)
 		pr.insert()
@@ -6377,8 +6551,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.docstatus, 1)
 		self.assertEqual(pr.taxes_and_charges_added, 2.25)
 		self.assertEqual(pr.grand_total, 30.30)
-		self.assertEqual(pr.base_grand_total,  1616.57)
-		get_pr_stock_ledger = frappe.db.get_all("Stock Ledger Entry",{"voucher_no": pr.name}, ['valuation_rate', 'actual_qty'])
+		self.assertEqual(pr.base_grand_total, 1616.57)
+		get_pr_stock_ledger = frappe.db.get_all(
+			"Stock Ledger Entry", {"voucher_no": pr.name}, ["valuation_rate", "actual_qty"]
+		)
 		self.assertTrue(get_pr_stock_ledger)
 		frappe.db.set_value("Account", "Creditors - -TCNI_", "account_currency", "AUD")
 		frappe.db.set_value("Supplier", supplier, "default_currency", "AUD")
@@ -6390,34 +6566,30 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.docstatus, 1)
 		self.assertEqual(pi.taxes_and_charges_added, 2.25)
 		self.assertEqual(pi.grand_total, 30.30)
-		self.assertEqual(pi.base_grand_total,  1616.57)
+		self.assertEqual(pi.base_grand_total, 1616.57)
 
 		pe = get_payment_entry(pi.doctype, pi.name)
 		pe.insert(ignore_permissions=True)
 		pe.submit()
 		self.assertEqual(pe.docstatus, 1)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(gl_entries_pr)
 
-		sle_pr = frappe.get_all("Stock Ledger Entry", filters={
-			"voucher_type": "Purchase Receipt",
-			"voucher_no": pr.name
-		})
+		sle_pr = frappe.get_all(
+			"Stock Ledger Entry", filters={"voucher_type": "Purchase Receipt", "voucher_no": pr.name}
+		)
 		self.assertTrue(sle_pr)
-		gl_entries_pi = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		})
+		gl_entries_pi = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name}
+		)
 		self.assertTrue(gl_entries_pi)
 		pi_outstanding = frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount")
 		self.assertEqual(pi_outstanding, 0)
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Payment Entry",
-			"voucher_no": pe.name
-		})
+		gl_entries_pe = frappe.get_all(
+			"GL Entry", filters={"voucher_type": "Payment Entry", "voucher_no": pe.name}
+		)
 		self.assertTrue(gl_entries_pe)
 
 	def test_discount_price_list_with_po_pr_pi_TC_B_118(self):
@@ -6428,26 +6600,28 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item_with_discount")
 
 		# Create Purchase Order
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"price_list_rate": 100,
-					"warehouse": warehouse,
-					"rate": 100,
-					"margin_type": "Amount",
-					"margin_rate_or_amount": 50,
-					"discount_amount": 10
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"price_list_rate": 100,
+						"warehouse": warehouse,
+						"rate": 100,
+						"margin_type": "Amount",
+						"margin_rate_or_amount": 50,
+						"discount_amount": 10,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -6455,25 +6629,27 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(po.items[0].rate, 140)
 
 		# Create Purchase Receipt from Purchase Order
-		pr = frappe.get_doc({
-			"doctype": "Purchase Receipt",
-			"supplier": po.supplier,
-			"company": po.company,
-			"posting_date": today(),
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"price_list_rate": 100,
-					"warehouse": warehouse,
-					"rate": 100,
-					"margin_type": "Amount",
-					"margin_rate_or_amount": 50,
-					"discount_amount": 10
-				}
-			],
-		})
+		pr = frappe.get_doc(
+			{
+				"doctype": "Purchase Receipt",
+				"supplier": po.supplier,
+				"company": po.company,
+				"posting_date": today(),
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"price_list_rate": 100,
+						"warehouse": warehouse,
+						"rate": 100,
+						"margin_type": "Amount",
+						"margin_rate_or_amount": 50,
+						"discount_amount": 10,
+					}
+				],
+			}
+		)
 		pr.insert()
 		pr.submit()
 		self.assertEqual(pr.docstatus, 1)
@@ -6481,37 +6657,40 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 140)
 
 		# Create Purchase Invoice from Purchase Receipt
-		pi = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"supplier": pr.supplier,
-			"company": pr.company,
-			"currency": "INR",
-			# "credit_to": "_Test Creditors - _TC",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"price_list_rate": 100,
-					"warehouse": warehouse,
-					"rate": 100,
-					"margin_type": "Amount",
-					"margin_rate_or_amount": 50,
-					"discount_amount": 10
-				}
-			],
-		})
+		pi = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"supplier": pr.supplier,
+				"company": pr.company,
+				"currency": "INR",
+				# "credit_to": "_Test Creditors - _TC",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"price_list_rate": 100,
+						"warehouse": warehouse,
+						"rate": 100,
+						"margin_type": "Amount",
+						"margin_rate_or_amount": 50,
+						"discount_amount": 10,
+					}
+				],
+			}
+		)
 		pi.insert(ignore_permissions=True)
 		pi.submit()
 		self.assertEqual(pi.docstatus, 1)
 		self.assertEqual(pi.total, 1400)
 		self.assertEqual(pi.items[0].rate, 140)
-		gl_entries_pe = frappe.get_all("GL Entry", filters={
-			"voucher_type": "Purchase Invoice",
-			"voucher_no": pi.name
-		},fields=["account", "debit", "credit", "posting_date"])
+		gl_entries_pe = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_type": "Purchase Invoice", "voucher_no": pi.name},
+			fields=["account", "debit", "credit", "posting_date"],
+		)
 		self.assertTrue(gl_entries_pe)
 		self.assertEqual(gl_entries_pe[0].get("account"), "Stock Received But Not Billed - TC-5")
-		self.assertEqual(gl_entries_pe[0].get('debit'), 1400)
+		self.assertEqual(gl_entries_pe[0].get("debit"), 1400)
 		self.assertEqual(gl_entries_pe[1].get("account"), "Creditors - TC-5")
 		self.assertEqual(gl_entries_pe[1].get("credit"), 1400)
 
@@ -6523,17 +6702,17 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-5"
 
 		po_data = {
-			"company" : company,
-			"item_code" : item.item_code,
+			"company": company,
+			"item_code": item.item_code,
 			"supplier": supplier,
-			"warehouse" : warehouse,
-			"qty" : 10,
-			"rate" : 1000,
-			"do_not_submit":True
+			"warehouse": warehouse,
+			"qty": 10,
+			"rate": 1000,
+			"do_not_submit": True,
 		}
-		get_accounts = create_or_get_purchase_taxes_template(company = company)
+		get_accounts = create_or_get_purchase_taxes_template(company=company)
 		doc_po = create_purchase_order(**po_data)
-		taxes =  [
+		taxes = [
 			{
 				"charge_type": "On Net Total",
 				"account_head": get_accounts.get("sgst_account"),
@@ -6545,7 +6724,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				"account_head": get_accounts.get("cgst_account"),
 				"rate": 2.5,
 				"description": "Input GST",
-			}
+			},
 		]
 		for tax in taxes:
 			doc_po.append("taxes", tax)
@@ -6555,13 +6734,15 @@ class TestPurchaseOrder(FrappeTestCase):
 		doc_pr = make_test_pr(doc_po.name)
 		self.assertEqual(doc_pr.items[0].qty, 10)
 		self.assertEqual(doc_pr.items[0].rate, 1000)
-		gl_entries_pr = frappe.get_all("GL Entry", filters={"voucher_no": doc_pr.name}, fields=["account", "debit", "credit"])
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pr.name}, fields=["account", "debit", "credit"]
+		)
 		for gl_entries in gl_entries_pr:
-			if gl_entries['account'] == "Stock In Hand - TC-5":
-				self.assertEqual(gl_entries['debit'], 10000)
-			elif gl_entries['account'] == "Stock Received But Not Billed - TC-5":
-				self.assertEqual(gl_entries['credit'], 10000)
-		doc_pi= make_purchase_invoice(doc_pr.name)
+			if gl_entries["account"] == "Stock In Hand - TC-5":
+				self.assertEqual(gl_entries["debit"], 10000)
+			elif gl_entries["account"] == "Stock Received But Not Billed - TC-5":
+				self.assertEqual(gl_entries["credit"], 10000)
+		doc_pi = make_purchase_invoice(doc_pr.name)
 		doc_pi.bill_no = "test_bill_1122"
 		doc_pi.save()
 		doc_pi.submit()
@@ -6582,12 +6763,12 @@ class TestPurchaseOrder(FrappeTestCase):
 		item.save()
 
 		po_data = {
-			"company" : company,
+			"company": company,
 			"supplier": supplier,
-			"item_code" : item.item_code,
-			"warehouse" : "Stores - TC-5",
-			"qty" : 5,
-			"rate" : 200
+			"item_code": item.item_code,
+			"warehouse": "Stores - TC-5",
+			"qty": 5,
+			"rate": 200,
 		}
 		po = create_purchase_order(**po_data)
 		pr = make_purchase_receipt_aganist_mr(po.name)
@@ -6611,7 +6792,15 @@ class TestPurchaseOrder(FrappeTestCase):
 			},
 		]
 		from erpnext.stock.doctype.quality_inspection.test_quality_inspection import create_quality_inspection
-		qi = create_quality_inspection(reference_type=pr.doctype, reference_name=pr.name,inspection_type="Incoming", item_code=item.item_code, readings=readings, do_not_save=True)
+
+		qi = create_quality_inspection(
+			reference_type=pr.doctype,
+			reference_name=pr.name,
+			inspection_type="Incoming",
+			item_code=item.item_code,
+			readings=readings,
+			do_not_save=True,
+		)
 		qi.save()
 		qi.submit()
 		self.assertEqual(qi.readings[0].status, "Accepted")
@@ -6621,13 +6810,15 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.reload()
 		pr.submit()
 		self.assertEqual(pr.status, "To Bill")
-		gl_entries_pr = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		gl_entries_pr = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		for gl_entries in gl_entries_pr:
-			if gl_entries['account'] == "Stock In Hand - _TC":
-				self.assertEqual(gl_entries['debit'], 1000)
-			elif gl_entries['account'] == "Stock Received But Not Billed - _TC":
-				self.assertEqual(gl_entries['credit'], 1000)
-		doc_pi= make_purchase_invoice(pr.name)
+			if gl_entries["account"] == "Stock In Hand - _TC":
+				self.assertEqual(gl_entries["debit"], 1000)
+			elif gl_entries["account"] == "Stock Received But Not Billed - _TC":
+				self.assertEqual(gl_entries["credit"], 1000)
+		doc_pi = make_purchase_invoice(pr.name)
 		doc_pi.save()
 		doc_pi.submit()
 		self.assertEqual(doc_pi.status, "Unpaid")
@@ -6639,22 +6830,24 @@ class TestPurchaseOrder(FrappeTestCase):
 		target_warehouse = "Stores - TC-3"
 		item = make_test_item("Testing-31")
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"price_list_rate": 100,
-					"discount_amount": 10,
-					"warehouse": target_warehouse
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"price_list_rate": 100,
+						"discount_amount": 10,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.items[0].rate = po.items[0].price_list_rate - po.items[0].discount_amount
 		po.taxes_and_charges = ""
 		po.taxes = []
@@ -6674,11 +6867,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 90)
 		self.assertEqual(flt(pr.items[0].amount), 900)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
-		expected_pr_entries = {
-			"Stock In Hand - TC-3": 900,
-			"Stock Received But Not Billed - TC-3": 900
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pr_entries = {"Stock In Hand - TC-3": 900, "Stock Received But Not Billed - TC-3": 900}
 		for entry in gl_entries:
 			if entry["account"] in expected_pr_entries:
 				if entry["debit"]:
@@ -6696,11 +6888,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.items[0].rate, 90)
 		self.assertEqual(flt(pi.items[0].amount), 900)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
-		expected_pi_entries = {
-			"Stock Received But Not Billed - TC-3": 900,
-			"Creditors - TC-3": 900
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pi_entries = {"Stock Received But Not Billed - TC-3": 900, "Creditors - TC-3": 900}
 		for entry in gl_entries:
 			if entry["account"] in expected_pi_entries:
 				if entry["debit"]:
@@ -6715,22 +6906,24 @@ class TestPurchaseOrder(FrappeTestCase):
 		target_warehouse = "Stores - TC-3"
 		item = make_test_item("Testing-31")
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"currency": "INR",
-			"schedule_date": today(),
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"price_list_rate": 100,
-					"discount_percentage": 10,
-					"warehouse": target_warehouse
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"currency": "INR",
+				"schedule_date": today(),
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"price_list_rate": 100,
+						"discount_percentage": 10,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.items[0].rate = po.items[0].price_list_rate - po.items[0].discount_percentage
 		po.taxes_and_charges = ""
 		po.taxes = []
@@ -6750,11 +6943,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 90)
 		self.assertEqual(flt(pr.items[0].amount), 900)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
-		expected_pr_entries = {
-			"Stock In Hand - TC-3": 900,
-			"Stock Received But Not Billed - TC-3": 900
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pr_entries = {"Stock In Hand - TC-3": 900, "Stock Received But Not Billed - TC-3": 900}
 		for entry in gl_entries:
 			if entry["account"] in expected_pr_entries:
 				if entry["debit"]:
@@ -6772,11 +6964,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.items[0].rate, 90)
 		self.assertEqual(flt(pi.items[0].amount), 900)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
-		expected_pi_entries = {
-			"Stock Received But Not Billed - TC-3": 900,
-			"Creditors - TC-3": 900
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pi_entries = {"Stock Received But Not Billed - TC-3": 900, "Creditors - TC-3": 900}
 		for entry in gl_entries:
 			if entry["account"] in expected_pi_entries:
 				if entry["debit"]:
@@ -6791,23 +6982,25 @@ class TestPurchaseOrder(FrappeTestCase):
 		target_warehouse = "Stores - TC-3"
 		item = make_test_item("test_item_margin_amount")
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"price_list_rate": 100,
-					"margin_type": "Amount",
-					"margin_rate_or_amount": 60,
-					"warehouse": target_warehouse
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"price_list_rate": 100,
+						"margin_type": "Amount",
+						"margin_rate_or_amount": 60,
+						"warehouse": target_warehouse,
+					}
+				],
+			}
+		)
 		po.taxes_and_charges = ""
 		po.taxes = []
 		po.insert()
@@ -6826,11 +7019,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pr.items[0].rate, 160)
 		self.assertEqual(flt(pr.items[0].amount), 1600)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
-		expected_pr_entries = {
-			"Stock In Hand - TC-3": 1600,
-			"Stock Received But Not Billed - TC-3": 1600
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pr_entries = {"Stock In Hand - TC-3": 1600, "Stock Received But Not Billed - TC-3": 1600}
 		for entry in gl_entries:
 			if entry["account"] in expected_pr_entries:
 				if entry["debit"]:
@@ -6848,11 +7040,10 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.items[0].rate, 160)
 		self.assertEqual(flt(pi.items[0].amount), 1600)
 
-		gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
-		expected_pi_entries = {
-			"Stock Received But Not Billed - TC-3": 1600,
-			"Creditors - TC-3": 1600
-		}
+		gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
+		expected_pi_entries = {"Stock Received But Not Billed - TC-3": 1600, "Creditors - TC-3": 1600}
 		for entry in gl_entries:
 			if entry["account"] in expected_pi_entries:
 				if entry["debit"]:
@@ -6869,39 +7060,41 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-5"
 		tax_account = create_or_get_purchase_taxes_template(company)
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"currency": "INR",
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 1,
-					"warehouse": warehouse,
-					"rate": 1000,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"currency": "INR",
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 1,
+						"warehouse": warehouse,
+						"rate": 1000,
+					}
+				],
+			}
+		)
 		taxes = [
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('sgst_account'),
-				"description": "SGST"
+				"account_head": tax_account.get("sgst_account"),
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('cgst_account'),
-				"description": "CGST"
-			}
+				"account_head": tax_account.get("cgst_account"),
+				"description": "CGST",
+			},
 		]
 		for tax in taxes:
 			po.append("taxes", tax)
@@ -6929,28 +7122,33 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	@if_app_installed("india_compliance")
 	def test_po_with_partial_pr_and_update_items_TC_B_129(self):
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company_and_supplier as create_data,
+		)
+
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-3"
 
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"warehouse": warehouse,
-					"rate": 1000,
-				}
-			]
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"warehouse": warehouse,
+						"rate": 1000,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -6984,29 +7182,34 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	@if_app_installed("india_compliance")
 	def test_po_with_partial_pi_and_update_items_TC_B_130(self):
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company_and_supplier as create_data,
+		)
+
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_test_item("test_item")
 		warehouse = "Stores - TC-3"
 		get_or_create_fiscal_year(company)
-		po = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier,
-			"company": company,
-			"schedule_date": today(),
-			"set_warehouse": warehouse,
-			"currency": "INR",
-			"items": [
-				{
-					"item_code": item.item_code,
-					"qty": 10,
-					"warehouse": warehouse,
-					"rate": 1000,
-				}
-			],
-		})
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier,
+				"company": company,
+				"schedule_date": today(),
+				"set_warehouse": warehouse,
+				"currency": "INR",
+				"items": [
+					{
+						"item_code": item.item_code,
+						"qty": 10,
+						"warehouse": warehouse,
+						"rate": 1000,
+					}
+				],
+			}
+		)
 		po.insert()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -7020,7 +7223,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		else:
 			bill_no = 1
 		pi_1 = make_pi_from_po(po.name)
-		pi_1.bill_no =  f"test_bill_{bill_no}"
+		pi_1.bill_no = f"test_bill_{bill_no}"
 		pi_1.items[0].qty = 3
 		pi_1.update_stock = 1
 		pi_1.currency = "INR"
@@ -7059,19 +7262,22 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	@if_app_installed("india_compliance")
 	def test_po_with_parking_charges_pr_pi_TC_B_137(self):
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company_and_supplier as create_data
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company_and_supplier as create_data,
+		)
+
 		get_company_supplier = create_data()
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_item("_test_item")
-		parent_account = frappe.get_doc(
+		frappe.get_doc(
 			{
 				"doctype": "Account",
 				"account_name": "Parking Charges Account",
 				"company": get_company_supplier.get("parent_company"),
 				"parent_account": "Indirect Expenses - TC-1",
 				"account_type": "Chargeable",
-				"account_currency": "INR"
+				"account_currency": "INR",
 			}
 		).insert(ignore_if_duplicate=1)
 		parking_charges_account = frappe.get_doc(
@@ -7081,7 +7287,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				"company": get_company_supplier.get("child_company"),
 				"parent_account": "Indirect Expenses - TC-3",
 				"account_type": "Chargeable",
-				"account_currency": "INR"
+				"account_currency": "INR",
 			}
 		).insert(ignore_if_duplicate=1)
 
@@ -7091,24 +7297,20 @@ class TestPurchaseOrder(FrappeTestCase):
 				"company": company,
 				"supplier": supplier,
 				"set_warehouse": "Stores - TC-3",
-				"items": [
-					{
-						"item_code": item.item_code,
-						"schedule_date": today(),
-						"qty": 10,
-						"rate": 1000
-					}
-				]
+				"items": [{"item_code": item.item_code, "schedule_date": today(), "qty": 10, "rate": 1000}],
 			}
 		)
 		po.insert()
-		po.append("taxes", {
-			"charge_type": "On Net Total",
-			"account_head": parking_charges_account.name,
-			"rate": 5,
-			"category": "Valuation",
-			"description": "Parking Charges Account"
-		})
+		po.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": parking_charges_account.name,
+				"rate": 5,
+				"category": "Valuation",
+				"description": "Parking Charges Account",
+			},
+		)
 		po.save()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -7124,19 +7326,15 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		get_pr_stock_ledger = frappe.get_all(
 			"Stock Ledger Entry",
-			{
-				"voucher_type": "Purchase Receipt",
-				"voucher_no": pr.name
-			},
-			[
-				"warehouse",
-				"actual_qty"
-			]
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["warehouse", "actual_qty"],
 		)
 		self.assertEqual(get_pr_stock_ledger[0].get("warehouse"), "Stores - TC-3")
 		self.assertEqual(get_pr_stock_ledger[0].get("actual_qty"), 10)
 
-		pr_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		pr_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		expected_si_entries = {
 			"Stock In Hand - TC-3": {"debit": 10500, "credit": 0},
 			"Stock Received But Not Billed - TC-3": {"debit": 0, "credit": 10000},
@@ -7154,7 +7352,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.total_taxes_and_charges, 1800)
 		self.assertEqual(pi.grand_total, 11800)
 
-		pi_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pi_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		expected_pi_entries = {
 			"Stock Received But Not Billed - TC-3": {"debit": 10000, "credit": 0},
 			"Input Tax CGST - TC-3": {"debit": 900, "credit": 0},
@@ -7172,31 +7372,25 @@ class TestPurchaseOrder(FrappeTestCase):
 		if not frappe.db.exists("Company", company):
 			company = frappe.new_doc("Company")
 			company.company_name = company
-			company.country="India",
-			company.default_currency= "INR",
+			company.country = ("India",)
+			company.default_currency = ("INR",)
 			company.save()
 		else:
 			company = frappe.get_doc("Company", company)
 		tax_template = "GST 12% - TC-5"
 		if not frappe.db.exists("Item Tax Template", tax_template):
 			tax_template = frappe.get_doc(
-			{
-				"doctype": "Item Tax Template",
-				"title": f"GST 12%",
-				"company": company,
-				"gst_treatment": "Taxable",
-				"gst_rate": 12,
-				"taxes": [
-					{
-						"tax_type": "Input Tax CGST - _TC",
-						"tax_rate": 12/2
-					},
-					{
-						"tax_type": "Input Tax SGST - _TC",
-						"tax_rate": 12/2
-					},
-				]
-			}
+				{
+					"doctype": "Item Tax Template",
+					"title": "GST 12%",
+					"company": company,
+					"gst_treatment": "Taxable",
+					"gst_rate": 12,
+					"taxes": [
+						{"tax_type": "Input Tax CGST - _TC", "tax_rate": 12 / 2},
+						{"tax_type": "Input Tax SGST - _TC", "tax_rate": 12 / 2},
+					],
+				}
 			)
 			tax_template.insert(ignore_if_duplicate=True)
 		else:
@@ -7204,7 +7398,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = create_item("_Test Item")
 		item = frappe.get_doc("Item", item.item_code)
 		gst_hsn = frappe.get_doc("GST HSN Code", item.gst_hsn_code)
-		gst_hsn.append("taxes", {"item_tax_template":tax_template.name, "valid_from": today()})
+		gst_hsn.append("taxes", {"item_tax_template": tax_template.name, "valid_from": today()})
 		gst_hsn.save()
 		warehouse = create_warehouse("Stores - _TC", company=company.name)
 		po_data_1 = {
@@ -7213,7 +7407,7 @@ class TestPurchaseOrder(FrappeTestCase):
 			"warehouse": warehouse,
 			"item_code": item.item_code,
 			"qty": 1,
-			"rate": 100
+			"rate": 100,
 		}
 		doc_po_1 = create_purchase_order(**po_data_1)
 		doc_pr_1 = make_test_pr(doc_po_1.name)
@@ -7221,13 +7415,15 @@ class TestPurchaseOrder(FrappeTestCase):
 		doc_pr_1.submit()
 		self.assertEqual(doc_pr_1.items[0].qty, 1)
 		self.assertEqual(doc_pr_1.items[0].rate, 100)
-		pr_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pr_1.name}, fields=["account", "debit", "credit"])
+		pr_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pr_1.name}, fields=["account", "debit", "credit"]
+		)
 		for gl_entries in pr_gl_entries:
-			if gl_entries['account'] == "Stock In Hand - _TC":
-				self.assertEqual(gl_entries['debit'], 100)
-			elif gl_entries['account'] == "Stock Received But Not Billed - _TC":
-				self.assertEqual(gl_entries['credit'], 100)
-		doc_pi_1= make_purchase_invoice(doc_pr_1.name)
+			if gl_entries["account"] == "Stock In Hand - _TC":
+				self.assertEqual(gl_entries["debit"], 100)
+			elif gl_entries["account"] == "Stock Received But Not Billed - _TC":
+				self.assertEqual(gl_entries["credit"], 100)
+		doc_pi_1 = make_purchase_invoice(doc_pr_1.name)
 		doc_pi_1.save()
 		doc_pi_1.submit()
 		po_data_2 = {
@@ -7236,7 +7432,7 @@ class TestPurchaseOrder(FrappeTestCase):
 			"warehouse": warehouse,
 			"item_code": item.item_code,
 			"qty": 1,
-			"rate": 100
+			"rate": 100,
 		}
 		doc_po_2 = create_purchase_order(**po_data_2)
 		doc_pr_2 = make_test_pr(doc_po_2.name)
@@ -7244,13 +7440,15 @@ class TestPurchaseOrder(FrappeTestCase):
 		doc_pr_2.submit()
 		self.assertEqual(doc_pr_2.items[0].qty, 1)
 		self.assertEqual(doc_pr_2.items[0].rate, 100)
-		pr_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pr_2.name}, fields=["account", "debit", "credit"])
+		pr_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pr_2.name}, fields=["account", "debit", "credit"]
+		)
 		for gl_entries in pr_gl_entries:
-			if gl_entries['account'] == "Stock In Hand - _TC":
-				self.assertEqual(gl_entries['debit'], 100)
-			elif gl_entries['account'] == "Stock Received But Not Billed - _TC":
-				self.assertEqual(gl_entries['credit'], 100)
-		doc_pi_2= make_purchase_invoice(doc_pr_2.name)
+			if gl_entries["account"] == "Stock In Hand - _TC":
+				self.assertEqual(gl_entries["debit"], 100)
+			elif gl_entries["account"] == "Stock Received But Not Billed - _TC":
+				self.assertEqual(gl_entries["credit"], 100)
+		doc_pi_2 = make_purchase_invoice(doc_pr_2.name)
 		doc_pi_2.save()
 		doc_pi_2.submit()
 		self.assertEqual(doc_pi_2.items[0].qty, 1)
@@ -7266,12 +7464,14 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		# Check if supplier exists
 		if not frappe.db.exists("Supplier", supplier_name):
-			supplier = frappe.get_doc({
-				"doctype": "Supplier",
-				"supplier_name": supplier_name,
-				"supplier_type": "Individual",
-				"default_currency": "USD"
-			}).insert(ignore_mandatory=1)
+			supplier = frappe.get_doc(
+				{
+					"doctype": "Supplier",
+					"supplier_name": supplier_name,
+					"supplier_type": "Individual",
+					"default_currency": "USD",
+				}
+			).insert(ignore_mandatory=1)
 			supplier_name = supplier.name
 		supplier = frappe.get_doc("Supplier", supplier_name)
 		supplier.default_currency = "USD"
@@ -7303,13 +7503,13 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		po_doc = create_purchase_order(
 			qty=10,
-			company = company,
-			supplier = supplier,
-			item = item.item_code,
-			warehouse = "Stores - TC-5",
-			rate = 1.59,
-			currency = "USD",
-			do_not_save = 1
+			company=company,
+			supplier=supplier,
+			item=item.item_code,
+			warehouse="Stores - TC-5",
+			rate=1.59,
+			currency="USD",
+			do_not_save=1,
 		)
 		po_doc.conversion_rate = 62.9
 		po_doc.save()
@@ -7319,11 +7519,13 @@ class TestPurchaseOrder(FrappeTestCase):
 		pr.save()
 		pr.submit()
 		self.assertEqual(pr.items[0].received_qty, 10)
-		self.assertEqual(pr.base_total, 1000.11) 
+		self.assertEqual(pr.base_total, 1000.11)
 		pi = make_purchase_invoice(pr.name)
 		pi.save()
 		pi.submit()
-		pr_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pr_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		self.assertEqual(pr_gl_entries[0].get("account"), "Stock Received But Not Billed - TC-5")
 		self.assertEqual(pr_gl_entries[0].get("debit"), 1000.11)
 		self.assertEqual(pr_gl_entries[1].get("account"), "Creditors USD 12 - TC-5")
@@ -7342,7 +7544,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		pe.paid_amount = pi.grand_total
 		pe.save(ignore_permissions=True)
 		pe.submit()
-	
+
 		err = frappe.new_doc("Exchange Rate Revaluation")
 		err.company = company.name
 		err.posting_date = today()
@@ -7373,11 +7575,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("test_item")
 
 		environmental_cess = create_new_account(
-			account_name='Environmental Cess',
-			company=company,
-			parent_account = 'Indirect Expenses - TC-5'
+			account_name="Environmental Cess", company=company, parent_account="Indirect Expenses - TC-5"
 		)
-		tax_template = create_or_get_purchase_taxes_template(company = company)
+		tax_template = create_or_get_purchase_taxes_template(company=company)
 
 		po = frappe.get_doc(
 			{
@@ -7392,21 +7592,24 @@ class TestPurchaseOrder(FrappeTestCase):
 						"schedule_date": today(),
 						"qty": 10,
 						"rate": 1000,
-						"warehouse" : "Stores - TC-5"
+						"warehouse": "Stores - TC-5",
 					}
 				],
 			}
 		)
 		po.taxes_and_charges = tax_template.get("purchase_tax_template")
 		po.insert()
-		po.append("taxes", {
-			"charge_type": "On Previous Row Total",
-			"account_head": environmental_cess,
-			"rate": 5,
-			"category": "Total",
-			"description": "Environmental Cess",
-			"row_id":2
-		})
+		po.append(
+			"taxes",
+			{
+				"charge_type": "On Previous Row Total",
+				"account_head": environmental_cess,
+				"rate": 5,
+				"category": "Total",
+				"description": "Environmental Cess",
+				"row_id": 2,
+			},
+		)
 		po.save()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
@@ -7422,19 +7625,15 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		get_pr_stock_ledger = frappe.get_all(
 			"Stock Ledger Entry",
-			{
-				"voucher_type": "Purchase Receipt",
-				"voucher_no": pr.name
-			},
-			[
-				"warehouse",
-				"actual_qty"
-			]
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["warehouse", "actual_qty"],
 		)
 		self.assertEqual(get_pr_stock_ledger[0].get("warehouse"), "Stores - TC-5")
 		self.assertEqual(get_pr_stock_ledger[0].get("actual_qty"), 10)
 
-		pr_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		pr_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		expected_si_entries = {
 			"Stock In Hand - TC-5": {"debit": 10000, "credit": 0},
 			"Stock Received But Not Billed - TC-5": {"debit": 0, "credit": 10000},
@@ -7451,14 +7650,15 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.total_taxes_and_charges, 2390)
 		self.assertEqual(pi.grand_total, 12390)
 
-		pi_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pi_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		expected_pi_entries = {
 			"Stock Received But Not Billed - TC-5": {"debit": 10000, "credit": 0},
 			"Input Tax CGST - TC-5": {"debit": 900, "credit": 0},
 			"Input Tax SGST - TC-5": {"debit": 900, "credit": 0},
 			"Creditors - TC-5": {"debit": 0, "credit": 12390},
 			"Environmental Cess - TC-5": {"debit": 590, "credit": 0},
-
 		}
 		for entry in pi_gle_entries:
 			self.assertEqual(entry["debit"], expected_pi_entries.get(entry["account"], {}).get("debit", 0))
@@ -7480,7 +7680,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				"company": get_company_supplier.get("company"),
 				"parent_account": "Indirect Expenses - TC-5",
 				"account_type": "Chargeable",
-				"account_currency": "INR"
+				"account_currency": "INR",
 			}
 		).insert(ignore_if_duplicate=1)
 
@@ -7492,19 +7692,9 @@ class TestPurchaseOrder(FrappeTestCase):
 				"set_warehouse": "Stores - TC-5",
 				"currency": "INR",
 				"items": [
-					{
-						"item_code": item.item_code,
-						"schedule_date": today(),
-						"qty": 10,
-						"rate": 1000
-					},
-					{
-						"item_code": item_1.item_code,
-						"schedule_date": today(),
-						"qty": 5,
-						"rate": 200
-					}
-				]
+					{"item_code": item.item_code, "schedule_date": today(), "qty": 10, "rate": 1000},
+					{"item_code": item_1.item_code, "schedule_date": today(), "qty": 5, "rate": 200},
+				],
 			}
 		)
 		taxes = [
@@ -7513,16 +7703,16 @@ class TestPurchaseOrder(FrappeTestCase):
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('sgst_account'),
-				"description": "SGST"
+				"account_head": tax_account.get("sgst_account"),
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('cgst_account'),
-				"description": "CGST"
+				"account_head": tax_account.get("cgst_account"),
+				"description": "CGST",
 			},
 			{
 				"charge_type": "On Item Quantity",
@@ -7530,7 +7720,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				"rate": 20,
 				"category": "Valuation and Total",
 				"description": "Transportation Charges",
-			}
+			},
 		]
 		for tax in taxes:
 			po.append("taxes", tax)
@@ -7549,21 +7739,17 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		get_pr_stock_ledger = frappe.get_all(
 			"Stock Ledger Entry",
-			{
-				"voucher_type": "Purchase Receipt",
-				"voucher_no": pr.name
-			},
-			[
-				"warehouse",
-				"actual_qty"
-			]
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["warehouse", "actual_qty"],
 		)
 		self.assertEqual(get_pr_stock_ledger[0].get("warehouse"), "Stores - TC-5")
 		self.assertEqual(get_pr_stock_ledger[0].get("actual_qty"), 5)
 		self.assertEqual(get_pr_stock_ledger[1].get("warehouse"), "Stores - TC-5")
 		self.assertEqual(get_pr_stock_ledger[1].get("actual_qty"), 10)
 
-		pr_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		pr_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		expected_si_entries = {
 			"Stock In Hand - TC-5": {"debit": 11300, "credit": 0},
 			"Stock Received But Not Billed - TC-5": {"debit": 0, "credit": 11000},
@@ -7581,7 +7767,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.total_taxes_and_charges, 2280)
 		self.assertEqual(pi.grand_total, 13280)
 
-		pi_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pi_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		expected_pi_entries = {
 			"Stock Received But Not Billed - TC-5": {"debit": 11000, "credit": 0},
 			"Input Tax CGST - TC-5": {"debit": 990, "credit": 0},
@@ -7592,46 +7780,45 @@ class TestPurchaseOrder(FrappeTestCase):
 		for entry in pi_gle_entries:
 			self.assertEqual(entry["debit"], expected_pi_entries.get(entry["account"], {}).get("debit", 0))
 			self.assertEqual(entry["credit"], expected_pi_entries.get(entry["account"], {}).get("credit", 0))
-	
+
 	def test_stop_po_creation_when_value_exceeds_budget_TC_ACC_132(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.utils import get_fiscal_year
-		
+
 		validate_fiscal_year("_Test Company")
 		year = get_fiscal_year(date=nowdate(), company="_Test Company")[0]
 
-		budget = frappe.get_doc({
-			"doctype":"Budget",
-			"budget_against":"Cost Center",
-			"company":"_Test Company",
-			"cost_center":"_Test Write Off Cost Center - _TC",
-			"fiscal_year":year,
-			"applicable_on_purchase_order":1,
-			"action_if_annual_budget_exceeded_on_po": "Stop",
-			"action_if_accumulated_monthly_budget_exceeded_on_po": "Stop",
-			"applicable_on_booking_actual_expenses":1,
-			"action_if_annual_budget_exceeded": "Stop",
-			"action_if_accumulated_monthly_budget_exceeded": "Stop",
-			"accounts":[{
-				"account":"Administrative Expenses - _TC",
-				"budget_amount":10000
-			}]
-		}).insert(ignore_permissions=1)
+		budget = frappe.get_doc(
+			{
+				"doctype": "Budget",
+				"budget_against": "Cost Center",
+				"company": "_Test Company",
+				"cost_center": "_Test Write Off Cost Center - _TC",
+				"fiscal_year": year,
+				"applicable_on_purchase_order": 1,
+				"action_if_annual_budget_exceeded_on_po": "Stop",
+				"action_if_accumulated_monthly_budget_exceeded_on_po": "Stop",
+				"applicable_on_booking_actual_expenses": 1,
+				"action_if_annual_budget_exceeded": "Stop",
+				"action_if_accumulated_monthly_budget_exceeded": "Stop",
+				"accounts": [{"account": "Administrative Expenses - _TC", "budget_amount": 10000}],
+			}
+		).insert(ignore_permissions=1)
 		budget.load_from_db()
 		budget.submit()
-  
+
 		item = make_test_item("_Test Item")
 		try:
 			po = create_purchase_order(
-				supplier = "_Test Supplier",
-				company = "_Test Company",
+				supplier="_Test Supplier",
+				company="_Test Company",
 				item_code=item.name,
 				rate=11000,
 				qty=1,
 				do_not_save=True,
-				do_not_submit=True
+				do_not_submit=True,
 			)
-	
+
 			po.cost_center = "_Test Write Off Cost Center - _TC"
 			po.items[0].expense_account = "Administrative Expenses - _TC"
 			po.items[0].cost_center = "_Test Write Off Cost Center - _TC"
@@ -7639,48 +7826,55 @@ class TestPurchaseOrder(FrappeTestCase):
 			po.insert(ignore_permissions=True)
 			po.load_from_db()
 			self.assertRaises(frappe.ValidationError, po.submit)
-		except Exception as e:
+		except Exception as _:
 			pass
 
 			# frappe.delete_doc("Budget", budget.name,force=1)
 			# frappe.delete_doc("Purchase Order", po.name,force=1)
-		
-			
+
 	def test_warn_po_creation_when_value_exceeds_budget_TC_ACC_144(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
 		from erpnext.accounts.utils import get_fiscal_year
+
 		validate_fiscal_year("_Test Company")
 		year = get_fiscal_year(date=nowdate(), company="_Test Company")[0]
-		if not frappe.get_value("Budget", {"company": "_Test Company", "fiscal_year": year,"cost_center": "_Test Write Off Cost Center - _TC"}, "name"):
-			budget = frappe.get_doc({
-				"doctype":"Budget",
-				"budget_against":"Cost Center",
-				"company":"_Test Company",
-				"cost_center":"_Test Write Off Cost Center - _TC",
-				"fiscal_year":year,
-				"applicable_on_purchase_order":1,
-				"action_if_annual_budget_exceeded_on_po": "Warn",
-				"action_if_accumulated_monthly_budget_exceeded_on_po": "Warn",
-				"applicable_on_booking_actual_expenses":1,
-				"action_if_annual_budget_exceeded": "Warn",
-				"action_if_accumulated_monthly_budget_exceeded": "Warn",
-				"accounts":[{
-					"account":"Administrative Expenses - _TC",
-					"budget_amount":10000
-				}]
-			}).insert(ignore_permissions=1)
+		if not frappe.get_value(
+			"Budget",
+			{
+				"company": "_Test Company",
+				"fiscal_year": year,
+				"cost_center": "_Test Write Off Cost Center - _TC",
+			},
+			"name",
+		):
+			budget = frappe.get_doc(
+				{
+					"doctype": "Budget",
+					"budget_against": "Cost Center",
+					"company": "_Test Company",
+					"cost_center": "_Test Write Off Cost Center - _TC",
+					"fiscal_year": year,
+					"applicable_on_purchase_order": 1,
+					"action_if_annual_budget_exceeded_on_po": "Warn",
+					"action_if_accumulated_monthly_budget_exceeded_on_po": "Warn",
+					"applicable_on_booking_actual_expenses": 1,
+					"action_if_annual_budget_exceeded": "Warn",
+					"action_if_accumulated_monthly_budget_exceeded": "Warn",
+					"accounts": [{"account": "Administrative Expenses - _TC", "budget_amount": 10000}],
+				}
+			).insert(ignore_permissions=1)
 			budget.load_from_db()
 			budget.submit()
 		item = make_test_item("_Test Item")
-		
+
 		po = create_purchase_order(
-			supplier = "_Test Supplier",
-			company = "_Test Company",
+			supplier="_Test Supplier",
+			company="_Test Company",
 			item_code=item.name,
 			rate=11000,
 			qty=1,
 			do_not_save=True,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 
 		po.cost_center = "_Test Write Off Cost Center - _TC"
@@ -7696,10 +7890,10 @@ class TestPurchaseOrder(FrappeTestCase):
 			if msg.get("title") == "Budget Exceeded" and msg.get("indicator") == "orange":
 				if "Annual Budget for Account" in msg.get("message", ""):
 					budget_exceeded_found = True
-					break  
+					break
 
 		self.assertTrue(budget_exceeded_found, "Budget exceeded message not found")
-		
+
 		# frappe.delete_doc("Budget", budget.name,force=1)
 		# frappe.delete_doc("Purchase Order", po.name,force=1)
 
@@ -7724,9 +7918,9 @@ class TestPurchaseOrder(FrappeTestCase):
 						"schedule_date": today(),
 						"qty": 10,
 						"rate": 1000,
-						"warehouse": "Stores - TC-5"
+						"warehouse": "Stores - TC-5",
 					}
-				]
+				],
 			}
 		)
 		taxes = [
@@ -7735,16 +7929,16 @@ class TestPurchaseOrder(FrappeTestCase):
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('sgst_account'),
-				"description": "SGST"
+				"account_head": tax_account.get("sgst_account"),
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('cgst_account'),
-				"description": "CGST"
+				"account_head": tax_account.get("cgst_account"),
+				"description": "CGST",
 			},
 			{
 				"charge_type": "Actual",
@@ -7752,8 +7946,8 @@ class TestPurchaseOrder(FrappeTestCase):
 				"tax_amount": 100,
 				"category": "Total",
 				"add_deduct_tax": "Deduct",
-				"description": "Damage Claims"
-			}
+				"description": "Damage Claims",
+			},
 		]
 		for tax in taxes:
 			po.append("taxes", tax)
@@ -7772,19 +7966,15 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		get_pr_stock_ledger = frappe.get_all(
 			"Stock Ledger Entry",
-			{
-				"voucher_type": "Purchase Receipt",
-				"voucher_no": pr.name
-			},
-			[
-				"warehouse",
-				"actual_qty"
-			]
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["warehouse", "actual_qty"],
 		)
 		self.assertEqual(get_pr_stock_ledger[0].get("warehouse"), "Stores - TC-5")
 		self.assertEqual(get_pr_stock_ledger[0].get("actual_qty"), 10)
 
-		pr_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		pr_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		expected_si_entries = {
 			"Stock In Hand - TC-5": {"debit": 10000, "credit": 0},
 			"Stock Received But Not Billed - TC-5": {"debit": 0, "credit": 10000},
@@ -7801,7 +7991,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.total_taxes_and_charges, 1700)
 		self.assertEqual(pi.grand_total, 11700)
 
-		pi_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pi_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		expected_pi_entries = {
 			"Stock Received But Not Billed - TC-5": {"debit": 10000, "credit": 0},
 			"Input Tax CGST - TC-5": {"debit": 900, "credit": 0},
@@ -7819,8 +8011,8 @@ class TestPurchaseOrder(FrappeTestCase):
 		company = get_company_supplier.get("child_company")
 		supplier = get_company_supplier.get("supplier")
 		item = make_test_item("_test_item")
-		item_tax_template = 'Test Item Tax Template'
-		account = frappe.db.get_value("Account", {'company':company}, "name")
+		item_tax_template = "Test Item Tax Template"
+		account = frappe.db.get_value("Account", {"company": company}, "name")
 		tax_category = "Test Tax Category"
 		if not frappe.db.exists("Tax Category", tax_category):
 			tax_category = frappe.new_doc("Tax Category")
@@ -7834,14 +8026,17 @@ class TestPurchaseOrder(FrappeTestCase):
 			purchase_tax_template.company = company
 			purchase_tax_template.title = item_tax_template
 			purchase_tax_template.tax_category = tax_category
-			purchase_tax_template.append("taxes", {
-				"category":"Total",
-				"add_deduct_tax":"Add",
-				"charge_type":"On Net Total",
-				"account_head":account,
-				"rate":5,
-				"description":"GST"
-			})
+			purchase_tax_template.append(
+				"taxes",
+				{
+					"category": "Total",
+					"add_deduct_tax": "Add",
+					"charge_type": "On Net Total",
+					"account_head": account,
+					"rate": 5,
+					"description": "GST",
+				},
+			)
 			purchase_tax_template.save()
 			existing_templates = purchase_tax_template.name
 
@@ -7856,14 +8051,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				"supplier": supplier,
 				"set_warehouse": "Stores - TC-3",
 				"currency": "INR",
-				"items": [
-					{
-						"item_code": item.item_code,
-						"schedule_date": today(),
-						"qty": 10,
-						"rate": 1000
-					}
-				]
+				"items": [{"item_code": item.item_code, "schedule_date": today(), "qty": 10, "rate": 1000}],
 			}
 		)
 		po.insert()
@@ -7883,19 +8071,15 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		get_pr_stock_ledger = frappe.get_all(
 			"Stock Ledger Entry",
-			{
-				"voucher_type": "Purchase Receipt",
-				"voucher_no": pr.name
-			},
-			[
-				"warehouse",
-				"actual_qty"
-			]
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["warehouse", "actual_qty"],
 		)
 		self.assertEqual(get_pr_stock_ledger[0].get("warehouse"), "Stores - TC-3")
 		self.assertEqual(get_pr_stock_ledger[0].get("actual_qty"), 10)
 
-		pr_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		pr_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		expected_si_entries = {
 			"Stock In Hand - TC-3": {"debit": 10000, "credit": 0},
 			"Stock Received But Not Billed - TC-3": {"debit": 0, "credit": 10000},
@@ -7905,7 +8089,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				if entry["account"] == accounts:
 					self.assertEqual(entry["debit"], expected_si_entries[accounts]["debit"])
 					self.assertEqual(entry["credit"], expected_si_entries[accounts]["credit"])
-		
+
 		pi = make_purchase_invoice(pr.name)
 		pi.bill_no = "test_bill - 1122"
 		pi.insert(ignore_permissions=True)
@@ -7914,7 +8098,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.total_taxes_and_charges, 500)
 		self.assertEqual(pi.grand_total, 10500)
 
-		pi_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pi_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		expected_pi_entries = {
 			"Stock Received But Not Billed - TC-3": {"debit": 10000, "credit": 0},
 			"Input Tax CGST - TC-3": {"debit": 250, "credit": 0},
@@ -7926,7 +8112,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				if entry["account"] == accounts:
 					self.assertEqual(entry["debit"], expected_pi_entries[accounts]["debit"])
 					self.assertEqual(entry["credit"], expected_pi_entries[accounts]["credit"])
-		
+
 	@if_app_installed("india_compliance")
 	def test_po_with_multiple_items_single_item_tax_10_pr_pi_TC_B_143(self):
 		get_company_supplier = get_company_or_supplier()
@@ -7957,16 +8143,16 @@ class TestPurchaseOrder(FrappeTestCase):
 						"schedule_date": today(),
 						"qty": 1,
 						"rate": 1000,
-						"warehouse": "Stores - TC-5"
+						"warehouse": "Stores - TC-5",
 					},
 					{
 						"item_code": item_2.item_code,
 						"schedule_date": today(),
 						"qty": 1,
 						"rate": 1000,
-						"warehouse": "Stores - TC-5"
+						"warehouse": "Stores - TC-5",
 					},
-				]
+				],
 			}
 		)
 		taxes = [
@@ -7975,17 +8161,17 @@ class TestPurchaseOrder(FrappeTestCase):
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('sgst_account'),
-				"description": "SGST"
+				"account_head": tax_account.get("sgst_account"),
+				"description": "SGST",
 			},
 			{
 				"charge_type": "On Net Total",
 				"add_deduct_tax": "Add",
 				"category": "Total",
 				"rate": 9,
-				"account_head": tax_account.get('cgst_account'),
-				"description": "CGST"
-			}
+				"account_head": tax_account.get("cgst_account"),
+				"description": "CGST",
+			},
 		]
 		for tax in taxes:
 			po.append("taxes", tax)
@@ -8004,21 +8190,17 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		get_pr_stock_ledger = frappe.get_all(
 			"Stock Ledger Entry",
-			{
-				"voucher_type": "Purchase Receipt",
-				"voucher_no": pr.name
-			},
-			[
-				"warehouse",
-				"actual_qty"
-			]
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["warehouse", "actual_qty"],
 		)
 		self.assertEqual(get_pr_stock_ledger[0].get("warehouse"), "Stores - TC-5")
 		self.assertEqual(get_pr_stock_ledger[0].get("actual_qty"), 1)
 		self.assertEqual(get_pr_stock_ledger[1].get("warehouse"), "Stores - TC-5")
 		self.assertEqual(get_pr_stock_ledger[1].get("actual_qty"), 1)
 
-		pr_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		pr_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		expected_si_entries = {
 			"Stock In Hand - TC-5": {"debit": 2000, "credit": 0},
 			"Stock Received But Not Billed - TC-5": {"debit": 0, "credit": 2000},
@@ -8035,7 +8217,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.total_taxes_and_charges, 280)
 		self.assertEqual(pi.grand_total, 2280)
 
-		pi_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pi_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		expected_pi_entries = {
 			"Stock Received But Not Billed - TC-5": {"debit": 2000, "credit": 0},
 			"Input Tax CGST - TC-5": {"debit": 140, "credit": 0},
@@ -8054,32 +8238,38 @@ class TestPurchaseOrder(FrappeTestCase):
 		warehouse = "Stores - TC-3"
 		item = make_test_item("_test_item")
 		get_or_create_fiscal_year(company)
-		account = frappe.db.get_value("Account", {'company':company}, "name")
+		account = frappe.db.get_value("Account", {"company": company}, "name")
 		tax_category_1 = "Test Tax Category"
 		if not frappe.db.exists("Tax Category", tax_category_1):
 			tax_category = frappe.new_doc("Tax Category")
 			tax_category.title = tax_category_1
 			tax_category.save()
 
-		item_tax_template = frappe.db.get_value("Purchase Taxes and Charges Template",{"company": company,"tax_category":tax_category_1}, "name")
+		item_tax_template = frappe.db.get_value(
+			"Purchase Taxes and Charges Template",
+			{"company": company, "tax_category": tax_category_1},
+			"name",
+		)
 		if frappe.db.exists("Purchase Taxes and Charges Template", item_tax_template):
 			existing_templates = item_tax_template
 		else:
 			purchase_tax_template = frappe.new_doc("Purchase Taxes and Charges Template")
 			purchase_tax_template.company = company
-			purchase_tax_template.title ="test"
+			purchase_tax_template.title = "test"
 			purchase_tax_template.tax_category = tax_category
-			purchase_tax_template.append("taxes", {
-				"category":"Total",
-				"add_deduct_tax":"Add",
-				"charge_type":"On Net Total",
-				"account_head":account,
-				"rate":5,
-				"description":"GST"
-			})
+			purchase_tax_template.append(
+				"taxes",
+				{
+					"category": "Total",
+					"add_deduct_tax": "Add",
+					"charge_type": "On Net Total",
+					"account_head": account,
+					"rate": 5,
+					"description": "GST",
+				},
+			)
 			purchase_tax_template.save()
 			existing_templates = purchase_tax_template.name
-			
 
 		po = frappe.get_doc(
 			{
@@ -8095,7 +8285,7 @@ class TestPurchaseOrder(FrappeTestCase):
 						"rate": 1000,
 						"warehouse": warehouse,
 					}
-				]
+				],
 			}
 		)
 		po.insert()
@@ -8115,19 +8305,15 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		get_pr_stock_ledger = frappe.get_all(
 			"Stock Ledger Entry",
-			{
-				"voucher_type": "Purchase Receipt",
-				"voucher_no": pr.name
-			},
-			[
-				"warehouse",
-				"actual_qty"
-			]
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			["warehouse", "actual_qty"],
 		)
 		self.assertEqual(get_pr_stock_ledger[0].get("warehouse"), "Stores - TC-3")
 		self.assertEqual(get_pr_stock_ledger[0].get("actual_qty"), 1)
 
-		pr_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+		pr_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+		)
 		expected_si_entries = {
 			"Stock In Hand - TC-3": {"debit": 1000, "credit": 0},
 			"Stock Received But Not Billed - TC-3": {"debit": 0, "credit": 1000},
@@ -8146,7 +8332,9 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(pi.total_taxes_and_charges, 50)
 		self.assertEqual(pi.grand_total, 1050)
 
-		pi_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+		pi_gle_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+		)
 		expected_pi_entries = {
 			"Stock Received But Not Billed - TC-3": {"debit": 1000, "credit": 0},
 			"Input Tax CGST - TC-3": {"debit": 25, "credit": 0},
@@ -8166,8 +8354,8 @@ class TestPurchaseOrder(FrappeTestCase):
 		if not frappe.db.exists("Company", company):
 			company = frappe.new_doc("Company")
 			company.company_name = company
-			company.country="India",
-			company.default_currency= "INR",
+			company.country = ("India",)
+			company.default_currency = ("INR",)
 			company.save()
 		else:
 			company = frappe.get_doc("Company", company)
@@ -8186,7 +8374,7 @@ class TestPurchaseOrder(FrappeTestCase):
 			"warehouse": create_warehouse("Stores - _TC", company=company.name),
 			"item_code": item.item_code,
 			"qty": 10,
-			"rate": 1000
+			"rate": 1000,
 		}
 		doc_po = create_purchase_order(**po_data)
 		doc_pr = make_test_pr(doc_po.name)
@@ -8194,204 +8382,45 @@ class TestPurchaseOrder(FrappeTestCase):
 		doc_pr.submit()
 		self.assertEqual(doc_pr.items[0].qty, 10)
 		self.assertEqual(doc_pr.items[0].rate, 1000)
-		pr_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pr.name}, fields=["account", "debit", "credit"])
+		pr_gl_entries = frappe.get_all(
+			"GL Entry", filters={"voucher_no": doc_pr.name}, fields=["account", "debit", "credit"]
+		)
 		for gl_entries in pr_gl_entries:
-			if gl_entries['account'] == "Stock In Hand - _TC":
-				self.assertEqual(gl_entries['debit'], 10000)
-			elif gl_entries['account'] == "Stock Received But Not Billed - _TC":
-				self.assertEqual(gl_entries['credit'], 10000)
+			if gl_entries["account"] == "Stock In Hand - _TC":
+				self.assertEqual(gl_entries["debit"], 10000)
+			elif gl_entries["account"] == "Stock Received But Not Billed - _TC":
+				self.assertEqual(gl_entries["credit"], 10000)
 		doc_pi = make_purchase_invoice(doc_pr.name)
 		doc_pi.save()
 		doc_pi.submit()
 		self.assertEqual(doc_pi.items[0].qty, 10)
 		self.assertEqual(doc_pi.items[0].rate, 1000)
 
-	@if_app_installed("india_compliance")
-	def test_po_with_create_tax_template_5_pr_pi_3_TC_B_146(self):
-		supplier = create_supplier(supplier_name="_Test Supplier PO")
-		company = "_Test Company"
-		if not frappe.db.exists("Company", company):
-			company = frappe.new_doc("Company")
-			company.company_name = company
-			company.country="India",
-			company.default_currency= "INR",
-			company.save()
-		else:
-			company = frappe.get_doc("Company", company)
-		tax_template = "GST 12% - TC-5"
-		if not frappe.db.exists("Item Tax Template", tax_template):
-			tax_template = frappe.get_doc(
-			{
-				"doctype": "Item Tax Template",
-				"title": f"GST 12%",
-				"company": company,
-				"gst_treatment": "Taxable",
-				"gst_rate": 12,
-				"taxes": [
-					{
-						"tax_type": "Input Tax CGST - _TC",
-						"tax_rate": 12/2
-					},
-					{
-						"tax_type": "Input Tax SGST - _TC",
-						"tax_rate": 12/2
-					},
-				]
-			}
-			)
-			tax_template.insert(ignore_if_duplicate=True)
-		else:
-			tax_template = frappe.get_doc("Item Tax Template", tax_template)
-		item = create_item("_Test Item")
-		item = frappe.get_doc("Item", item.item_code)
-		gst_hsn = frappe.get_doc("GST HSN Code", item.gst_hsn_code)
-		gst_hsn.append("taxes", {"item_tax_template":tax_template.name, "valid_from": today()})
-		gst_hsn.save()
-		warehouse = create_warehouse("Stores - _TC", company=company.name)
-		po_data_1 = {
-			"company": company.name,
-			"supplier": supplier.name,
-			"warehouse": warehouse,
-			"item_code": item.item_code,
-			"qty": 1,
-			"rate": 100
-		}
-		doc_po_1 = create_purchase_order(**po_data_1)
-		doc_pr_1 = make_test_pr(doc_po_1.name)
-		doc_pr_1.save()
-		doc_pr_1.submit()
-		self.assertEqual(doc_pr_1.items[0].qty, 1)
-		self.assertEqual(doc_pr_1.items[0].rate, 100)
-		pr_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pr_1.name}, fields=["account", "debit", "credit"])
-		for gl_entries in pr_gl_entries:
-			if gl_entries['account'] == "Stock In Hand - _TC":
-				self.assertEqual(gl_entries['debit'], 100)
-			elif gl_entries['account'] == "Stock Received But Not Billed - _TC":
-				self.assertEqual(gl_entries['credit'], 100)
-		doc_pi_1= make_purchase_invoice(doc_pr_1.name)
-		doc_pi_1.save()
-		doc_pi_1.submit()
-		po_data_2 = {
-			"company": company.name,
-			"supplier": supplier.name,
-			"warehouse": warehouse,
-			"item_code": item.item_code,
-			"qty": 1,
-			"rate": 100
-		}
-		doc_po_2 = create_purchase_order(**po_data_2)
-		doc_pr_2 = make_test_pr(doc_po_2.name)
-		doc_pr_2.save()
-		doc_pr_2.submit()
-		self.assertEqual(doc_pr_2.items[0].qty, 1)
-		self.assertEqual(doc_pr_2.items[0].rate, 100)
-		pr_gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": doc_pr_2.name}, fields=["account", "debit", "credit"])
-		for gl_entries in pr_gl_entries:
-			if gl_entries['account'] == "Stock In Hand - _TC":
-				self.assertEqual(gl_entries['debit'], 100)
-			elif gl_entries['account'] == "Stock Received But Not Billed - _TC":
-				self.assertEqual(gl_entries['credit'], 100)
-		doc_pi_2= make_purchase_invoice(doc_pr_2.name)
-		doc_pi_2.save()
-		doc_pi_2.submit()
-		self.assertEqual(doc_pi_2.items[0].qty, 1)
-		self.assertEqual(doc_pi_2.items[0].rate, 100)
-
-	@change_settings("Accounts Settings", {"over_billing_allowance": 25})
-	@change_settings("Stock Settings", {"over_delivery_receipt_allowance": 25})
-	def test_purchase_order_and_PR_TC_SCK_181(self):
-		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
-		from datetime import datetime, timedelta
-		if not frappe.db.exists("Company", "_Test Company"):
-			company = frappe.new_doc("Company")
-			company.company_name = "_Test Company"
-			company.default_currency = "INR"
-			company.insert()
-		supplier = create_supplier(
-			supplier_name="_Test Supplier 1",
-			supplier_type="Company",
-		)
-		item_fields = {
-			"item_name": "_Test Book",
-			"is_stock_item": 1,
-			"valuation_rate": 100,
-		}
-		item = make_item("_Test Book", item_fields)
-		today = datetime.today().date()  # Get today's date
-		schedule_date = today + timedelta(days=10)  # Add 10 days
-		# make_stock_entry(
-		# 		item_code=item.name, to_warehouse=create_warehouse("_Test Stores", company="_Test Company"), qty=20, purpose="Material Receipt"
-		# 	)
-
-		purchase_order = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier.name,
-			"schedule_date": schedule_date,
-			"company": "_Test Company",
-			"items": [{
-				"item_code": item.name,
-				"qty": 8,
-				"rate": 10,
-				"warehouse": create_warehouse("_Test Stores", company="_Test Company")
-			}]
-		})
-		purchase_order.insert()
-		purchase_order.submit()
-
-		purchase_order_item = purchase_order.items[0].name
-
-		# Create Purchase Receipt from Purchase Order
-		purchase_receipt = frappe.get_doc({
-			"doctype": "Purchase Receipt",
-			"supplier": supplier.name,
-			"company": "_Test Company",
-			"items": [{
-				"item_code": item.name,
-				"qty": 10,  # Over-billed qty (within 20% limit)
-				"rate": 10,
-				"warehouse": create_warehouse("_Test Stores", company="_Test Company"),
-				"purchase_order": purchase_order.name,
-				"so_detail": purchase_order_item
-			}]
-		})
-		purchase_receipt.insert()
-		purchase_receipt.submit()
-
-		# Check Stock Ledger
-		StockLedgerEntry = DocType("Stock Ledger Entry")
-		stock_ledger_entries = (
-		frappe.qb.from_(StockLedgerEntry)
-		.select(StockLedgerEntry.actual_qty, StockLedgerEntry.warehouse)
-		.where(StockLedgerEntry.voucher_no == purchase_receipt.name)
-		).run(as_dict=True)
-
-		self.assertTrue(any(entry["actual_qty"] == 10 and entry["warehouse"] == "_Test Stores - _TC" for entry in stock_ledger_entries), "Stock Ledger did not update correctly")
-
 	def test_single_po_pi_multi_pr_TC_SCK_122(self):
 		# Scenario : 1PO => 2PR => 1PI
-		pricing_rule = frappe.get_doc({
-			"doctype": "Pricing Rule",
-			"title": "10% Discount",
-			"company": "_Test Company",
-			"apply_on": "Item Code",
-			"items":[
-				{
-					"item_code":"_Test Item"
-				}
-			],
-			"rate_or_discount": "Discount Percentage",
-			"discount_percentage": 10,
-			"selling": 0,
-			"buying": 1
-		}).insert(ignore_if_duplicate=1)
-		
-		purchase_order_list = [{
-			"company" : "_Test Company",
-			"item_code" : "_Test Item",
-			"warehouse" : "Stores - _TC",
-			"qty" : 6,
-			"rate" : 100,
-		}]
+		frappe.get_doc(
+			{
+				"doctype": "Pricing Rule",
+				"title": "10% Discount",
+				"company": "_Test Company",
+				"apply_on": "Item Code",
+				"items": [{"item_code": "_Test Item"}],
+				"rate_or_discount": "Discount Percentage",
+				"discount_percentage": 10,
+				"selling": 0,
+				"buying": 1,
+			}
+		).insert(ignore_if_duplicate=1)
+
+		purchase_order_list = [
+			{
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 6,
+				"rate": 100,
+			}
+		]
 
 		pur_receipt_qty = [3, 3]
 		pur_receipt_name_list = []
@@ -8402,19 +8431,21 @@ class TestPurchaseOrder(FrappeTestCase):
 		for received_qty in pur_receipt_qty:
 			doc_pr = make_pr_for_po(doc_po.name, received_qty)
 			self.assertEqual(doc_pr.docstatus, 1)
-			
+
 			pur_receipt_name_list.append(doc_pr.name)
-		
+
 		item_dict = [
-					{"item_code" : "_Test Item",
-					"warehouse" : "Stores - _TC",
-					"qty" : 3,
-					"rate" : 100,
-					"purchase_receipt":pur_receipt_name_list[1]
-					}]
-		
-		doc_pi = make_pi_against_pr(pur_receipt_name_list[0], item_dict_list= item_dict)
-		
+			{
+				"item_code": "_Test Item",
+				"warehouse": "Stores - _TC",
+				"qty": 3,
+				"rate": 100,
+				"purchase_receipt": pur_receipt_name_list[1],
+			}
+		]
+
+		doc_pi = make_pi_against_pr(pur_receipt_name_list[0], item_dict_list=item_dict)
+
 		self.assertEqual(doc_pi.docstatus, 1)
 		self.assertEqual(doc_po.total_qty, doc_pi.total_qty)
 		self.assertEqual(doc_po.grand_total, doc_pi.grand_total)
@@ -8422,8 +8453,10 @@ class TestPurchaseOrder(FrappeTestCase):
 	@change_settings("Accounts Settings", {"over_billing_allowance": 25})
 	@change_settings("Stock Settings", {"over_delivery_receipt_allowance": 25})
 	def test_purchase_order_and_PR_TC_SCK_181(self):
-		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 		from datetime import datetime, timedelta
+
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
 		if not frappe.db.exists("Company", "_Test Company"):
 			company = frappe.new_doc("Company")
 			company.company_name = "_Test Company"
@@ -8442,63 +8475,75 @@ class TestPurchaseOrder(FrappeTestCase):
 		today = datetime.today().date()
 		schedule_date = today + timedelta(days=10)
 
-		purchase_order = frappe.get_doc({
-			"doctype": "Purchase Order",
-			"supplier": supplier.name,
-			"schedule_date": schedule_date,
-			"company": "_Test Company",
-			"items": [{
-				"item_code": item.name,
-				"qty": 8,
-				"rate": 10,
-				"warehouse": create_warehouse("_Test Stores", company="_Test Company")
-			}]
-		})
+		purchase_order = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": supplier.name,
+				"schedule_date": schedule_date,
+				"company": "_Test Company",
+				"items": [
+					{
+						"item_code": item.name,
+						"qty": 8,
+						"rate": 10,
+						"warehouse": create_warehouse("_Test Stores", company="_Test Company"),
+					}
+				],
+			}
+		)
 		purchase_order.insert()
 		purchase_order.submit()
 
 		purchase_order_item = purchase_order.items[0].name
 
 		# Create Purchase Receipt from Purchase Order
-		purchase_receipt = frappe.get_doc({
-			"doctype": "Purchase Receipt",
-			"supplier": supplier.name,
-			"company": "_Test Company",
-			"items": [{
-				"item_code": item.name,
-				"qty": 10,  # Over-billed qty (within 20% limit)
-				"rate": 10,
-				"warehouse": create_warehouse("_Test Stores", company="_Test Company"),
-				"purchase_order": purchase_order.name,
-				"so_detail": purchase_order_item
-			}]
-		})
+		purchase_receipt = frappe.get_doc(
+			{
+				"doctype": "Purchase Receipt",
+				"supplier": supplier.name,
+				"company": "_Test Company",
+				"items": [
+					{
+						"item_code": item.name,
+						"qty": 10,  # Over-billed qty (within 20% limit)
+						"rate": 10,
+						"warehouse": create_warehouse("_Test Stores", company="_Test Company"),
+						"purchase_order": purchase_order.name,
+						"so_detail": purchase_order_item,
+					}
+				],
+			}
+		)
 		purchase_receipt.insert()
 		purchase_receipt.submit()
 
 		# Check Stock Ledger
 		stock_ledger_entries = frappe.get_all(
-			"Stock Ledger Entry", 
-			filters={
-				"voucher_no": purchase_receipt.name
-			},
-			fields=[
-				"actual_qty",
-				"warehouse"
-			]
+			"Stock Ledger Entry",
+			filters={"voucher_no": purchase_receipt.name},
+			fields=["actual_qty", "warehouse"],
 		)
 
-		self.assertTrue(any(entry["actual_qty"] == 10 and entry["warehouse"] == "_Test Stores - _TC" for entry in stock_ledger_entries), "Stock Ledger did not update correctly")
+		self.assertTrue(
+			any(
+				entry["actual_qty"] == 10 and entry["warehouse"] == "_Test Stores - _TC"
+				for entry in stock_ledger_entries
+			),
+			"Stock Ledger did not update correctly",
+		)
 
 	def test_po_with_uploaded_file_feature_TC_B_091(self):
-		import openpyxl
 		import os
+
+		import openpyxl
+
 		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+
 		create_supplier(supplier_name="_Test Supplier")
 		make_item("_Test Item 1")
 		make_item("_Test Item 2")
 		filename = "sample_data.xlsx"
-		headers = ["item_code", "item_name", "schedule_date","qty","rate"]
+		headers = ["item_code", "item_name", "schedule_date", "qty", "rate"]
 		data = [
 			["_Test Item 1", "_Test Item 1", nowdate(), 5, 100],
 			["_Test Item 2", "_Test Item 2", nowdate(), 5, 100],
@@ -8523,19 +8568,17 @@ class TestPurchaseOrder(FrappeTestCase):
 				"item_name": row[1],
 				"schedule_date": row[2],
 				"qty": row[3],
-				"rate": row[4]
+				"rate": row[4],
 			}
 			main_items.append(item)
-		
+
 		po = frappe.new_doc("Purchase Order")
 		po.company = "_Test Company"
 		po.supplier = "_Test Supplier"
 		po.transaction_date = nowdate()
 		po.set_warehouse = "_Test Warehouse - _TC"
 		for item in main_items:
-			po.append(
-				"items",item
-			)
+			po.append("items", item)
 		po.insert()
 		po.save()
 		po.submit()
@@ -8585,158 +8628,11 @@ class TestPurchaseOrder(FrappeTestCase):
 	@if_app_installed("projects")
 	def test_validate_available_budget_TC_B_160(self):
 		from unittest.mock import patch
+
 		project_name = "test_project" + frappe.generate_hash(length=5)
-		if not frappe.db.exists("Project",{"project_name": project_name}):
+		if not frappe.db.exists("Project", {"project_name": project_name}):
 			frappe.get_doc(
-				{
-					"doctype": "Project",
-					"company": "_Test Company",
-					"project_name": project_name,
-					"is_wbs": 1
-				}
-			).insert()
-
-		project = frappe.db.get_value("Project", {"project_name": project_name})
-
-		wbs = frappe.get_doc(
-			{
-				"doctype": "Work Breakdown Structure",
-				"project": project,
-				"wbs_name": "test_wbs",
-				"company": "_Test Company",
-				"gl_account": "Cash - _TC"
-			}
-		)
-		wbs.insert()
-		wbs.submit()
-
-		self.assertEqual(wbs.docstatus, 1)
-
-		zero_budget = frappe.get_doc(
-			{
-				"doctype": "Zero Budget",
-				"project": project,
-				"posting_date": today(),
-				"zero_budget_item": [
-					{
-						"wbs_element": wbs.name,
-						"zero_budget": 100
-					}
-				]
-			}
-		)
-		zero_budget.insert()
-		zero_budget.submit()
-
-		self.assertEqual(wbs.docstatus, 1)
-
-		wbs.load_from_db()
-
-		wbs_1 = frappe.copy_doc(wbs)
-		wbs_1.insert()
-		wbs_1.submit()
-
-		with patch("frappe.msgprint") as mock_msgprint:
-			args = {
-				"qty":1,
-				"rate": 200,
-				"do_not_submit": True
-			}
-			po = create_purchase_order(**args)
-			po.items[0].work_breakdown_structure = wbs.name
-			po.save()
-
-			self.assertTrue(mock_msgprint.called)
-			msg_args, _ = mock_msgprint.call_args
-			self.assertIn("Available Budget Limit Exceeded", msg_args[0])
-
-			po.append(
-				"items",
-				{
-					"item_code": "_Test Item",
-					"rate": 200,
-					"qty": 1,
-					"warehouse": "_Test Warehouse - _TC",
-					"work_breakdown_structure": wbs_1.name
-				}
-			)
-			po.save()
-			self.assertTrue(mock_msgprint.called)
-			msg_args, _ = mock_msgprint.call_args
-			self.assertIn("Available Budget Limit Exceeded", msg_args[0])
-
-	@if_app_installed("projects")
-	def test_update_committed_overall_budge_TC_B_161(self):
-		project_name = "test_project" + frappe.generate_hash(length=5)
-		if not frappe.db.exists("Project",{"project_name": project_name}):
-			frappe.get_doc(
-				{
-					"doctype": "Project",
-					"company": "_Test Company",
-					"project_name": project_name,
-					"is_wbs": 1
-				}
-			).insert()
-
-		project = frappe.db.get_value("Project", {"project_name": project_name})
-
-		wbs = frappe.get_doc(
-			{
-				"doctype": "Work Breakdown Structure",
-				"project": project,
-				"wbs_name": "test_wbs",
-				"company": "_Test Company",
-				"gl_account": "Cash - _TC"
-			}
-		)
-		wbs.insert()
-		wbs.submit()
-
-		self.assertEqual(wbs.docstatus, 1)
-
-		zero_budget = frappe.get_doc(
-			{
-				"doctype": "Zero Budget",
-				"project": project,
-				"posting_date": today(),
-				"zero_budget_item": [
-					{
-						"wbs_element": wbs.name,
-						"zero_budget": 100
-					}
-				]
-			}
-		)
-		zero_budget.insert()
-		zero_budget.submit()
-
-		self.assertEqual(wbs.docstatus, 1)
-
-		args = {
-			"qty":1,
-			"rate": 200,
-			"do_not_submit": True
-		}
-		po = create_purchase_order(**args)
-		po.items[0].work_breakdown_structure = wbs.name
-		po.save()
-		po.submit()
-		self.assertEqual(po.docstatus, 1)
-
-		po.load_from_db()
-		po.cancel()
-
-	@if_app_installed("projects")
-	def test_locked_update_committed_overall_budget_TC_B_162(self):
-		project_name = "test_project" + frappe.generate_hash(length=5)
-		if not frappe.db.exists("Project",{"project_name": project_name}):
-			frappe.get_doc(
-				{
-					"doctype": "Project",
-					"company": "_Test Company",
-					"project_name": project_name,
-					"is_wbs": 1
-				}
+				{"doctype": "Project", "company": "_Test Company", "project_name": project_name, "is_wbs": 1}
 			).insert()
 
 		project = frappe.db.get_value("Project", {"project_name": project_name})
@@ -8760,12 +8656,122 @@ class TestPurchaseOrder(FrappeTestCase):
 				"doctype": "Zero Budget",
 				"project": project,
 				"posting_date": today(),
-				"zero_budget_item": [
-					{
-						"wbs_element": wbs.name,
-						"zero_budget": 100
-					}
-				]
+				"zero_budget_item": [{"wbs_element": wbs.name, "zero_budget": 100}],
+			}
+		)
+		zero_budget.insert()
+		zero_budget.submit()
+
+		self.assertEqual(wbs.docstatus, 1)
+
+		wbs.load_from_db()
+
+		wbs_1 = frappe.copy_doc(wbs)
+		wbs_1.insert()
+		wbs_1.submit()
+
+		with patch("frappe.msgprint") as mock_msgprint:
+			args = {"qty": 1, "rate": 200, "do_not_submit": True}
+			po = create_purchase_order(**args)
+			po.items[0].work_breakdown_structure = wbs.name
+			po.save()
+
+			self.assertTrue(mock_msgprint.called)
+			msg_args, _ = mock_msgprint.call_args
+			self.assertIn("Available Budget Limit Exceeded", msg_args[0])
+
+			po.append(
+				"items",
+				{
+					"item_code": "_Test Item",
+					"rate": 200,
+					"qty": 1,
+					"warehouse": "_Test Warehouse - _TC",
+					"work_breakdown_structure": wbs_1.name,
+				},
+			)
+			po.save()
+			self.assertTrue(mock_msgprint.called)
+			msg_args, _ = mock_msgprint.call_args
+			self.assertIn("Available Budget Limit Exceeded", msg_args[0])
+
+	@if_app_installed("projects")
+	def test_update_committed_overall_budge_TC_B_161(self):
+		project_name = "test_project" + frappe.generate_hash(length=5)
+		if not frappe.db.exists("Project", {"project_name": project_name}):
+			frappe.get_doc(
+				{"doctype": "Project", "company": "_Test Company", "project_name": project_name, "is_wbs": 1}
+			).insert()
+
+		project = frappe.db.get_value("Project", {"project_name": project_name})
+
+		wbs = frappe.get_doc(
+			{
+				"doctype": "Work Breakdown Structure",
+				"project": project,
+				"wbs_name": "test_wbs",
+				"company": "_Test Company",
+				"gl_account": "Cash - _TC",
+			}
+		)
+		wbs.insert()
+		wbs.submit()
+
+		self.assertEqual(wbs.docstatus, 1)
+
+		zero_budget = frappe.get_doc(
+			{
+				"doctype": "Zero Budget",
+				"project": project,
+				"posting_date": today(),
+				"zero_budget_item": [{"wbs_element": wbs.name, "zero_budget": 100}],
+			}
+		)
+		zero_budget.insert()
+		zero_budget.submit()
+
+		self.assertEqual(wbs.docstatus, 1)
+
+		args = {"qty": 1, "rate": 200, "do_not_submit": True}
+		po = create_purchase_order(**args)
+		po.items[0].work_breakdown_structure = wbs.name
+		po.save()
+		po.submit()
+		self.assertEqual(po.docstatus, 1)
+
+		po.load_from_db()
+		po.cancel()
+
+	@if_app_installed("projects")
+	def test_locked_update_committed_overall_budget_TC_B_162(self):
+		project_name = "test_project" + frappe.generate_hash(length=5)
+		if not frappe.db.exists("Project", {"project_name": project_name}):
+			frappe.get_doc(
+				{"doctype": "Project", "company": "_Test Company", "project_name": project_name, "is_wbs": 1}
+			).insert()
+
+		project = frappe.db.get_value("Project", {"project_name": project_name})
+
+		wbs = frappe.get_doc(
+			{
+				"doctype": "Work Breakdown Structure",
+				"project": project,
+				"wbs_name": "test_wbs",
+				"company": "_Test Company",
+				"gl_account": "Cash - _TC",
+			}
+		)
+		wbs.insert()
+		wbs.submit()
+
+		self.assertEqual(wbs.docstatus, 1)
+
+		zero_budget = frappe.get_doc(
+			{
+				"doctype": "Zero Budget",
+				"project": project,
+				"posting_date": today(),
+				"zero_budget_item": [{"wbs_element": wbs.name, "zero_budget": 100}],
 			}
 		)
 		zero_budget.insert()
@@ -8774,11 +8780,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		self.assertEqual(wbs.docstatus, 1)
 		frappe.db.set_value("Work Breakdown Structure", wbs.name, "locked", 1)
 
-		args = {
-			"qty":1,
-			"rate": 100,
-			"do_not_submit": True
-		}
+		args = {"qty": 1, "rate": 100, "do_not_submit": True}
 		po = create_purchase_order(**args)
 		po.items[0].work_breakdown_structure = wbs.name
 		po.save()
@@ -8800,14 +8802,9 @@ class TestPurchaseOrder(FrappeTestCase):
 	@if_app_installed("projects")
 	def test_locked_committed_overall_budget_mr_po_TC_B_163(self):
 		project_name = "test_project" + frappe.generate_hash(length=5)
-		if not frappe.db.exists("Project",{"project_name": project_name}):
+		if not frappe.db.exists("Project", {"project_name": project_name}):
 			frappe.get_doc(
-				{
-					"doctype": "Project",
-					"company": "_Test Company",
-					"project_name": project_name,
-					"is_wbs": 1
-				}
+				{"doctype": "Project", "company": "_Test Company", "project_name": project_name, "is_wbs": 1}
 			).insert()
 
 		project = frappe.db.get_value("Project", {"project_name": project_name})
@@ -8831,21 +8828,13 @@ class TestPurchaseOrder(FrappeTestCase):
 				"doctype": "Zero Budget",
 				"project": project,
 				"posting_date": today(),
-				"zero_budget_item": [
-					{
-						"wbs_element": wbs.name,
-						"zero_budget": 100
-					}
-				]
+				"zero_budget_item": [{"wbs_element": wbs.name, "zero_budget": 100}],
 			}
 		)
 		zero_budget.insert()
 		zero_budget.submit()
 
-		args = {
-			"qty": 1,
-			"rate": 100
-		}
+		args = {"qty": 1, "rate": 100}
 		mr = make_material_request(**args)
 		self.assertEqual(mr.docstatus, 1)
 
@@ -8871,11 +8860,8 @@ class TestPurchaseOrder(FrappeTestCase):
 
 	def test_validate_bom_for_subcontracting_items_TC_B_164(self):
 		item = make_test_item("__Test_item_")
-		frappe.db.set_value("Item",{"item_code": item.item_code}, "is_sub_contracted_item", 1)
-		args = {
-			"item_code": item.item_code,
-			"do_not_save": True
-		}
+		frappe.db.set_value("Item", {"item_code": item.item_code}, "is_sub_contracted_item", 1)
+		args = {"item_code": item.item_code, "do_not_save": True}
 		po = create_purchase_order(**args)
 		po.is_old_subcontracting_flow = 1
 		# Expecting validation error due to missing BOM
@@ -8890,22 +8876,23 @@ class TestPurchaseOrder(FrappeTestCase):
 		criteria = "test supplier cretiria"
 		supplier_name = "_Test Supplier"
 
-		setup_supplier_scorecard(supplier_name, criteria, [
-			{
-				"standing_name": "Very Poor",
-				"standing_color": "Red",
-				"min_grade": 0.00,
-				"max_grade": 100.00,
-				"prevent_pos": 1
-			}
-		])
+		setup_supplier_scorecard(
+			supplier_name,
+			criteria,
+			[
+				{
+					"standing_name": "Very Poor",
+					"standing_color": "Red",
+					"min_grade": 0.00,
+					"max_grade": 100.00,
+					"prevent_pos": 1,
+				}
+			],
+		)
 
 		frappe.db.set_value("Supplier", supplier_name, "prevent_pos", 1)
 
-		args = {
-			"supplier": supplier_name,
-			"do_not_save": True
-		}
+		args = {"supplier": supplier_name, "do_not_save": True}
 
 		po = create_purchase_order(**args)
 		with self.assertRaises(ValidationError) as e:
@@ -8913,29 +8900,30 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		self.assertIn(
 			"Purchase Orders are not allowed for _Test Supplier due to a scorecard standing of Very Poor.",
-			str(e.exception)
+			str(e.exception),
 		)
 
 	def test_validate_supplier_score_board_to_warn_po_TC_B_166(self):
 		criteria = "test supplier cretiria"
 		supplier_name = "_Test Supplier"
 
-		setup_supplier_scorecard(supplier_name, criteria, [
-			{
-				"standing_name": "Very Poor",
-				"standing_color": "Red",
-				"min_grade": 0.00,
-				"max_grade": 100.00,
-				"warn_pos": 1
-			}
-		])
+		setup_supplier_scorecard(
+			supplier_name,
+			criteria,
+			[
+				{
+					"standing_name": "Very Poor",
+					"standing_color": "Red",
+					"min_grade": 0.00,
+					"max_grade": 100.00,
+					"warn_pos": 1,
+				}
+			],
+		)
 
 		frappe.db.set_value("Supplier", supplier_name, "warn_pos", 1)
 
-		args = {
-			"supplier": supplier_name,
-			"do_not_submit": True
-		}
+		args = {"supplier": supplier_name, "do_not_submit": True}
 
 		po_warn = create_purchase_order(**args)
 		po_warn.submit()
@@ -8945,22 +8933,23 @@ class TestPurchaseOrder(FrappeTestCase):
 		item = make_test_item("__test_item")
 		item.is_stock_item = 0
 		item.save()
-		args = {
-			"item_code": item.item_code,
-			"do_not_save": True
-		}
+		args = {"item_code": item.item_code, "do_not_save": True}
 		po = create_purchase_order(**args)
 		po.is_subcontracted = 1
 		with self.assertRaises(frappe.exceptions.ValidationError) as e:
 			po.save()
 
-		self.assertIn("Row #1: Finished Good Item is not specified for service item __test_item", str(e.exception))
+		self.assertIn(
+			"Row #1: Finished Good Item is not specified for service item __test_item", str(e.exception)
+		)
 		frappe.db.set_value("Item", "_Test FG Item", "is_sub_contracted_item", 0)
 		po.items[0].fg_item = "_Test FG Item"
 		with self.assertRaises(frappe.exceptions.ValidationError) as e:
 			po.save()
 
-		self.assertIn("Row #1: Finished Good Item _Test FG Item must be a sub-contracted item", str(e.exception))
+		self.assertIn(
+			"Row #1: Finished Good Item _Test FG Item must be a sub-contracted item", str(e.exception)
+		)
 
 		frappe.db.set_value("Item", "_Test FG Item", "is_sub_contracted_item", 1)
 		frappe.db.set_value("Item", "_Test FG Item", "default_bom", "")
@@ -8987,9 +8976,7 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		self.assertIn("Not Permitted", str(context.exception))
 
-		args = {
-			"do_not_save": True
-		}
+		args = {"do_not_save": True}
 		po_1 = create_purchase_order(**args)
 		po_1.contact_email = frappe.session.user
 		po_1.save()
@@ -9033,19 +9020,13 @@ class TestPurchaseOrder(FrappeTestCase):
 			"service_item": item.item_code,
 			"finished_good_bom": "BOM-_Test FG Item-001",
 			"service_item_uom": "Nos",
-			"conversion_factor": 1
+			"conversion_factor": 1,
 		}
 		if not frappe.db.exists("Subcontracting BOM", filters):
-			sub_contracting_bom = frappe.get_doc({
-				"doctype": "Subcontracting BOM",
-				**filters
-			})
+			sub_contracting_bom = frappe.get_doc({"doctype": "Subcontracting BOM", **filters})
 			sub_contracting_bom.insert()
 
-		args = {
-			"item_code": item.item_code,
-			"do_not_save": True
-		}
+		args = {"item_code": item.item_code, "do_not_save": True}
 		po = create_purchase_order(**args)
 		po.is_subcontracted = 1
 		po.items[0].item_code = ""
@@ -9056,6 +9037,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		po.save()
 		po.submit()
 		self.assertEqual(po.docstatus, 1)
+
 
 def create_po_for_sc_testing():
 	from erpnext.controllers.tests.test_subcontracting_controller import (
@@ -9102,6 +9084,7 @@ def create_po_for_sc_testing():
 		is_subcontracted=1,
 		supplier_warehouse="_Test Warehouse 1 - _TC",
 	)
+
 
 def prepare_data_for_internal_transfer():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier
@@ -9153,6 +9136,7 @@ def make_pr_against_po(po, received_qty=0):
 	pr.submit()
 	return pr
 
+
 def make_return_pi(source_name):
 	from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import make_debit_note
 
@@ -9161,6 +9145,7 @@ def make_return_pi(source_name):
 	return_pi.insert()
 	return_pi.submit()
 	return return_pi
+
 
 def get_same_items():
 	return [
@@ -9255,11 +9240,12 @@ test_dependencies = ["BOM", "Item Price"]
 
 test_records = frappe.get_test_records("Purchase Order")
 
-def make_pi_against_pr(source_name, received_qty=0, item_dict_list = None, args = None):
 
-	doc_pi =  make_pi_from_pr(source_name)
-	if received_qty != 0: doc_pi.get("items")[0].qty = received_qty
-	
+def make_pi_against_pr(source_name, received_qty=0, item_dict_list=None, args=None):
+	doc_pi = make_pi_from_pr(source_name)
+	if received_qty != 0:
+		doc_pi.get("items")[0].qty = received_qty
+
 	if item_dict_list is not None:
 		for item in item_dict_list:
 			doc_pi.append("items", item)
@@ -9267,7 +9253,7 @@ def make_pi_against_pr(source_name, received_qty=0, item_dict_list = None, args 
 	if args:
 		args = frappe._dict(args)
 		doc_pi.update(args)
-	
+
 	pi = frappe.db.get_all("Purchase Invoice", fields=["name"])
 	if pi:
 		bill_no = len(pi) + 1
@@ -9279,23 +9265,25 @@ def make_pi_against_pr(source_name, received_qty=0, item_dict_list = None, args 
 	return doc_pi
 
 
-def make_pr_for_po(source_name, received_qty=0, item_dict_list = None):
+def make_pr_for_po(source_name, received_qty=0, item_dict_list=None):
 	doc_pr = make_purchase_receipt(source_name)
-	if received_qty != 0: doc_pr.get("items")[0].qty = received_qty
-	
+	if received_qty != 0:
+		doc_pr.get("items")[0].qty = received_qty
+
 	if item_dict_list is not None:
 		for item in item_dict_list:
 			doc_pr.append("items", item)
 
-	
 	doc_pr.insert()
 	doc_pr.submit()
 	return doc_pr
 
+
 def check_payment_gl_entries(
 	self,
 	voucher_no,
-	expected_gle,):
+	expected_gle,
+):
 	gle = frappe.qb.DocType("GL Entry")
 	gl_entries = (
 		frappe.qb.from_(gle)
@@ -9311,71 +9299,78 @@ def check_payment_gl_entries(
 		for field in ["account", "debit", "credit"]:
 			self.assertEqual(expected_gle[row][field], gl_entries[row][field])
 
+
 def create_taxes_interstate():
+	acc = frappe.new_doc("Account")
+	acc.account_name = "Input Tax CGST"
+	acc.parent_account = "Tax Assets - _TC"
+	acc.company = "_Test Company"
+	account_name_cgst = frappe.db.exists(
+		"Account", {"account_name": "Input Tax CGST", "company": "_Test Company"}
+	)
+	if not account_name_cgst:
+		account_name_cgst = acc.insert(ignore_permissions=True)
 
-		acc = frappe.new_doc("Account")
-		acc.account_name = "Input Tax CGST"
-		acc.parent_account = "Tax Assets - _TC"
-		acc.company = "_Test Company"
-		account_name_cgst = frappe.db.exists("Account", {"account_name" : "Input Tax CGST","company": "_Test Company" })
-		if not account_name_cgst:
-			account_name_cgst = acc.insert(ignore_permissions=True)
+	acc = frappe.new_doc("Account")
+	acc.account_name = "Input Tax SGST"
+	acc.parent_account = "Tax Assets - _TC"
+	acc.company = "_Test Company"
+	account_name_sgst = frappe.db.exists(
+		"Account", {"account_name": "Input Tax SGST", "company": "_Test Company"}
+	)
+	if not account_name_sgst:
+		account_name_sgst = acc.insert(ignore_permissions=True)
 
-		
-		acc = frappe.new_doc("Account")
-		acc.account_name = "Input Tax SGST"
-		acc.parent_account = "Tax Assets - _TC"
-		acc.company = "_Test Company"
-		account_name_sgst = frappe.db.exists("Account", {"account_name" : "Input Tax SGST","company": "_Test Company" })
-		if not account_name_sgst:
-			account_name_sgst = acc.insert(ignore_permissions=True)
-		
-		return [
+	return [
+		{
+			"charge_type": "On Net Total",
+			"account_head": account_name_cgst,
+			"rate": 9,
+			"description": "Input GST",
+		},
+		{
+			"charge_type": "On Net Total",
+			"account_head": account_name_sgst,
+			"rate": 9,
+			"description": "Input GST",
+		},
+	]
+
+
+def create_new_account(account_name, company, parent_account, account_type=None, tax_rate=None):
+	if not frappe.db.exists("Account", {"account_name": account_name, "company": company}):
+		account = frappe.get_doc(
 			{
-					"charge_type": "On Net Total",
-					"account_head": account_name_cgst,
-					"rate": 9,
-					"description": "Input GST",
-			},
-			{
-					"charge_type": "On Net Total",
-					"account_head": account_name_sgst,
-					"rate": 9,
-					"description": "Input GST",
+				"doctype": "Account",
+				"account_name": account_name,
+				"company": company,
+				"parent_account": parent_account,
+				"account_type": account_type,
+				"tax_rate": tax_rate,
 			}
-		]
-def create_new_account(account_name,company,parent_account, account_type = None, tax_rate = None):
-		if not frappe.db.exists("Account", {"account_name": account_name, "company": company}):
-			account = frappe.get_doc(
-				{
-					"doctype": "Account",
-					"account_name": account_name,
-					"company": company,
-					"parent_account": parent_account,
-					"account_type": account_type,
-					"tax_rate": tax_rate
-				}
-			)
-			account.insert(ignore_if_duplicate=1, ignore_permissions=True)
-			return account.name
+		)
+		account.insert(ignore_if_duplicate=1, ignore_permissions=True)
+		return account.name
 
-		else:
-			account = frappe.get_doc("Account", {"company": company, "account_name": account_name})
-			return account.name
+	else:
+		account = frappe.get_doc("Account", {"company": company, "account_name": account_name})
+		return account.name
+
 
 def create_company():
 	company_name = "_Test Company PO"
 	if not frappe.db.exists("Company", company_name):
 		company = frappe.new_doc("Company")
 		company.company_name = company_name
-		company.country="India",
-		company.default_currency= "INR",
-		company.create_chart_of_accounts_based_on= "Standard Template",
-		company.chart_of_accounts= "Standard",
+		company.country = ("India",)
+		company.default_currency = ("INR",)
+		company.create_chart_of_accounts_based_on = ("Standard Template",)
+		company.chart_of_accounts = ("Standard",)
 		company = company.save()
 		company.load_from_db()
 
 	return company_name
+
 
 def create_fiscal_year():
 	today = date.today()
@@ -9386,19 +9381,20 @@ def create_fiscal_year():
 		start_date = date(today.year - 1, 4, 1)
 		end_date = date(today.year, 3, 31)
 
-	company="_Test Company PO", 
+	company = ("_Test Company PO",)
 	fy_doc = frappe.new_doc("Fiscal Year")
 	fy_doc.year = "2025 PO"
 	fy_doc.year_start_date = start_date
 	fy_doc.year_end_date = end_date
 	fy_doc.append("companies", {"company": company})
 	fy_doc.submit()
-	
-def make_test_po(source_name, type = "Material Request", received_qty = 0, item_dict = None):
+
+
+def make_test_po(source_name, type="Material Request", received_qty=0, item_dict=None):
 	if type == "Material Request":
 		doc_po = make_purchase_order(source_name)
 
-	if type == 'Supplier Quotation':
+	if type == "Supplier Quotation":
 		doc_po = create_po_aganist_sq(source_name)
 
 	if doc_po.supplier is None:
@@ -9415,7 +9411,8 @@ def make_test_po(source_name, type = "Material Request", received_qty = 0, item_
 	doc_po.submit()
 	return doc_po
 
-def make_test_pr(source_name, received_qty = None, item_dict = None):
+
+def make_test_pr(source_name, received_qty=None, item_dict=None):
 	doc_pr = make_purchase_receipt_aganist_mr(source_name)
 
 	if received_qty is not None:
@@ -9428,7 +9425,8 @@ def make_test_pr(source_name, received_qty = None, item_dict = None):
 	doc_pr.submit()
 	return doc_pr
 
-def make_test_pi(source_name, received_qty = None, item_dict = None):
+
+def make_test_pi(source_name, received_qty=None, item_dict=None):
 	doc_pi = make_purchase_invoice(source_name)
 	if received_qty is not None:
 		doc_pi.items[0].qty = received_qty
@@ -9440,15 +9438,16 @@ def make_test_pi(source_name, received_qty = None, item_dict = None):
 	doc_pi.submit()
 	return doc_pi
 
+
 def make_test_rfq(source_name, received_qty=0):
 	doc_rfq = make_request_for_quotation(source_name)
 
-	supplier_data=[
-				{
-					"supplier": "_Test Supplier",
-					"email_id": "123_testrfquser@example.com",
-				}
-			]
+	supplier_data = [
+		{
+			"supplier": "_Test Supplier",
+			"email_id": "123_testrfquser@example.com",
+		}
+	]
 	doc_rfq.append("suppliers", supplier_data[0])
 	doc_rfq.message_for_supplier = "Please supply the specified items at the best possible rates."
 
@@ -9459,8 +9458,9 @@ def make_test_rfq(source_name, received_qty=0):
 	doc_rfq.submit()
 	return doc_rfq
 
-def make_test_sq(source_name, rate = 0, received_qty=0):
-	doc_sq = make_supplier_quotation_from_rfq(source_name, for_supplier = "_Test Supplier")
+
+def make_test_sq(source_name, rate=0, received_qty=0):
+	doc_sq = make_supplier_quotation_from_rfq(source_name, for_supplier="_Test Supplier")
 
 	if received_qty:
 		doc_sq.items[0].qty = received_qty
@@ -9471,21 +9471,24 @@ def make_test_sq(source_name, rate = 0, received_qty=0):
 	doc_sq.submit()
 	return doc_sq
 
-def get_shipping_rule_name(args = None):
+
+def get_shipping_rule_name(args=None):
 	from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
+
 	doc_shipping_rule = create_shipping_rule("Buying", "_Test Shipping Rule -TC", args)
 	return doc_shipping_rule.name
 
-def make_payment_entry(dt, dn, paid_amount, args = None):
 
+def make_payment_entry(dt, dn, paid_amount, args=None):
 	doc_pe = get_payment_entry(dt, dn, paid_amount)
-	
-	args =  frappe._dict() if args is None else frappe._dict(args)
+
+	args = frappe._dict() if args is None else frappe._dict(args)
 	doc_pe.mode_of_payment = args.mode_of_payment or None
-	doc_pe.reference_no =  args.reference_no or "Test Reference"
-	
+	doc_pe.reference_no = args.reference_no or "Test Reference"
+
 	doc_pe.submit()
 	return doc_pe
+
 
 def make_pi_direct_aganist_po(source_name):
 	doc_pi = make_pi_from_po(source_name)
@@ -9494,15 +9497,19 @@ def make_pi_direct_aganist_po(source_name):
 	doc_pi.submit()
 	return doc_pi
 
+
 def make_pr_form_pi(source_name):
 	from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import make_purchase_receipt
+
 	doc_pi = make_purchase_receipt(source_name)
 	doc_pi.insert()
 	doc_pi.submit()
 	return doc_pi
 
+
 def create_company_and_suppliers():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import get_active_fiscal_year
+
 	fiscal_year = get_active_fiscal_year()
 	company = "_Test company with other country address"
 	supplier = "Test supplier for other country address"
@@ -9514,31 +9521,28 @@ def create_company_and_suppliers():
 				"abbr": "-TCNI_",
 				"default_currency": "INR",
 				"country": "India",
-				"gst_category": "Unregistered"
+				"gst_category": "Unregistered",
 			}
 		)
 		company.insert()
 
 		add_company_fiscal_year = frappe.get_doc("Fiscal Year", fiscal_year)
-		add_company_fiscal_year.append("companies",{"company": company})
+		add_company_fiscal_year.append("companies", {"company": company})
 		add_company_fiscal_year.save()
 
-		company_address = frappe.get_doc({
-			"doctype": "Address",
-			"address_type": "Billing",
-			"address_line1": "30 Pitt Street, Sydney Harbour Marriott",
-			"country": "Australia",
-			"city": "Sydney",
-			"pincode": "2000",
-			"gst_category": "Overseas",
-			"is_your_company_address":1,
-			"links": [
-				{
-					"link_doctype": "Company",
-					"link_name": company
-				}
-			],
-		})
+		company_address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_type": "Billing",
+				"address_line1": "30 Pitt Street, Sydney Harbour Marriott",
+				"country": "Australia",
+				"city": "Sydney",
+				"pincode": "2000",
+				"gst_category": "Overseas",
+				"is_your_company_address": 1,
+				"links": [{"link_doctype": "Company", "link_name": company}],
+			}
+		)
 		company_address.insert()
 
 	if not frappe.db.exists("Supplier", supplier):
@@ -9548,7 +9552,7 @@ def create_company_and_suppliers():
 				"supplier_name": "Test supplier for other country address",
 				"country": "India",
 				"supplier_type": "Company",
-				"place": "Hyderabad"
+				"place": "Hyderabad",
 			}
 		)
 		supplier.insert()
@@ -9563,49 +9567,42 @@ def create_company_and_suppliers():
 				"country": "Australia",
 				"pincode": 2000,
 				"gst_category": "Overseas",
-				"links": [
-					{
-						"link_doctype": "Supplier",
-						"link_name": supplier
-					}
-				]
+				"links": [{"link_doctype": "Supplier", "link_name": supplier}],
 			}
 		)
 		supplier_address.insert()
 	company_name = frappe.get_doc("Company", company)
 	supplier_name = frappe.get_doc("Supplier", supplier)
-	
-	return {
-		"company": company_name.name,
-		"supplier": supplier_name.name
-	}
+
+	return {"company": company_name.name, "supplier": supplier_name.name}
+
 
 def get_item_tax_template(company, tax_template, rate):
 	if not frappe.db.exists(tax_template):
 		get_company = create_data()
-		parent_sgst = create_new_account(
-			account_name = "Input Tax SGST",
-			company = get_company.get("parent_company"),
-			parent_account = "Tax Assets - TC-1",
-			account_type = "Tax"
+		create_new_account(
+			account_name="Input Tax SGST",
+			company=get_company.get("parent_company"),
+			parent_account="Tax Assets - TC-1",
+			account_type="Tax",
 		)
-		parent_cgst = create_new_account(
-			account_name = "Input Tax CGST",
-			company = get_company.get("parent_company"),
-			parent_account = "Tax Assets - TC-1",
-			account_type = "Tax"
+		create_new_account(
+			account_name="Input Tax CGST",
+			company=get_company.get("parent_company"),
+			parent_account="Tax Assets - TC-1",
+			account_type="Tax",
 		)
 		account_cgst = create_new_account(
-			account_name = "Input Tax CGST",
-			company = company,
-			parent_account = "Tax Assets - TC-3",
-			account_type = "Tax"
+			account_name="Input Tax CGST",
+			company=company,
+			parent_account="Tax Assets - TC-3",
+			account_type="Tax",
 		)
 		account_sgst = create_new_account(
-			account_name = "Input Tax SGST",
-			company = company,
-			parent_account = "Tax Assets - TC-3",
-			account_type = "Tax"
+			account_name="Input Tax SGST",
+			company=company,
+			parent_account="Tax Assets - TC-3",
+			account_type="Tax",
 		)
 		tax_template = frappe.get_doc(
 			{
@@ -9615,51 +9612,34 @@ def get_item_tax_template(company, tax_template, rate):
 				"gst_treatment": "Taxable",
 				"gst_rate": rate,
 				"taxes": [
-					{
-						"tax_type": account_cgst,
-						"tax_rate": rate/2
-					},
-					{
-						"tax_type": account_sgst,
-						"tax_rate": rate/2
-					},
-				]
+					{"tax_type": account_cgst, "tax_rate": rate / 2},
+					{"tax_type": account_sgst, "tax_rate": rate / 2},
+				],
 			}
 		)
 		tax_template.insert(ignore_if_duplicate=True)
 
 		return tax_template.name
 
+
 def create_quality_inspection_template(template):
 	if not frappe.db.exists("Quality Inspection Template", template):
 		qi_template = frappe.get_doc(
 			{
-				"doctype":"Quality Inspection Template",
+				"doctype": "Quality Inspection Template",
 				"quality_inspection_template_name": template,
-				"item_quality_inspection_parameter":[
-					{
-						"specification":"Needle Shape",
-						"value":"OK"
-					},
-					{
-						"specification":"Syringe Shape",
-						"value":"OK"
-					},
-					{
-						"specification":"Plastic Clarity",
-						"value":"OK"
-					},
-					{
-						"specification":"Syringe Length",
-						"min_value":4,
-						"max_value":6
-					},
-				]
+				"item_quality_inspection_parameter": [
+					{"specification": "Needle Shape", "value": "OK"},
+					{"specification": "Syringe Shape", "value": "OK"},
+					{"specification": "Plastic Clarity", "value": "OK"},
+					{"specification": "Syringe Length", "min_value": 4, "max_value": 6},
+				],
 			}
 		)
 		qi_template.insert(ignore_if_duplicate=True)
 		return qi_template.name
-	
+
+
 def get_tax_template(company, tax_template, rate):
 	if not frappe.db.exists(tax_template):
 		tax_template = frappe.get_doc(
@@ -9670,37 +9650,39 @@ def get_tax_template(company, tax_template, rate):
 				"gst_treatment": "Taxable",
 				"gst_rate": rate,
 				"taxes": [
-					{
-						"tax_type": "Input Tax CGST - _TC",
-						"tax_rate": rate/2
-					},
-					{
-						"tax_type": "Input Tax SGST - _TC",
-						"tax_rate": rate/2
-					},
-				]
+					{"tax_type": "Input Tax CGST - _TC", "tax_rate": rate / 2},
+					{"tax_type": "Input Tax SGST - _TC", "tax_rate": rate / 2},
+				],
 			}
 		)
 		tax_template.insert(ignore_if_duplicate=True)
 
 		return tax_template.name
-	
+
+
 def get_gl_entries(voucher_no):
-	return frappe.get_all("GL Entry", filters={"voucher_no": voucher_no}, fields=["account", "debit", "credit"])
+	return frappe.get_all(
+		"GL Entry", filters={"voucher_no": voucher_no}, fields=["account", "debit", "credit"]
+	)
 
 
 def get_sle(voucher_no):
-	return frappe.get_all("Stock Ledger Entry", filters={"voucher_no": voucher_no}, fields=['actual_qty', 'item_code'])
+	return frappe.get_all(
+		"Stock Ledger Entry", filters={"voucher_no": voucher_no}, fields=["actual_qty", "item_code"]
+	)
+
 
 def validate_fiscal_year(company):
 	from erpnext.accounts.utils import get_fiscal_year
+
 	year = get_fiscal_year(today())
-	if len(year) >1:
+	if len(year) > 1:
 		fiscal_year = frappe.get_doc("Fiscal Year", year[0])
 		company_list = {d.company for d in fiscal_year.companies}
 		if company not in company_list:
 			fiscal_year.append("companies", {"company": company})
 			fiscal_year.save()
+
 
 def create_fiscal_with_company(company):
 	today = date.today()
@@ -9718,46 +9700,63 @@ def create_fiscal_with_company(company):
 	fy_doc.append("companies", {"company": company})
 	fy_doc.submit()
 
+
 def get_or_create_fiscal_year(company):
-	from datetime import datetime, date
+	from datetime import date, datetime
+
 	import frappe
 
 	current_date = datetime.today().date()
-	existing_fy = frappe.get_all(
-		"Fiscal Year",
-		filters={"disabled": 0},
-		fields=["name", "year_start_date", "year_end_date"]
-	)
-	updated_existing_fy = None
-	for d in existing_fy:
-		start_date = d.year_start_date.date() if isinstance(d.year_start_date, datetime) else d.year_start_date
-		end_date = d.year_end_date.date() if isinstance(d.year_end_date, datetime) else d.year_end_date
-		if start_date <= current_date <= end_date:
-			updated_existing_fy = d.name
-			break
 
+	matching_fy_list = frappe.get_all(
+		"Fiscal Year",
+		filters={
+			"disabled": 0,
+			"year_start_date": ["<=", current_date],
+			"year_end_date": [">=", current_date],
+		},
+		fields=["name", "year_start_date", "year_end_date"],
+	)
 	is_company = False
-	if updated_existing_fy:
-		fiscal_year = frappe.get_doc("Fiscal Year", updated_existing_fy)
-		for years in fiscal_year.companies:
-			if years.company == company:
-				is_company = True
+	if len(matching_fy_list) > 0:
+		for fy in matching_fy_list:
+			fiscal_year = frappe.get_doc("Fiscal Year", fy["name"])
+			for years in fiscal_year.companies:
+				if years.company == company:
+					is_company = True
+					break
+			if is_company:
+				break
+
 		if not is_company:
-			fiscal_year.append("companies", {"company": company})
-			fiscal_year.save()
+			for rows in matching_fy_list:
+				try:
+					fiscal_year = frappe.get_doc("Fiscal Year", rows.name)
+					fiscal_year.append("companies", {"company": company})
+					fiscal_year.save()
+					break
+				except Exception as e:
+					print(f"Failed to get Fiscal Year {fy['name']}: {e}")
+					continue
+
 	else:
-		current_year = datetime.now().year
+		# No fiscal year includes current date — create a new one
+		current_year = current_date.year
 		first_date = date(current_year, 1, 1)
 		last_date = date(current_year, 12, 31)
+
 		fiscal_year = frappe.new_doc("Fiscal Year")
 		fiscal_year.year = f"{current_year}-{company}"
 		fiscal_year.year_start_date = first_date
 		fiscal_year.year_end_date = last_date
+		fiscal_year.company = company  # Required to avoid overlap error
 		fiscal_year.append("companies", {"company": company})
 		fiscal_year.save()
 
+
 def get_company_or_supplier():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import get_active_fiscal_year
+
 	fiscal_year = get_active_fiscal_year()
 	company = "Test Company-5566"
 	supplier = "Test Supplier-5566"
@@ -9765,12 +9764,7 @@ def get_company_or_supplier():
 
 	if not frappe.db.exists("Company", company):
 		frappe.get_doc(
-			{
-				"doctype": "Company",
-				"company_name": company,
-				"abbr": "TC-5",
-				"default_currency": "INR"
-			}
+			{"doctype": "Company", "company_name": company, "abbr": "TC-5", "default_currency": "INR"}
 		).insert()
 
 	fiscal_year_doc = frappe.get_doc("Fiscal Year", fiscal_year)
@@ -9786,7 +9780,7 @@ def get_company_or_supplier():
 				"doctype": "Supplier",
 				"supplier_name": supplier,
 				"supplier_type": "Individual",
-				"country": "India"
+				"country": "India",
 			}
 		).insert()
 
@@ -9797,16 +9791,12 @@ def get_company_or_supplier():
 				"customer_name": customer,
 				"customer_type": "Individual",
 				"customer_group": "All Customer Groups",
-				"territory": "All Territories"
+				"territory": "All Territories",
 			}
 		).insert()
 
+	return {"company": company, "supplier": supplier, "customer": customer}
 
-	return {
-		"company": company,
-		"supplier": supplier,
-		"customer": customer
-	}
 
 def create_or_get_purchase_taxes_template(company):
 	sgst_account = "Input Tax SGST - TC-5"
@@ -9814,91 +9804,93 @@ def create_or_get_purchase_taxes_template(company):
 	purchase_template = "Input GST In-state - TC-5"
 	tax_category = "In-State"
 	if not frappe.db.exists("Tax Category", tax_category):
-		tax_category = frappe.get_doc(
-			{
-				"doctype": "Tax Category",
-				"title": tax_category
-			}
-		).insert().name
+		tax_category = frappe.get_doc({"doctype": "Tax Category", "title": tax_category}).insert().name
 
 	if not frappe.db.exists("Account", sgst_account):
 		sgst_account = create_new_account(
-			account_name = "Input Tax SGST",
-			company = company,
-			parent_account = "Tax Assets - TC-5",
-			account_type = "Tax",
+			account_name="Input Tax SGST",
+			company=company,
+			parent_account="Tax Assets - TC-5",
+			account_type="Tax",
 		)
 
 	if not frappe.db.exists("Account", cgst_account):
 		cgst_account = create_new_account(
-			account_name = "Input Tax CGST",
-			company = company,
-			parent_account = "Tax Assets - TC-5",
-			account_type = "Tax",
+			account_name="Input Tax CGST",
+			company=company,
+			parent_account="Tax Assets - TC-5",
+			account_type="Tax",
 		)
 
 	if not frappe.db.exists("Purchase Taxes and Charges Template", purchase_template):
-		purchase_template = frappe.get_doc(
-			{
-				"doctype": "Purchase Taxes and Charges Template",
-				"title": "Input GST In-state",
-				"company": company,
-				"tax_category": tax_category,
-				"taxes": [
-					{
-						"charge_type": "On Net Total",
-						"add_deduct_tax": "Add",
-						"category": "Total",
-						"rate": 9,
-						"account_head": sgst_account,
-						"description": "SGST"
-					},
-					{
-						"charge_type": "On Net Total",
-						"add_deduct_tax": "Add",
-						"category": "Total",
-						"rate": 9,
-						"account_head": cgst_account,
-						"description": "CGST"
-					}
-				]
-			}
-		).insert().name
+		purchase_template = (
+			frappe.get_doc(
+				{
+					"doctype": "Purchase Taxes and Charges Template",
+					"title": "Input GST In-state",
+					"company": company,
+					"tax_category": tax_category,
+					"taxes": [
+						{
+							"charge_type": "On Net Total",
+							"add_deduct_tax": "Add",
+							"category": "Total",
+							"rate": 9,
+							"account_head": sgst_account,
+							"description": "SGST",
+						},
+						{
+							"charge_type": "On Net Total",
+							"add_deduct_tax": "Add",
+							"category": "Total",
+							"rate": 9,
+							"account_head": cgst_account,
+							"description": "CGST",
+						},
+					],
+				}
+			)
+			.insert()
+			.name
+		)
 
 	return {
 		"purchase_tax_template": purchase_template,
 		"sgst_account": sgst_account,
-		"cgst_account": cgst_account
+		"cgst_account": cgst_account,
 	}
+
 
 def remove_existing_shipping_rules():
 	existing_shipping_rules = frappe.get_all("Shipping Rule", pluck="name")
 	for rule in existing_shipping_rules:
 		frappe.delete_doc("Shipping Rule", rule, force=1)
 
+
 def _make_blanket_order(**args):
 	from erpnext.manufacturing.doctype.blanket_order.test_blanket_order import make_blanket_order
+
 	return make_blanket_order(**args)
+
 
 def setup_supplier_scorecard(supplier_name, criteria_name, standing_options):
 	if not frappe.db.exists("Supplier Scorecard Criteria", criteria_name):
-		frappe.get_doc({
-			"doctype": "Supplier Scorecard Criteria",
-			"criteria_name": criteria_name,
-			"max_score": 100,
-			"formula": "10",
-		}).insert(ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard Criteria",
+				"criteria_name": criteria_name,
+				"max_score": 100,
+				"formula": "10",
+			}
+		).insert(ignore_permissions=True)
 
 	if not frappe.db.exists("Supplier Scorecard", supplier_name):
-		frappe.get_doc({
-			"doctype": "Supplier Scorecard",
-			"supplier": supplier_name,
-			"period": "Per Week",
-			"standings": standing_options,
-			"criteria": [
-				{
-					"criteria_name": criteria_name,
-					"weight": 100
-				}
-			]
-		}).insert(ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": "Supplier Scorecard",
+				"supplier": supplier_name,
+				"period": "Per Week",
+				"standings": standing_options,
+				"criteria": [{"criteria_name": criteria_name, "weight": 100}],
+			}
+		).insert(ignore_permissions=True)

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -8350,37 +8350,49 @@ def get_or_create_fiscal_year(company):
 	import frappe
 
 	current_date = datetime.today().date()
-	existing_fy = frappe.get_all(
-		"Fiscal Year", filters={"disabled": 0}, fields=["name", "year_start_date", "year_end_date"]
+
+	matching_fy_list = frappe.get_all(
+		"Fiscal Year",
+		filters={
+			"disabled": 0,
+			"year_start_date": ["<=", current_date],
+			"year_end_date": [">=", current_date],
+		},
+		fields=["name", "year_start_date", "year_end_date"],
 	)
-	updated_existing_fy = None
-
-	for d in existing_fy:
-		start_date = (
-			d.year_start_date.date() if isinstance(d.year_start_date, datetime) else d.year_start_date
-		)
-		end_date = d.year_end_date.date() if isinstance(d.year_end_date, datetime) else d.year_end_date
-		if start_date <= current_date <= end_date:
-			updated_existing_fy = d.name
-			break
-
 	is_company = False
-	if updated_existing_fy:
-		fiscal_year = frappe.get_doc("Fiscal Year", updated_existing_fy)
-		for years in fiscal_year.companies:
-			if years.company == company:
-				is_company = True
+	if len(matching_fy_list) > 0:
+		for fy in matching_fy_list:
+			fiscal_year = frappe.get_doc("Fiscal Year", fy["name"])
+			for years in fiscal_year.companies:
+				if years.company == company:
+					is_company = True
+					break
+			if is_company:
+				break
+
 		if not is_company:
-			fiscal_year.append("companies", {"company": company})
-			fiscal_year.save()
+			for rows in matching_fy_list:
+				try:
+					fiscal_year = frappe.get_doc("Fiscal Year", rows.name)
+					fiscal_year.append("companies", {"company": company})
+					fiscal_year.save()
+					break
+				except Exception as e:
+					print(f"Failed to get Fiscal Year {fy['name']}: {e}")
+					continue
+
 	else:
-		current_year = datetime.now().year
+		# No fiscal year includes current date — create a new one
+		current_year = current_date.year
 		first_date = date(current_year, 1, 1)
 		last_date = date(current_year, 12, 31)
+
 		fiscal_year = frappe.new_doc("Fiscal Year")
 		fiscal_year.year = f"{current_year}-{company}"
 		fiscal_year.year_start_date = first_date
 		fiscal_year.year_end_date = last_date
+		fiscal_year.company = company  # Required to avoid overlap error
 		fiscal_year.append("companies", {"company": company})
 		fiscal_year.save()
 


### PR DESCRIPTION
### Bug Description
- Running tests that involve get_or_create_fiscal_year("_Test Company") throws a frappe.exceptions.NameError due to overlapping fiscal year dates already existing in the system.

### Root Cause
- The test attempts to create a new Fiscal Year document with start and end dates that overlap with an existing fiscal year for the same company (_Test Company).
- ERPNext has a built-in validation to prevent overlapping fiscal years, which triggers an exception during the .save() operation.

### Expected Result
- The fiscal year should be created only if one doesn't already exist for the specified date range and company.
- Tests should run smoothly without conflict with previously created fiscal years.

### Actual Result
- The test fails with a traceback:
  frappe.exceptions.NameError: Year start date or end date is overlapping with 2025. To avoid please set company
- This prevents tests from running and halts CI/CD pipelines or local testing.

### Fix Summary
- Modified the logic in get_or_create_fiscal_year() to check for existing fiscal years with overlapping dates before creating a new one.


### Affected Module
- Accounts → Fiscal Year
- Stock Ledger Entry Tests

### Issue Id:
#2646 
