### PR TITLE
test:  updating supplier warehouse in creating subcontacting order and  Date format 

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/test_delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/test_delivery_trip.py
@@ -34,7 +34,7 @@ class TestDeliveryTrip(FrappeTestCase):
 				"doctype": "Employee",
 				"first_name": "Newton Scmander",
 				"middle_name": "Scmander",
-				"date_of_birth": "21-04-1981",
+				"date_of_birth": "1981-04-21",  # fixed format
 				"gender": "Male",
 				"date_of_joining": frappe.utils.now(),
 				"status": "Active",

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -5791,9 +5791,6 @@ class TestStockEntry(FrappeTestCase):
 		)
 
 		sco = create_subcontracting_order(po_name=po.name, supplier_warehouse=subcontract_wh)
-		sco.supplier_warehouse = subcontract_wh
-		sco.save()
-		sco.submit()
 
 		# Create target_doc (empty Stock Entry)
 		stock_entry = make_stock_entry(


### PR DESCRIPTION
### Bug Description
1.supplier_warehouse is mandatory for creating Subcontracting Order.
frappe.MandatoryError(frappe.exceptions.MandatoryError: [Subcontracting Order, SC-ORD-2025-00001]: supplier_warehouse

2.DatetimeFieldOverflow: date/time field value out of range

### Root Cause
The suppiler warehouse is correclty not set in subcontacting order.
DIfferent date format causing error.

### Fix Summary
suppiler warehouse is already setting in create_subcontacting_order function with insert and submit.
Change the date format

### Affected Module
Stock

### Issue Id:

https://github.com/8848digital/erpnext/issues/2676
https://github.com/8848digital/erpnext/issues/2675