### PR TITLE
fix: Resolving supplier duplication entry

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -196,14 +196,14 @@ class TestRequestforQuotation(FrappeTestCase):
 
 	def test_get_supplier_email_preview_TC_B_194(self):
 		item_code = "_Test Item"
-		supplier_name = "Test Supplier for RFQ"
+		supplier_name = "_Test Supplier"
 		if not frappe.db.exists("Item", item_code):
 			make_item(item_code, {"stock_uom": "Nos"})
 		if not frappe.db.exists({"doctype": "Supplier", "supplier_name": supplier_name}):
 			supplier_doc = frappe.get_doc(
 				{
 					"doctype": "Supplier",
-					"supplier_name": "Test Supplier for RFQ",
+					"supplier_name": "_Test Supplier",
 					"supplier_group": "_Test Supplier Group",
 				}
 			).insert()


### PR DESCRIPTION
TC_B_194 - test_get_supplier_email_preview_TC_B_194

Issue:
This test case was effecting to fail test_portal_user_with_new_supplier with a DuplicateEntryError due to an attempt to insert a Supplier record (Test Supplier for RFQ) that already existed in the database.

Root Cause:
No validation was in place to check if the supplier already existed before attempting to insert it.

Fix Summary:

Modified Supplier to _Test Supplier

Expected Outcome:
Test should pass by previewing the correct email content without causing any unique constraint violations.

Affected Module:
Buying

Reference PR:

#2619