### PR TITLE
test: Fixed assertEqual as it was checking with objects instead of name

### DIFF
--- a/erpnext/stock/doctype/putaway_rule/test_putaway_rule.py
+++ b/erpnext/stock/doctype/putaway_rule/test_putaway_rule.py
@@ -119,7 +119,7 @@ class TestPutawayRule(FrappeTestCase):
 		]
 
 		apply_putaway_rule("Putaway Rule", items, company, purpose="Stock Entry")
-		self.assertEqual(items[0]["item_code"], item_code)
+		self.assertEqual(items[0]["item_code"].name, item_code.name)
 		self.assertEqual(items[0]["qty"], 1)
 
 	def assertUnchangedItemsOnResave(self, doc):


### PR DESCRIPTION
**Title**:
Putaway Rule — Fixed assertEqual as it was checking with objects instead of name

**Description**:
Test Summary:
This test ensures that the Putaway Rule logic correctly applies item placement rules within the warehouse. The focus is on verifying that the system accurately matches the expected item_code and its associated object when rules are applied.

A key correction in this test case was made to compare the actual item_code.name instead of the object itself during assertion. This prevents false negatives when comparing serialized fields versus document objects.

**Doctype Covered:**
Putaway Rule

**Test Case Implemented:**
🔸 TC-SCK-413: test_apply_putaway_rule_TC_SCK_413
Tests the correct application of Putaway Rule logic by asserting that the returned item matches the expected item name.

Expected Results:

items[0]["item_code"] returns the correct item code

items[0]["item_code"].name returns the same value as item_code.name

**Key Enhancements:**
Corrected assertion logic to compare item name strings instead of document object references

Improved test reliability by explicitly asserting the .name attribute of linked item document

Ensured clarity in validation logic for future maintainability

**Scenarios Covered:**
Validation of item assignment through putaway rules

Accurate matching of expected item code vs. document name

Prevention of assertion mismatches due to object vs. string comparison

**Technology Used:**
Python unittest framework

**Frappe utilities:**

frappe.get_doc, frappe.db.exists

make_test_item, create_customer

**Assertion methods:**

self.assertEqual() for comparing item names

**Linked Feature/Bug:**
https://github.com/8848digital/erpnext/pull/2644

**Issue ID:**
https://github.com/8848digital/erpnext/pull/2644