### PR TITLE
test: Add pragma no-cover to type checking blocks for doctypes

### DIFF
--- a/erpnext/accounts/doctype/customer_group_item/customer_group_item.py
+++ b/erpnext/accounts/doctype/customer_group_item/customer_group_item.py
@@ -11,7 +11,7 @@ class CustomerGroupItem(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		customer_group: DF.Link | None

--- a/erpnext/accounts/doctype/customer_item/customer_item.py
+++ b/erpnext/accounts/doctype/customer_item/customer_item.py
@@ -11,7 +11,7 @@ class CustomerItem(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		customer: DF.Link | None

--- a/erpnext/accounts/doctype/discount_terms/discount_terms.py
+++ b/erpnext/accounts/doctype/discount_terms/discount_terms.py
@@ -11,7 +11,7 @@ class DiscountTerms(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		discount: DF.Float

--- a/erpnext/accounts/doctype/discounted_invoice/discounted_invoice.py
+++ b/erpnext/accounts/doctype/discounted_invoice/discounted_invoice.py
@@ -12,7 +12,7 @@ class DiscountedInvoice(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		customer: DF.Link | None

--- a/erpnext/accounts/doctype/distribution_percentage/distribution_percentage.py
+++ b/erpnext/accounts/doctype/distribution_percentage/distribution_percentage.py
@@ -11,12 +11,26 @@ class DistributionPercentage(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		allocation: DF.Percent
 		budget: DF.Currency
-		month: DF.Literal["", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+		month: DF.Literal[
+			"",
+			"January",
+			"February",
+			"March",
+			"April",
+			"May",
+			"June",
+			"July",
+			"August",
+			"September",
+			"October",
+			"November",
+			"December",
+		]
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -27,7 +27,7 @@ class Dunning(AccountsController):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.overdue_payment.overdue_payment import OverduePayment

--- a/erpnext/accounts/doctype/dunning_letter_text/dunning_letter_text.py
+++ b/erpnext/accounts/doctype/dunning_letter_text/dunning_letter_text.py
@@ -12,7 +12,7 @@ class DunningLetterText(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		body_text: DF.TextEditor | None

--- a/erpnext/accounts/doctype/dunning_type/dunning_type.py
+++ b/erpnext/accounts/doctype/dunning_type/dunning_type.py
@@ -12,7 +12,7 @@ class DunningType(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.dunning_letter_text.dunning_letter_text import DunningLetterText


### PR DESCRIPTION
### Title:
Add pragma no-cover to type checking blocks for doctypes

### Test Summary:
No test written just  Add pragma no-cover to type checking blocks for doctypes

### Doctypes Covered:
customer_group_item
customer_item
discount_terms
discounted_invoice
distribution_percentage
dunning
dunning_letter_text
dunning_type