### PR TITLE
test: Fixed MandatoryError for supplier_warehouse and item gst_hsn code error.

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -5061,7 +5061,12 @@ class TestStockEntry(FrappeTestCase):
 		item = make_item("Test Item", {"stock_uom": "Nos", "is_stock_item": 1})
 		if not item.has_batch_no:
 			item.has_batch_no = 1
-			item.save()
+
+		# if gst_hsn_code is not set in item
+		if not item.gst_hsn_code:
+			item.gst_hsn_code = "100111"
+
+		item.save()
 
 		# Also insert the corresponding batch
 		if not frappe.db.exists("Batch", "TEST-BATCH-001"):

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -5763,6 +5763,7 @@ class TestStockEntry(FrappeTestCase):
 				"schedule_date": frappe.utils.nowdate(),
 				"is_subcontracted": 1,
 				"subcontracting_type": "Raw Material Supplied",
+				"supplier_warehouse": subcontract_wh,
 				"items": [
 					{
 						"fg_item": "Sub Raw Bom Mat",

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -5063,7 +5063,7 @@ class TestStockEntry(FrappeTestCase):
 			item.has_batch_no = 1
 
 		# if gst_hsn_code is not set in item
-		if not item.gst_hsn_code:
+		if frappe.db.has_column("Item", "gst_hsn_code") and not item.gst_hsn_code:
 			item.gst_hsn_code = "100111"
 
 		item.save()


### PR DESCRIPTION
### Title:
Fixed MandatoryError for supplier_warehouse and item gst_hsn code error.

### Description:
This fix addresses a MandatoryError raised when submitting a Purchase Order marked as subcontracted, due to the missing supplier_warehouse field.
This fix resolves error due to missing gst_hsn code

### Test Summary:
The test ensures that a subcontracted Purchase Order can be submitted successfully and correctly triggers the creation of a Subcontracting Order.
It validates that supplier_warehouse, a required field, is explicitly provided during test setup to prevent failure during on_submit.

The test verifies that item have gst_hsn_code.

### Doctype Covered:
Stock Entry
Warehouse

### Test Case Involoved:
TC-SCK-403: test_get_items_from_subcontract_order_TC_SCK_403
Creates a Purchase Order with subcontracted items and supplied raw materials, then verifies that get_items_from_subcontract_order() correctly returns the raw material from the SCO.

TC-SCK-364: test_move_sample_to_retention_warehouse_TC_SCK_364
Ensures samples are moved from source warehouse to the configured Retention Warehouse, validating batch handling and inventory integrity.

### Expected Results:
Purchase Order submits without errors

Subcontracting Order is auto-created without MandatoryError
Returned Stock Entry from subcontracting contains the correct raw material (Sub Raw Mat)

A Stock Entry is created for sample movement
Stock Entry.purpose is "Material Transfer"
target_warehouse in Stock Entry is the Retention Warehouse
Item moved has correct batch no and quantity

### Key Enhancements:
Set supplier_warehouse explicitly on Purchase Order

Ensured required fields are present during SCO mapping

Verified raw material mapping through get_items_from_subcontract_order

### Scenarios Covered:
Subcontracting with "Raw Material Supplied" type

Auto-generation of Subcontracting Order from PO submission

Correct item mapping into Stock Entry based on SCO

### Technology Used:
Python unittest

Frappe APIs: frappe.get_doc, frappe.db.set_value, frappe.as_json

Assertion: self.assertEqual, self.assertGreater

### Linked Feature/Bug:
2676

