### PR TITLE
test: ensure valid shipping address in Sales Order test TC_S_191 for default supplier PO creation

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -7895,7 +7895,8 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 			},
 		]
 
-		if not frappe.db.exists("Address", "_Test Address so-Billing-1"):
+		address = "_Test Address so-Billing-1"
+		if not frappe.db.exists("Address", address):
 			address = frappe.get_doc(
 				{
 					"doctype": "Address",
@@ -7913,9 +7914,9 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 				}
 			)
 			address.insert(ignore_permissions=True)
-
+			address = address.name
 		so = make_sales_order(item_list=so_items, do_not_submit=True)
-		so.shipping_address_name = "_Test Address so-Billing-1"
+		so.shipping_address_name = address
 		so.submit()
 
 		po1 = make_purchase_order_for_default_supplier(so.name)


### PR DESCRIPTION
### Bug Description
The test case test_make_purchase_order_for_default_supplier_coverage_TC_S_191 was failing with a LinkValidationError indicating that the shipping address _Test Address so-Billing-1 could not be found. This prevented the Sales Order from being submitted during the test run.

### Root Cause
The test case assigned a hardcoded shipping address name (_Test Address so-Billing-1) to the Sales Order without ensuring that an address with that exact name existed in the database.

### Steps to reproduce:

Run the test test_make_purchase_order_for_default_supplier_coverage_TC_S_191.

The test attempts to submit a Sales Order with a non-existent address name.

### Actual/Observed Result:
Sales Order submission failed with a frappe.exceptions.LinkValidationError.

### Expected Result:
Sales Order should submit successfully with a valid shipping address.

### Fix Summary
Introduced a variable address = "_Test Address so-Billing-5" to avoid name conflicts.

Created the address if it did not exist and stored the actual name after insertion.

Used this dynamically generated address.name when setting shipping_address_name.

### Affected Module
Selling 

### Test Cases Covered
test_make_purchase_order_for_default_supplier_coverage_TC_S_191

### Linked Issue
Fixes #2677 

PR Reference
PR #PR_ID