### PR TITLE
test: removed not required link from address

### DIFF
--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -8450,7 +8450,6 @@ def create_registered_address_for_gst_entities():
 				"links": [
 					{"link_doctype": "Company", "link_name": "_Test Indian Registered Company"},
 					{"link_doctype": "Customer", "link_name": "_Test Registered Customer"},
-					{"link_doctype": "Customer", "link_name": "_Test Registered Composition Customer"},
 				],
 			}
 		)


### PR DESCRIPTION
### Bug Description
A test case for GST-based Sales Orders (test_sales_order_create_si_via_partial_pe_dn_with_gst_TC_S_043) was failing due to a LinkValidationError while inserting a test Address in create_registered_address_for_gst_entities.

### Root Cause
The Address document setup included a link to a Customer named _Test Registered Composition Customer, which was not created anywhere in the test setup. This caused Frappe’s link validation to fail when inserting the address.

### Steps to Reproduce:

Run the test case test_sales_order_create_si_via_partial_pe_dn_with_gst_TC_S_043.

It triggers the creation of an address with multiple linked entities.

Since _Test Registered Composition Customer does not exist, the test fails on address insertion.

### Actual/Observed Result:
Test case fails with:

frappe.exceptions.LinkValidationError: Could not find Row #3: Link Name: _Test Registered Composition Customer

### Expected Result:
The address should be created successfully, and the test should pass.

### Fix Summary
Removed the invalid customer link (_Test Registered Composition Customer) from the links list in the create_registered_address_for_gst_entities method.

Retained valid links to the company and _Test Registered Customer only.

### Affected Module
Selling 

### Test Cases Covered
test_sales_order_create_si_via_partial_pe_dn_with_gst_TC_S_043

Other dependent tests using create_registered_address_for_gst_entities

### Linked Issue
Fixes #2678

### PR Reference
PR #PR_ID