### PR TITLE
test: Test Scenarios for Tax Withholding Category, Share Transfer Validations, and Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.py
@@ -2,12 +2,16 @@
 # For license information, please see license.txt
 # import frappe
 from frappe.model.document import Document
+
+
 class ProcessStatementOfAccountsCC(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 	from typing import TYPE_CHECKING
-	if TYPE_CHECKING:
+
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
+
 		cc: DF.Link | None
 		parent: DF.Data
 		parentfield: DF.Data

--- a/erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.py
@@ -12,7 +12,7 @@ class ProcessStatementOfAccountsCustomer(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		billing_email: DF.Data | None

--- a/erpnext/accounts/doctype/process_subscription/process_subscription.py
+++ b/erpnext/accounts/doctype/process_subscription/process_subscription.py
@@ -14,7 +14,7 @@ class ProcessSubscription(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		amended_from: DF.Link | None

--- a/erpnext/accounts/doctype/process_subscription/test_process_subscription.py
+++ b/erpnext/accounts/doctype/process_subscription/test_process_subscription.py
@@ -1,9 +1,43 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+from erpnext.accounts.doctype.subscription.test_subscription import create_subscription
+from erpnext.accounts.doctype.subscription_plan.test_subscription_plan import get_subscription_plan
+from erpnext.selling.doctype.customer.test_customer import get_customer_dict
 
 
 class TestProcessSubscription(FrappeTestCase):
-	pass
+	def setUp(self):
+		item = make_test_item("__Test Subscription Item")
+		customer = frappe.get_doc(get_customer_dict("__Test Subscription Customer_")).insert(
+			ignore_permissions=True
+		)
+		self.item_code = item.item_code
+		self.customer = customer.name
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_create_subscription_process_TC_ACC_262(self):
+		from unittest.mock import patch
+
+		from .process_subscription import create_subscription_process
+
+		subscription_plan = get_subscription_plan(self.item_code)
+		args = {
+			"customer": self.customer,
+			"start_date": today(),
+			"plans": [{"plan": subscription_plan.name, "qty": 1}],
+		}
+		subscription = create_subscription(**args)
+		self.assertEqual(subscription.status, "Active")
+
+		with patch("frappe.db.commit"):
+			create_subscription_process(subscription)
+			get_process_subscription = frappe.get_last_doc("Process Subscription")
+			self.assertEqual(get_process_subscription.subscription, subscription.name)

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -78,20 +78,29 @@ class PromotionalScheme(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
+		from frappe.types import DF
+
 		from erpnext.accounts.doctype.customer_group_item.customer_group_item import CustomerGroupItem
 		from erpnext.accounts.doctype.customer_item.customer_item import CustomerItem
 		from erpnext.accounts.doctype.pricing_rule_brand.pricing_rule_brand import PricingRuleBrand
 		from erpnext.accounts.doctype.pricing_rule_item_code.pricing_rule_item_code import PricingRuleItemCode
-		from erpnext.accounts.doctype.pricing_rule_item_group.pricing_rule_item_group import PricingRuleItemGroup
-		from erpnext.accounts.doctype.promotional_scheme_price_discount.promotional_scheme_price_discount import PromotionalSchemePriceDiscount
-		from erpnext.accounts.doctype.promotional_scheme_product_discount.promotional_scheme_product_discount import PromotionalSchemeProductDiscount
+		from erpnext.accounts.doctype.pricing_rule_item_group.pricing_rule_item_group import (
+			PricingRuleItemGroup,
+		)
+		from erpnext.accounts.doctype.promotional_scheme_price_discount.promotional_scheme_price_discount import (
+			PromotionalSchemePriceDiscount,
+		)
+		from erpnext.accounts.doctype.promotional_scheme_product_discount.promotional_scheme_product_discount import (
+			PromotionalSchemeProductDiscount,
+		)
 		from erpnext.accounts.doctype.supplier_group_item.supplier_group_item import SupplierGroupItem
 		from erpnext.accounts.doctype.supplier_item.supplier_item import SupplierItem
 		from erpnext.accounts.doctype.territory_item.territory_item import TerritoryItem
-		from frappe.types import DF
 
-		applicable_for: DF.Literal["", "Customer", "Customer Group", "Territory", "Supplier", "Supplier Group"]
+		applicable_for: DF.Literal[
+			"", "Customer", "Customer Group", "Territory", "Supplier", "Supplier Group"
+		]
 		apply_on: DF.Literal["", "Item Code", "Item Group", "Brand", "Transaction"]
 		apply_rule_on_other: DF.Literal["", "Item Code", "Item Group", "Brand"]
 		brands: DF.Table[PricingRuleBrand]

--- a/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.py
+++ b/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.py
@@ -11,7 +11,7 @@ class PromotionalSchemePriceDiscount(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		apply_discount_on_rate: DF.Check

--- a/erpnext/accounts/doctype/promotional_scheme_product_discount/promotional_scheme_product_discount.py
+++ b/erpnext/accounts/doctype/promotional_scheme_product_discount/promotional_scheme_product_discount.py
@@ -11,7 +11,7 @@ class PromotionalSchemeProductDiscount(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		apply_multiple_pricing_rules: DF.Check

--- a/erpnext/accounts/doctype/psoa_cost_center/psoa_cost_center.py
+++ b/erpnext/accounts/doctype/psoa_cost_center/psoa_cost_center.py
@@ -12,7 +12,7 @@ class PSOACostCenter(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		cost_center_name: DF.Link

--- a/erpnext/accounts/doctype/purchase_invoice_advance/purchase_invoice_advance.py
+++ b/erpnext/accounts/doctype/purchase_invoice_advance/purchase_invoice_advance.py
@@ -11,7 +11,7 @@ class PurchaseInvoiceAdvance(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		advance_amount: DF.Currency

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.py
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.py
@@ -11,7 +11,7 @@ class PurchaseInvoiceItem(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		allow_zero_valuation_rate: DF.Check

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.py
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.py
@@ -11,7 +11,7 @@ class PurchaseTaxesandCharges(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		account_currency: DF.Link | None

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.py
@@ -16,7 +16,7 @@ class PurchaseTaxesandChargesTemplate(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.purchase_taxes_and_charges.purchase_taxes_and_charges import (

--- a/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
@@ -11,7 +11,7 @@ class RepostAccountingLedgerItems(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		parent: DF.Data

--- a/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.py
@@ -11,7 +11,7 @@ class RepostAccountingLedgerSettings(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.repost_allowed_types.repost_allowed_types import RepostAllowedTypes

--- a/erpnext/accounts/doctype/repost_allowed_types/repost_allowed_types.py
+++ b/erpnext/accounts/doctype/repost_allowed_types/repost_allowed_types.py
@@ -11,7 +11,7 @@ class RepostAllowedTypes(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		allowed: DF.Check

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -7288,6 +7288,341 @@ class TestSalesInvoice(FrappeTestCase):
 			customer.tax_withholding_category = ""
 			customer.save()
 
+	def test_set_indicators_TC_ACC_241(self):
+		from .sales_invoice import make_sales_return
+
+		si = create_sales_invoice()
+		si.set_indicator()
+		self.assertEqual(si.docstatus, 1)
+		self.assertEqual(si.status, "Unpaid")
+
+		r_si = make_sales_return(si.name)
+		r_si.insert()
+		r_si.submit()
+		r_si.set_indicator()
+		self.assertEqual(r_si.docstatus, 1)
+		self.assertEqual(r_si.status, "Return")
+
+		si_1 = create_sales_invoice()
+		pe = get_payment_entry(si_1.doctype, si_1.name)
+		pe.insert(ignore_permissions=1)
+		pe.submit()
+
+		si_1.load_from_db()
+		si_1.set_indicator()
+
+		self.assertEqual(si_1.docstatus, 1)
+		self.assertEqual(si_1.status, "Paid")
+
+	def test_validate_serial_against_delivery_note_TC_ACC_242(self):
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		dn = create_delivery_note(do_not_save=True)
+		dn.insert(ignore_permissions=True)
+		dn.submit()
+		self.assertEqual(dn.docstatus, 1)
+		self.assertEqual(dn.status, "To Bill")
+
+		si = make_sales_invoice(dn.name)
+		si.insert(ignore_permissions=True)
+		si.validate_serial_against_delivery_note()
+		si.submit()
+		self.assertEqual(si.docstatus, 1)
+		self.assertEqual(si.status, "Unpaid")
+
+	def test_loyalty_programs_TC_ACC_243(self):
+		from erpnext.selling.doctype.customer.test_customer import get_customer_dict
+
+		from .sales_invoice import get_loyalty_programs
+
+		customer = frappe.get_doc(get_customer_dict("__Test Loyalty Customer 1")).insert(
+			ignore_permissions=True
+		)
+		customer.loyalty_program = create_loyalty_program()
+		customer.save()
+
+		loyalty_program = get_loyalty_programs(customer.name)
+		self.assertEqual(loyalty_program[0], "__Test Single Loyalty 1")
+
+		l1_program = frappe.get_doc("Loyalty Program", create_loyalty_program())
+		l1_program.auto_opt_in = 1
+		l1_program.save()
+
+	def test_create_invoice_discounting_TC_ACC_244(self):
+		from .sales_invoice import create_invoice_discounting
+
+		si = create_sales_invoice()
+
+		self.assertEqual(si.docstatus, 1)
+		self.assertEqual(si.status, "Unpaid")
+
+		accounts = create_discounting_accounts()
+
+		invoice_discounting = create_invoice_discounting(si.name)
+		invoice_discounting.loan_start_date = today()
+		invoice_discounting.loan_period = 100
+		invoice_discounting.short_term_loan = accounts.get("short_term_loan")
+		invoice_discounting.bank_account = accounts.get("bank_account")
+		invoice_discounting.bank_charges_account = accounts.get("bank_charges_account")
+		invoice_discounting.accounts_receivable_credit = accounts.get("ar_credit")
+		invoice_discounting.accounts_receivable_discounted = accounts.get("ar_discounted")
+		invoice_discounting.accounts_receivable_unpaid = accounts.get("ar_unpaid")
+		invoice_discounting.insert(ignore_permissions=True)
+		invoice_discounting.submit()
+
+		self.assertEqual(invoice_discounting.docstatus, 1)
+		self.assertEqual(invoice_discounting.status, "Sanctioned")
+
+	def test_get_warehouse_TC_ACC_245(self):
+		si = create_sales_invoice(do_not_save=1)
+		si.insert(ignore_permissions=True)
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.get_warehouse()
+		self.assertIn("POS Profile required to make POS Entry", str(cm.exception))
+
+	def test_validate_warehouse_TC_ACC_246(self):
+		si = create_sales_invoice(do_not_save=1)
+		si.update_stock = 1
+		si.items[0].warehouse = ""
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert(ignore_permissions=True)
+		self.assertIn(f"Warehouse required for stock Item {si.items[0].item_code}", str(cm.exception))
+
+	@change_settings("Selling Settings", {"so_required": "Yes"})
+	def test_so_required_in_si_TC_ACC_247(self):
+		si = create_sales_invoice(do_not_save=1)
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert(ignore_permissions=True)
+		self.assertIn(f"Sales Order is mandatory for Item {si.items[0].item_code}", str(cm.exception))
+
+	def test_validate_item_cost_centers_TC_ACC_248(self):
+		si = create_sales_invoice(do_not_save=1)
+		si.items[0].cost_center = "Main - _TC1"
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert()
+		self.assertIn(
+			f"Row #{si.items[0].idx}: Cost Center {si.items[0].cost_center} does not belong to company {si.company}",
+			str(cm.exception),
+		)
+
+	def test_get_list_context_TC_ACC_249(self):
+		from .sales_invoice import get_list_context
+
+		data = get_list_context()
+		self.assertTrue(data.get("title"), "Invoices")
+		self.assertTrue(data.get("no_breadcrumbs"), True)
+		self.assertTrue(data.get("show_sidebar"), True)
+		self.assertTrue(data.get("show_search"), True)
+
+	def test_set_pos_fields_TC_ACC_250(self):
+		from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
+
+		pos = make_pos_profile(do_not_insert=1)
+		pos.account_for_change_amount = "Cash - _TC"
+		pos.insert(ignore_permissions=True)
+		si = create_sales_invoice(do_not_save=1)
+		si.is_pos = 1
+		si.pos_profile = pos.name
+		si.set_pos_fields()
+		si.insert()
+		si.submit()
+		company_abbr = si.get_company_abbr()
+
+		self.assertEqual(si.docstatus, 1)
+		self.assertEqual(si.status, "Unpaid")
+		self.assertEqual(company_abbr, "_TC")
+
+	def test_validate_delivery_note_TC_ACC_251(self):
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		dn = create_delivery_note(do_not_save=1)
+		dn.insert(ignore_permissions=True)
+		dn.submit()
+
+		si = make_sales_invoice(dn.name)
+		si.update_stock = 1
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert(ignore_permissions=1)
+
+		self.assertIn(f"Stock cannot be updated against Delivery Note {dn.name}", str(cm.exception))
+
+	def test_allow_write_off_only_on_pos_TC_ACC_252(self):
+		si = create_sales_invoice(do_not_save=1)
+		si.write_off_account = "Sales - _TC"
+		si.insert(ignore_permissions=True)
+
+		si.load_from_db()
+		self.assertIsNone(si.write_off_account)
+
+	def test_validate_dropship_item_TC_ACC_253(self):
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_invoice, make_sales_order
+
+		so = make_sales_order(do_not_save=True)
+		so.items[0].delivered_by_supplier = 1
+		so.items[0].supplier = "_Test Supplier"
+		so.insert()
+		so.submit()
+
+		si = make_sales_invoice(so.name)
+		si.update_stock = 1
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert()
+		self.assertIn("Could not update stock, invoice contains drop shipping item.", str(cm.exception))
+
+	def test_enable_discount_accounting_TC_ACC_254(self):
+		si = create_sales_invoice(do_not_save=1)
+		si.insert(ignore_permissions=True)
+		discounting = si.enable_discount_accounting
+		self.assertEqual(
+			discounting, frappe.db.get_single_value("Selling Settings", "enable_discount_accounting")
+		)
+
+	def test_validate_receivable_to_acc_TC_ACC_255(self):
+		si = create_sales_invoice(do_not_save=1)
+		si.debit_to = create_account(
+			account_name="__Test Re Account__",
+			parent_account="Accounts Receivable - _TC",
+			company="_Test Company",
+			account_type="Cash",
+			report_type="Balance Sheet",
+		)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert(ignore_permissions=True)
+		self.assertIn(
+			"Please ensure Debit To account __Test Re Account__ - _TC is a Receivable account. Change the account type to Receivable or select a different account.",
+			str(cm.exception),
+		)
+
+	def test_validate_debit_to_acc_TC_ACC_256(self):
+		account = create_discounting_accounts()
+		si = create_sales_invoice(do_not_save=1)
+		si.debit_to = account.get("report_account")
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert(ignore_permissions=True)
+		self.assertIn(
+			"Please ensure Debit To account is a Balance Sheet account. You can change the parent account to a Balance Sheet account or select a different account.",
+			str(cm.exception),
+		)
+
+	def test_on_recurring_TC_ACC_257(self):
+		reference_si = create_sales_invoice(do_not_save=1)
+		reference_si.insert(ignore_permissions=True)
+		reference_si.submit()
+		self.assertEqual(reference_si.docstatus, 1)
+		self.assertEqual(reference_si.status, "Unpaid")
+
+		auto_repeat = frappe.get_doc(
+			{
+				"doctype": "Auto Repeat",
+				"reference_doctype": "Sales Invoice",
+				"reference_document": reference_si.name,
+				"frequency": "Monthly",
+				"next_schedule_date": add_days(today(), 30),
+			}
+		)
+		auto_repeat.insert(ignore_permissions=True)
+
+		new_si = create_sales_invoice(do_not_save=1)
+		new_si.insert(ignore_permissions=True)
+		new_si.submit()
+		new_si.on_recurring(reference_doc=reference_si, auto_repeat_doc=auto_repeat)
+
+		self.assertEqual(new_si.docstatus, 1)
+		self.assertIsNone(new_si.due_date)
+
+	def test_make_maintenance_schedule_from_si_TC_ACC_258(self):
+		from .sales_invoice import make_maintenance_schedule
+
+		si = create_sales_invoice(do_not_save=1)
+		si.insert(ignore_permissions=True)
+		si.submit()
+
+		self.assertEqual(si.docstatus, 1)
+		self.assertEqual(si.status, "Unpaid")
+
+		ms = make_maintenance_schedule(si.name)
+		ms.transaction_date = today()
+		ms.items[0].start_date = today()
+		ms.items[0].end_date = add_days(today(), 1)
+		ms.items[0].no_of_visits = 2
+		ms.insert(ignore_permissions=True)
+		ms.submit()
+
+		self.assertEqual(ms.docstatus, 1)
+
+	def test_validate_pos_TC_ACC_259(self):
+		from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
+
+		pos = make_pos_profile(do_not_insert=1)
+		pos.account_for_change_amount = "Cash - _TC"
+		pos.insert(ignore_permissions=True)
+
+		si = create_sales_invoice(do_not_save=1)
+		si.is_pos = 1
+		si.pos_profile = pos.name
+		si.write_off_amount = 1000
+		si.is_return = 1
+		si.taxes_and_charges = ""
+		si.taxes = []
+		si.items[0].qty = -1
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			si.insert(ignore_permissions=True)
+		self.assertIn("Paid amount + Write Off Amount can not be greater than Grand Total", str(cm.exception))
+
+	def test_get_all_mode_of_payments_TC_ACC_260(self):
+		from .sales_invoice import get_all_mode_of_payments, get_mode_of_payment_info
+
+		si = create_sales_invoice()
+		mode_of_pmt = get_all_mode_of_payments(si)
+		if mode_of_pmt:
+			self.assertEqual(mode_of_pmt[0].get("default_account"), "Cash - _TC")
+
+		pmt_info = get_mode_of_payment_info("Cash", si.company)
+		if pmt_info:
+			self.assertEqual(pmt_info[0].get("default_account"), "Cash - _TC")
+
+	@change_settings("Accounts Settings", {"unlink_payment_on_cancellation_of_invoice": 1})
+	def test_check_if_return_invoice_linked_with_payment_entry_TC_ACC_261(self):
+		si = create_sales_invoice(rate=1000, do_not_save=True)
+		si.insert(ignore_permissions=True)
+		si.submit()
+
+		return_si = create_sales_invoice(rate=200, do_not_save=True)
+		return_si.is_return = 1
+		# return_si.return_against = si.name
+		return_si.items[0].qty = -1
+		return_si.insert(ignore_permissions=True)
+		return_si.submit()
+
+		pe = get_payment_entry(si.doctype, si.name)
+		pe.append(
+			"references",
+			{
+				"reference_doctype": return_si.doctype,
+				"reference_name": return_si.name,
+				"allocated_amount": -200,
+			},
+		)
+		pe.insert(ignore_permissions=True)
+		pe.submit()
+
+		return_si.load_from_db()
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			return_si.cancel()
+		self.assertIn(
+			f"Please cancel and amend the Payment Entry {pe.name} to unallocate the amount of this Return Invoice before cancelling it.",
+			str(cm.exception),
+		)
+
 
 def set_advance_flag(company, flag, default_account):
 	frappe.db.set_value(
@@ -8122,3 +8457,91 @@ def create_fiscal_year(company):
 		fiscal_year.company = company  # Required to avoid overlap error
 		fiscal_year.append("companies", {"company": company})
 		fiscal_year.save()
+
+
+def create_discounting_accounts():
+	ar_credit = create_account(
+		account_name="_Test Accounts Receivable Credit",
+		parent_account="Accounts Receivable - _TC",
+		company="_Test Company",
+	)
+	ar_discounted = create_account(
+		account_name="_Test Accounts Receivable Discounted",
+		parent_account="Accounts Receivable - _TC",
+		company="_Test Company",
+	)
+	ar_unpaid = create_account(
+		account_name="_Test Accounts Receivable Unpaid",
+		parent_account="Accounts Receivable - _TC",
+		company="_Test Company",
+	)
+	short_term_loan = create_account(
+		account_name="_Test Short Term Loan",
+		parent_account="Source of Funds (Liabilities) - _TC",
+		company="_Test Company",
+	)
+	bank_account = create_account(
+		account_name="_Test Bank 2", parent_account="Bank Accounts - _TC", company="_Test Company"
+	)
+	bank_charges_account = create_account(
+		account_name="_Test Bank Charges Account",
+		parent_account="Expenses - _TC",
+		company="_Test Company",
+	)
+	report_account = create_account(
+		account_name="_Test Report Account_",
+		parent_account="Expenses - _TC",
+		company="_Test Company",
+		report_type="Profit and Loss",
+		account_type="Cash",
+	)
+
+	return {
+		"ar_credit": ar_credit,
+		"ar_discounted": ar_discounted,
+		"ar_unpaid": ar_unpaid,
+		"short_term_loan": short_term_loan,
+		"bank_account": bank_account,
+		"bank_charges_account": bank_charges_account,
+		"report_account": report_account,
+	}
+
+
+def create_loyalty_program():
+	from erpnext.buying.doctype.purchase_order.test_purchase_order import create_company
+
+	create_company()
+	loyality_program = "__Test Single Loyalty 1"
+	# create a new loyalty Account
+	if not frappe.db.exists("Account", "Loyalty - _TC"):
+		frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "Loyalty",
+				"parent_account": "Direct Expenses - _TC",
+				"company": "_Test Company",
+				"is_group": 0,
+				"account_type": "Expense Account",
+			}
+		).insert()
+
+	# create a new loyalty program Single tier
+	if not frappe.db.exists("Loyalty Program", loyality_program):
+		frappe.get_doc(
+			{
+				"doctype": "Loyalty Program",
+				"loyalty_program_name": "__Test Single Loyalty 1",
+				"auto_opt_in": 0,
+				"from_date": today(),
+				"to_date": today(),
+				"loyalty_program_type": "Single Tier Program",
+				"conversion_factor": 1,
+				"expiry_duration": 10,
+				"company": "_Test Company",
+				"cost_center": "Main - _TC",
+				"expense_account": "Loyalty - _TC",
+				"collection_rules": [{"tier_name": "Silver", "collection_factor": 1000, "min_spent": 1000}],
+			}
+		).insert()
+
+	return {loyality_program}

--- a/erpnext/accounts/doctype/share_transfer/share_transfer.py
+++ b/erpnext/accounts/doctype/share_transfer/share_transfer.py
@@ -20,7 +20,7 @@ class ShareTransfer(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		amended_from: DF.Link | None

--- a/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
+++ b/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
 
 from erpnext.accounts.doctype.share_transfer.share_transfer import ShareDontExists
 
 test_dependencies = ["Share Type", "Shareholder"]
 
 
-class TestShareTransfer(unittest.TestCase):
+class TestShareTransfer(FrappeTestCase):
 	def setUp(self):
 		frappe.db.sql("delete from `tabShare Transfer`")
 		frappe.db.sql("delete from `tabShare Balance`")
@@ -90,6 +90,9 @@ class TestShareTransfer(unittest.TestCase):
 			st = frappe.get_doc(d)
 			st.submit()
 
+	def tearDown(self):
+		frappe.db.rollback()
+
 	def test_invalid_share_transfer(self):
 		doc = frappe.get_doc(
 			{
@@ -127,10 +130,9 @@ class TestShareTransfer(unittest.TestCase):
 		)
 		self.assertRaises(ShareDontExists, doc.insert)
 
-
 	def test_create_share_transfer_and_then_jv_TC_ACC_106(self):
 		from erpnext.accounts.doctype.share_transfer.share_transfer import make_jv_entry
-		
+
 		# Create a valid share transfer document (Transfer from SH-00001 to SH-00002)
 		doc = frappe.get_doc(
 			{
@@ -154,20 +156,172 @@ class TestShareTransfer(unittest.TestCase):
 
 		amount = doc.no_of_shares * doc.rate
 		journal_entry = make_jv_entry(
-				company=doc.company,
-				account=doc.asset_account,
-				amount=amount,
-				payment_account=doc.equity_or_liability_account,
-				credit_applicant_type="Shareholder",
-				credit_applicant=doc.to_shareholder,
-				debit_applicant_type="",
-				debit_applicant=""
-			)
-		self.assertEqual(
-			journal_entry['accounts'][0]['debit_in_account_currency'], amount,
-			f"Debit amount in Journal Entry is incorrect. Expected: {amount}, Found: {journal_entry['accounts'][0]['debit_in_account_currency']}"
+			company=doc.company,
+			account=doc.asset_account,
+			amount=amount,
+			payment_account=doc.equity_or_liability_account,
+			credit_applicant_type="Shareholder",
+			credit_applicant=doc.to_shareholder,
+			debit_applicant_type="",
+			debit_applicant="",
 		)
 		self.assertEqual(
-			journal_entry['accounts'][1]['credit_in_account_currency'], amount,
-			f"Credit amount in Journal Entry is incorrect. Expected: {amount}, Found: {journal_entry['accounts'][1]['credit_in_account_currency']}"
+			journal_entry["accounts"][0]["debit_in_account_currency"],
+			amount,
+			f"Debit amount in Journal Entry is incorrect. Expected: {amount}, Found: {journal_entry['accounts'][0]['debit_in_account_currency']}",
 		)
+		self.assertEqual(
+			journal_entry["accounts"][1]["credit_in_account_currency"],
+			amount,
+			f"Credit amount in Journal Entry is incorrect. Expected: {amount}, Found: {journal_entry['accounts'][1]['credit_in_account_currency']}",
+		)
+
+	def test_sharetransfer_issue_on_cancel_TC_ACC_238(self):
+		# share transfer issue
+		get_holders = setup_shareholders()
+		issue_doc = get_share_transfer()
+		issue_doc.transfer_type = "Issue"
+		issue_doc.to_shareholder = get_holders.get("shareholder_1")
+
+		issue_doc.insert(ignore_permissions=True)
+		issue_doc.submit()
+		self.assertEqual(issue_doc.docstatus, 1)
+
+		shareholder = frappe.get_doc("Shareholder", get_holders.get("shareholder_1"))
+		self.assertEqual(shareholder.share_balance[0].no_of_shares, 100)
+
+		# share transfer purchase
+		purchase_doc = get_share_transfer()
+		purchase_doc.transfer_type = "Purchase"
+		purchase_doc.from_shareholder = get_holders.get("shareholder_1")
+		purchase_doc.no_of_shares = 50
+		purchase_doc.from_no = 500
+		purchase_doc.to_no = 549
+		purchase_doc.insert(ignore_permissions=True)
+		purchase_doc.submit()
+		self.assertEqual(purchase_doc.docstatus, 1)
+
+		shareholder.reload()
+		self.assertEqual(shareholder.share_balance[0].no_of_shares, 50)
+
+		# share transfer type "Transfer"
+		transfer_doc = get_share_transfer()
+		transfer_doc.transfer_type = "Transfer"
+		transfer_doc.from_shareholder = get_holders.get("shareholder_1")
+		transfer_doc.to_shareholder = get_holders.get("shareholder_2")
+		transfer_doc.no_of_shares = 50
+		transfer_doc.from_no = 550
+		transfer_doc.to_no = 599
+		transfer_doc.insert(ignore_permissions=True)
+		transfer_doc.submit()
+		self.assertEqual(transfer_doc.docstatus, 1)
+
+		shareholder.reload()
+		self.assertEqual(shareholder.share_balance, [])
+
+		issue_doc.cancel()
+		purchase_doc.cancel()
+		transfer_doc.cancel()
+
+	def test_basic_validations_TC_ACC_239(self):
+		purchase_doc = get_share_transfer()
+		purchase_doc.transfer_type = "Purchase"
+		purchase_doc.from_shareholder = ""
+		purchase_doc.no_of_shares = 50
+		purchase_doc.from_no = 500
+		purchase_doc.to_no = 549
+		with self.assertRaises(frappe.ValidationError) as cm:
+			purchase_doc.insert(ignore_permissions=True)
+		self.assertIn("The field From Shareholder cannot be blank", str(cm.exception))
+
+	def test_basic_validation_without_account_TC_ACC_240(self):
+		get_holders = setup_shareholders()
+		issue_doc = get_share_transfer()
+		issue_doc.transfer_type = "Issue"
+		issue_doc.to_shareholder = get_holders.get("shareholder_1")
+		issue_doc.asset_account = ""
+		with self.assertRaises(frappe.ValidationError) as cm:
+			issue_doc.insert(ignore_permissions=True)
+		self.assertIn("The field Asset Account cannot be blank", str(cm.exception))
+
+		issue_doc.asset_account = ("Cash - _TC",)
+		issue_doc.to_shareholder = ""
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			issue_doc.insert(ignore_permissions=True)
+		self.assertIn("The field To Shareholder cannot be blank", str(cm.exception))
+
+		transfer_doc = get_share_transfer()
+		transfer_doc.transfer_type = "Transfer"
+		transfer_doc.from_shareholder = ""
+		transfer_doc.to_shareholder = ""
+		transfer_doc.no_of_shares = 50
+		transfer_doc.from_no = 550
+		transfer_doc.to_no = 599
+		with self.assertRaises(frappe.ValidationError) as cm:
+			transfer_doc.insert(ignore_permissions=True)
+		self.assertIn("The fields From Shareholder and To Shareholder cannot be blank", str(cm.exception))
+
+		transfer_doc.from_shareholder = get_holders.get("shareholder_1")
+		transfer_doc.to_shareholder = get_holders.get("shareholder_2")
+		transfer_doc.equity_or_liability_account = ""
+		with self.assertRaises(frappe.ValidationError) as cm:
+			transfer_doc.insert(ignore_permissions=True)
+		self.assertIn("The field Equity/Liability Account cannot be blank", str(cm.exception))
+
+		transfer_doc.equity_or_liability_account = "Creditors - _TC"
+		transfer_doc.to_shareholder = get_holders.get("shareholder_1")
+		with self.assertRaises(frappe.ValidationError) as cm:
+			transfer_doc.insert(ignore_permissions=True)
+		self.assertIn("The seller and the buyer cannot be the same", str(cm.exception))
+
+		transfer_doc.to_shareholder = get_holders.get("shareholder_2")
+		transfer_doc.no_of_shares = 51
+		with self.assertRaises(frappe.ValidationError) as cm:
+			transfer_doc.insert(ignore_permissions=True)
+		self.assertIn("The number of shares and the share numbers are inconsistent", str(cm.exception))
+
+		transfer_doc.no_of_shares = 50
+		transfer_doc.amount = 10
+		with self.assertRaises(frappe.ValidationError) as cm:
+			transfer_doc.insert(ignore_permissions=True)
+		self.assertIn(
+			"There are inconsistencies between the rate, no of shares and the amount calculated",
+			str(cm.exception),
+		)
+
+
+def setup_shareholders():
+	holder_1 = "_Test_Shareholder_1"
+	holder_2 = "_Test_Shareholder_2"
+	if not frappe.db.exists("Shareholder", holder_1):
+		frappe.get_doc({"doctype": "Shareholder", "title": holder_1, "company": "_Test Company"}).insert(
+			ignore_permissions=True
+		)
+
+	if not frappe.db.exists("Shareholder", holder_2):
+		frappe.get_doc({"doctype": "Shareholder", "title": holder_2, "company": "_Test Company"}).insert(
+			ignore_permissions=True
+		)
+
+	shareholder_1 = frappe.get_doc("Shareholder", {"title": holder_1})
+	shareholder_2 = frappe.get_doc("Shareholder", {"title": holder_2})
+
+	return {"shareholder_1": shareholder_1.name, "shareholder_2": shareholder_2.name}
+
+
+def get_share_transfer():
+	return frappe.get_doc(
+		{
+			"doctype": "Share Transfer",
+			"date": today(),
+			"share_type": "Equity",
+			"from_no": 500,
+			"to_no": 599,
+			"no_of_shares": 100,
+			"rate": 15,
+			"company": "_Test Company",
+			"asset_account": "Cash - _TC",
+			"equity_or_liability_account": "Creditors - _TC",
+		}
+	)

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -18,7 +18,7 @@ class TaxWithholdingCategory(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.tax_withholding_account.tax_withholding_account import (
@@ -52,7 +52,7 @@ class TaxWithholdingCategory(Document):
 				frappe.throw(_("Row #{0}: Dates overlapping with other row").format(d.idx))
 
 			last_to_date = d.to_date
- 
+
 	def validate_companies_and_accounts(self):
 		existing_accounts = set()
 		companies = set()
@@ -282,9 +282,9 @@ def get_lower_deduction_certificate(company, posting_date, tax_details, pan_no):
 def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=None):
 	vouchers, voucher_wise_amount = get_invoice_vouchers(
 		parties,
- 		tax_details,
- 		inv.company,
- 		party_type=party_type,
+		tax_details,
+		inv.company,
+		party_type=party_type,
 	)
 
 	payment_entry_vouchers = get_payment_entry_vouchers(
@@ -359,16 +359,16 @@ def get_invoice_vouchers(parties, tax_details, company, party_type="Supplier"):
 	vouchers = []
 
 	ldcs = frappe.db.get_all(
- 		"Lower Deduction Certificate",
- 		filters={
- 			"valid_from": [">=", tax_details.from_date],
- 			"valid_upto": ["<=", tax_details.to_date],
- 			"company": company,
- 			"supplier": ["in", parties],
- 		},
- 		fields=["supplier", "valid_from", "valid_upto", "rate"],
- 	)
-	
+		"Lower Deduction Certificate",
+		filters={
+			"valid_from": [">=", tax_details.from_date],
+			"valid_upto": ["<=", tax_details.to_date],
+			"company": company,
+			"supplier": ["in", parties],
+		},
+		fields=["supplier", "valid_from", "valid_upto", "rate"],
+	)
+
 	doctype = "Purchase Invoice" if party_type == "Supplier" else "Sales Invoice"
 	field = [
 		"base_tax_withholding_net_total as base_net_total" if party_type == "Supplier" else "base_net_total",
@@ -394,19 +394,19 @@ def get_invoice_vouchers(parties, tax_details, company, party_type="Supplier"):
 
 	for d in invoices_details:
 		d = frappe._dict(
- 			{
- 				"voucher_name": d.name,
- 				"voucher_type": doctype,
- 				"taxable_amount": d.base_net_total,
- 				"grand_total": d.grand_total,
- 				"posting_date": d.posting_date,
- 			}
+			{
+				"voucher_name": d.name,
+				"voucher_type": doctype,
+				"taxable_amount": d.base_net_total,
+				"grand_total": d.grand_total,
+				"posting_date": d.posting_date,
+			}
 		)
 
 		if ldc := [x for x in ldcs if d.posting_date >= x.valid_from and d.posting_date <= x.valid_upto]:
 			if ldc[0].supplier in parties and ldc[0].rate == 0:
 				d.update({"taxable_amount": 0})
- 
+
 		vouchers.append(d.voucher_name)
 		voucher_wise_amount.append(d)
 
@@ -636,7 +636,7 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 				"voucher_no": ["in", vouchers],
 			},
 			"sum(debit)",
-			order_by=None
+			order_by=None,
 		)
 		or 0.0
 	)
@@ -650,7 +650,6 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 	conditions.append(ple.party.isin(parties))
 	conditions.append(ple.voucher_no == ple.against_voucher_no)
 	conditions.append(ple.company == inv.company)
-
 
 	advance_amt = (
 		qb.from_(ple).select(Abs(Sum(ple.amount))).where(Criterion.all(conditions)).run()[0][0] or 0.0
@@ -704,7 +703,7 @@ def get_limit_consumed(ldc, parties):
 			"company": ldc.company,
 		},
 		"sum(tax_withholding_net_total)",
-		order_by=None
+		order_by=None,
 	)
 
 	return limit_consumed

--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -9,6 +9,7 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import add_days, add_months, today
 
+from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
@@ -662,7 +663,7 @@ class TestTaxWithholdingCategory(FrappeTestCase):
 				"pan": "ABCTY1234D",
 			},
 		)
- 
+
 		fiscal_year = get_fiscal_year(today(), company="_Test Company")
 		valid_from = fiscal_year[1]
 		valid_upto = add_months(valid_from, 1)
@@ -823,6 +824,156 @@ class TestTaxWithholdingCategory(FrappeTestCase):
 		self.assertEqual(payment.taxes[0].tax_amount, 6000)
 		self.assertEqual(payment.taxes[0].allocated_amount, 6000)
 
+	def test_validate_dates_TC_ACC_232(self):
+		category = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS",
+			rate=10,
+			from_date=add_days(today(), 1),
+			to_date=today(),
+			account=get_account(),
+			single_threshold=0,
+			cumulative_threshold=30000.00,
+		)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			category.insert(ignore_permissions=True)
+		self.assertIn("Row #1: From Date cannot be before To Date", str(cm.exception))
+
+		category_1 = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS 1",
+			rate=10,
+			from_date=today(),
+			to_date=add_days(today(), 2),
+			account=get_account(),
+			single_threshold=0,
+			cumulative_threshold=30000.00,
+		)
+		category_1.append(
+			"rates",
+			{
+				"from_date": add_days(today(), 1),
+				"to_date": add_days(today(), 3),
+				"tax_withholding_rate": 10,
+				"single_threshold": 0,
+				"cumulative_threshold": 1000.00,
+			},
+		)
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			category_1.insert(ignore_permissions=True)
+		self.assertIn("Row #2: Dates overlapping with other row", str(cm.exception))
+
+	def test_validate_companies_and_accounts_TC_ACC_233(self):
+		category = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS 1",
+			rate=10,
+			from_date=today(),
+			to_date=add_days(today(), 2),
+			account=get_account(),
+			single_threshold=0,
+			cumulative_threshold=30000.00,
+		)
+		category.append("accounts", {"company": "_Test Company", "account": "Cash - _TC"})
+		with self.assertRaises(frappe.ValidationError) as cm:
+			category.insert()
+		self.assertIn("Company _Test Company added multiple times", str(cm.exception))
+
+		category_1 = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS 1",
+			rate=10,
+			from_date=today(),
+			to_date=add_days(today(), 2),
+			account=get_account(),
+			single_threshold=0,
+			cumulative_threshold=30000.00,
+		)
+		category_1.append("accounts", {"company": "_Test Company 1", "account": get_account()})
+		with self.assertRaises(frappe.ValidationError) as cm:
+			category_1.insert()
+		self.assertIn(f"Account {get_account()} added multiple times", str(cm.exception))
+
+	def test_validate_thresholds_TC_ACC_234(self):
+		category = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS 1",
+			rate=10,
+			from_date=today(),
+			to_date=add_days(today(), 2),
+			account=get_account(),
+			single_threshold=30000.00,
+			cumulative_threshold=20000.00,
+		)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			category.insert()
+		self.assertIn(
+			f"{category.rates[0].idx}: Cumulative threshold cannot be less than Single Transaction threshold",
+			str(cm.exception),
+		)
+
+	def test_get_tax_withholding_rates_TC_ACC_235(self):
+		from .tax_withholding_category import get_tax_withholding_rates
+
+		category = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS",
+			rate=10,
+			from_date=today(),
+			to_date=add_days(today(), 1),
+			account=get_account(),
+			single_threshold=0,
+			cumulative_threshold=30000.00,
+		)
+		category.insert(ignore_permissions=True)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			get_tax_withholding_rates(category, add_days(today(), -1))
+		self.assertIn("No Tax Withholding data found for the current posting date.", str(cm.exception))
+
+	def test_get_lower_deduction_amount_TC_ACC_236(self):
+		from .tax_withholding_category import get_lower_deduction_amount, get_tax_withholding_details
+
+		category = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS",
+			rate=10,
+			from_date=today(),
+			to_date=add_days(today(), 1),
+			account=get_account(),
+			single_threshold=0,
+			cumulative_threshold=30000.00,
+		)
+		category.insert(ignore_permissions=True)
+
+		tax_details = get_tax_withholding_details(category.name, today(), category.accounts[0].company)
+		deduction_amount = get_lower_deduction_amount(200, 200, 1000, 2, tax_details=tax_details)
+		self.assertEqual(deduction_amount, 4.0)
+
+		deduction_amount_1 = get_lower_deduction_amount(200, 200, 100, 2, tax_details=tax_details)
+		self.assertEqual(deduction_amount_1, 28.0)
+
+	def test_is_valid_certificate_TC_ACC_237(self):
+		from .tax_withholding_category import is_valid_certificate, normal_round
+
+		category = get_tax_withholding_category(
+			category_name="__Test Cumulative Threshold TDS",
+			rate=10,
+			from_date=today(),
+			to_date=add_days(today(), 1),
+			account=get_account(),
+			single_threshold=0,
+			cumulative_threshold=30000.00,
+		)
+		category.insert(ignore_permissions=True)
+
+		create_lower_deduction_certificate(
+			supplier="Test LDC Supplier",
+			certificate_no="1AE0423AAJ",
+			tax_withholding_category=category.name,
+			tax_rate=2,
+			limit=50000,
+		)
+		lds = frappe.get_last_doc("Lower Deduction Certificate")
+		self.assertTrue(is_valid_certificate(lds, today(), 1000))
+		self.assertFalse(is_valid_certificate(lds, add_days(today(), -5), 50000))
+
+		self.assertEqual(normal_round(2.36), 2)
+		self.assertEqual(normal_round(2.6), 3)
+
 
 def cancel_invoices():
 	purchase_invoices = frappe.get_all(
@@ -854,7 +1005,7 @@ def create_purchase_invoice(**args):
 		{
 			"doctype": "Purchase Invoice",
 			"set_posting_time": args.set_posting_time or False,
- 			"posting_date": args.posting_date or today(),
+			"posting_date": args.posting_date or today(),
 			"apply_tds": 0 if args.do_not_apply_tds else 1,
 			"supplier": args.supplier,
 			"company": "_Test Company",
@@ -1004,28 +1155,31 @@ def create_records():
 			{"customer_group": "_Test Customer Group", "customer_name": name, "doctype": "Customer"}
 		).insert()
 
-	# create item
+	has_gst_hsn_code = frappe.db.has_column("Item", "gst_hsn_code")
+
 	if not frappe.db.exists("Item", "TDS Item"):
-		frappe.get_doc(
-			{
-				"doctype": "Item",
-				"item_code": "TDS Item",
-				"item_name": "TDS Item",
-				"item_group": "All Item Groups",
-				"is_stock_item": 0,
-			}
-		).insert()
+		tds_item_data = {
+			"doctype": "Item",
+			"item_code": "TDS Item",
+			"item_name": "TDS Item",
+			"item_group": "All Item Groups",
+			"is_stock_item": 0,
+		}
+		if has_gst_hsn_code:
+			tds_item_data["gst_hsn_code"] = "01011010"
+		frappe.get_doc(tds_item_data).insert()
 
 	if not frappe.db.exists("Item", "TCS Item"):
-		frappe.get_doc(
-			{
-				"doctype": "Item",
-				"item_code": "TCS Item",
-				"item_name": "TCS Item",
-				"item_group": "All Item Groups",
-				"is_stock_item": 1,
-			}
-		).insert()
+		tcs_item_data = {
+			"doctype": "Item",
+			"item_code": "TCS Item",
+			"item_name": "TCS Item",
+			"item_group": "All Item Groups",
+			"is_stock_item": 1,
+		}
+		if has_gst_hsn_code:
+			tcs_item_data["gst_hsn_code"] = "01011010"
+		frappe.get_doc(tcs_item_data).insert()
 
 	# create tds account
 	if not frappe.db.exists("Account", "TDS - _TC"):
@@ -1181,16 +1335,17 @@ def create_tax_withholding_category(
 			}
 		).insert(ignore_permissions=True)
 	elif frappe.db.exists("Tax Withholding Category", category_name):
-		doc = frappe.get_doc("Tax Withholding Category",category_name)
+		doc = frappe.get_doc("Tax Withholding Category", category_name)
 		if doc.accounts:
-			child=frappe.get_doc("Tax Withholding Account",doc.accounts[0].name)
+			child = frappe.get_doc("Tax Withholding Account", doc.accounts[0].name)
 			if child.account != account:
-				child.account=account
+				child.account = account
 				child.save()
 
+
 def create_lower_deduction_certificate(
- 	supplier, tax_withholding_category, tax_rate, certificate_no, limit, valid_from=None, valid_upto=None
- ):
+	supplier, tax_withholding_category, tax_rate, certificate_no, limit, valid_from=None, valid_upto=None
+):
 	fiscal_year = get_fiscal_year(today(), company="_Test Company")
 	if not frappe.db.exists("Lower Deduction Certificate", certificate_no):
 		frappe.get_doc(
@@ -1202,11 +1357,11 @@ def create_lower_deduction_certificate(
 				"tax_withholding_category": tax_withholding_category,
 				"fiscal_year": fiscal_year[0],
 				"valid_from": valid_from or fiscal_year[1],
- 				"valid_upto": valid_upto or fiscal_year[2],
+				"valid_upto": valid_upto or fiscal_year[2],
 				"rate": tax_rate,
 				"certificate_limit": limit,
 			}
-		).insert()
+		).insert(ignore_mandatory=1)
 
 
 def make_pan_no_field():
@@ -1222,3 +1377,50 @@ def make_pan_no_field():
 	}
 
 	create_custom_fields(pan_field, update=1)
+
+
+def get_tax_withholding_category(
+	category_name,
+	rate,
+	from_date,
+	to_date,
+	account,
+	single_threshold=0,
+	cumulative_threshold=0,
+	round_off_tax_amount=0,
+	consider_party_ledger_amount=0,
+	tax_on_excess_amount=0,
+):
+	if not frappe.db.exists("Tax Withholding Category", category_name):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Tax Withholding Category",
+				"name": category_name,
+				"category_name": category_name,
+				"round_off_tax_amount": round_off_tax_amount,
+				"consider_party_ledger_amount": consider_party_ledger_amount,
+				"tax_on_excess_amount": tax_on_excess_amount,
+				"rates": [
+					{
+						"from_date": from_date,
+						"to_date": to_date,
+						"tax_withholding_rate": rate,
+						"single_threshold": single_threshold,
+						"cumulative_threshold": cumulative_threshold,
+					}
+				],
+				"accounts": [{"company": "_Test Company", "account": account}],
+			}
+		)
+		return doc
+	return category_name
+
+
+def get_account():
+	return create_account(
+		account_name="_Test Cash",
+		parent_account="Cash In Hand - _TC",
+		company="_Test Company",
+		account_currency="INR",
+		account_type="Cash",
+	)


### PR DESCRIPTION
## Title – Test Scenarios for Tax Withholding Category, Share Transfer Validations, and Sales Invoice Logic in ERPNext
# Description:
### Test Summary
- These tests rigorously validate critical workflows in ERPNext’s Accounts and Stock modules. Focus areas include Tax Withholding Category validations, Share Transfer lifecycle management, and Sales Invoice compliance and automation logic. The test cases simulate business edge cases, enforce validation rules, and ensure accurate document processing across workflows.

**Doctype – Tax Withholding Category**
- **TC_ACC_232**: Ensures that from_date cannot be after to_date, and overlapping date ranges in rates are properly flagged. Verifies validation for temporal consistency in tax withholding rules.

- **TC_ACC_233**: Validates uniqueness constraints on company-account mapping. Ensures no company or account is duplicated in the configuration, maintaining data integrity.

- **TC_ACC_234**: Ensures logical threshold configuration by validating that the cumulative threshold cannot be less than the single transaction threshold.

- **TC_ACC_235**: Tests the get_tax_withholding_rates utility. Ensures proper exception is raised when tax data is requested for a date outside the withholding validity period.

- **TC_ACC_236**: Validates get_lower_deduction_amount logic for various deduction scenarios. Ensures computation reflects expected tax deduction values under differing thresholds.

- **TC_ACC_237**: Verifies is_valid_certificate for supplier certificates, including edge cases with expired or overutilized certificates. Also checks rounding behavior.

**Doctype – Share Transfer**
- **TC_ACC_238**: Full cycle test of Share Transfer lifecycle: Issue → Purchase → Transfer. Confirms accurate share balances and proper cleanup on cancellation.

- **TC_ACC_239**: Validates basic field constraints like non-empty from_shareholder in Purchase transfers.

- **TC_ACC_240**: Comprehensive validation of required fields and logical consistency across all transfer types (Issue, Purchase, Transfer). Includes same shareholder validation, mismatched share number-range checks, and amount consistency checks.

**Doctype – Sales Invoice**
- **TC_ACC_241**: Tests status indicators (Unpaid, Return, Paid) based on related document status and payment linkage.

- **TC_ACC_242**: Validates that serial numbers match between Delivery Note and generated Sales Invoice.

- **TC_ACC_243**: Tests loyalty program assignment and retrieval for customers based on setup and auto-opt-in configurations.

- **TC_ACC_244**: Validates end-to-end creation of Invoice Discounting document from a Sales Invoice with correct account linkages.

- **TC_ACC_245**: Ensures error is thrown when POS Profile is not configured during a POS invoice creation.

- **TC_ACC_246**: Validates warehouse presence for stock items when update_stock is enabled.

- **TC_ACC_247**: Ensures Sales Order is mandatory when configured so in Selling Settings.

- **TC_ACC_248**: Validates that item cost center belongs to the same company as the invoice, enforcing organizational data integrity.

- **TC_ACC_249**: Tests the context values returned in the Sales Invoice list view controller for proper frontend rendering.

- **TC_ACC_250**: Validates POS field auto-setup during invoice generation from POS Profile.

- **TC_ACC_251**: Ensures that delivery notes marked for stock update cannot be billed again incorrectly in Sales Invoice.

- **TC_ACC_252**: Validates write-off account is not retained if invoice is not POS.

- **TC_ACC_253**: Ensures stock update is blocked for items marked as "drop-shipped" by the supplier.

- **TC_ACC_254**: Validates that the enable_discount_accounting field reflects the global selling setting.

- **TC_ACC_255**: Ensures that the “Debit To” account is of type Receivable, maintaining proper financial mapping.

- **TC_ACC_256**: Validates that “Debit To” must be under a Balance Sheet account, rejecting inappropriate mappings.

- **TC_ACC_257**: Tests the recurring invoice generation using Auto Repeat setup. Ensures correct linkage with the original invoice.

- **TC_ACC_258**: Validates creation of Maintenance Schedule from a Sales Invoice, ensuring data and transactional correctness.

- **TC_ACC_259**: Validates POS return scenarios with write-off amounts, ensuring total payments do not exceed invoice total.

- **TC_ACC_260**: Tests utility methods for fetching mode of payments and default account mappings from Sales Invoice.

- **TC_ACC_261**: Ensures that a return invoice cannot be cancelled if its amount is allocated in a Payment Entry, enforcing financial traceability.

**Doctype –  Process Subscription**
- **TC_ACC_262**: Tests background processing of subscriptions. Ensures that after activating a subscription, the process subscription document correctly links and reflects processing.

### Scenarios Covered
- **Input and Configuration Validations**

  - Tax Withholding date ranges and thresholds
  - Share transfer document field requirements
  - Sales Invoice warehouse, cost centers, accounts, and status transitions

- **Edge Case Handling**

  - Expired or overlapping tax rules

  - Missing or invalid loyalty or delivery data

  - Return invoices linked to active payment entries
  - Auto repeat invoice generation
  - nvoice discounting and maintenance schedules
  - POS profile-based behavior

### Technology
- Python unittest framework
- Frappe test utilities

### Linked Feature/Bug
- N/A

### Issue Tracker ID
- N/A