### PR TITLE
Fix SQL syntax error for empty bundles in serial number query

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -289,7 +289,10 @@ def get_serial_nos_for_outward(kwargs):
 
 	return [d.serial_no for d in serial_nos]
 
+
 def get_serial_nos_from_sle_list(bundles):
+	if not bundles:
+		return {}
 	table = frappe.qb.DocType("Serial and Batch Entry")
 	query = frappe.qb.from_(table).select(table.parent, table.serial_no).where(table.parent.isin(bundles))
 	data = query.run(as_dict=True)


### PR DESCRIPTION
**Title**:
Fix SQL syntax error for empty bundles in serial number query

**Description:**

**Bug Description**
When the bundles list passed to get_serial_nos_from_sle_list was empty, it caused a SQL syntax error. This impacted reports and functions relying on this method, causing them to fail during execution.

**Root Cause**
The issue was caused by generating a SQL query with an empty IN () clause in PostgreSQL, which is not valid syntax.

**Steps to Reproduce:**

Trigger any report or method that calls get_serial_nos_from_sle_list with an empty bundles list.

Observe the traceback in logs or the UI.

**Actual/Observed Result:**
System throws a psycopg2.errors.SyntaxError: syntax error at or near ")".

**Expected Result:**
The method should return an empty dictionary and skip the SQL query when bundles is empty.

**Fix Summary**
A conditional check was added to return early ({}) when the bundles list is empty, thereby avoiding the invalid SQL generation.

**Affected Module**
Stock Reports

**Linked Issue**
#2699 

**PR Reference**
#2699 