### PR TITLE
test: Fixed Quantity KeyError in Product Bundle for Packed Items

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -318,7 +318,7 @@ def get_items_from_product_bundle(row):  # pragma: no cover
 
 	bundled_items = get_product_bundle_items(row["item_code"])
 	for item in bundled_items:
-		row.update({"item_code": item.item_code, "qty": flt(row["quantity"]) * flt(item.qty)})
+		row.update({"item_code": item.item_code, "qty": flt(row["qty"]) * flt(item.qty)})
 		items.append(get_item_details(row))
 
 	return items


### PR DESCRIPTION
**Title:**
Fixed Quantity KeyError in Product Bundle for Packed Items

**Description:**
This fix resolves a KeyError caused by referencing a non-existent quantity field during the unpacking of product bundles into individual Packed Items. The correction ensures that the correct field name qty is used—matching the actual data schema—thereby preventing runtime errors during validation and processing of delivery transactions.

**Test Summary:**
The test case validates the system’s ability to handle product bundles correctly during the on_doctype_update execution. By triggering the get_items_from_product_bundle function with test data from a Product Bundle, the test ensures the logic gracefully handles missing or incorrect fields and raises appropriate validation messages when required fields like Company are not provided.

**Key Fixes Implemented:**

Field Mapping Correction in Product Bundle (TC_SCK_416):
Replaced incorrect reference to a non-existent field quantity with the correct field qty in the product bundle unpacking logic to avoid KeyError and ensure smooth item mapping in delivery documents.

- row.update({"item_code": item.item_code, "qty": flt(row["quantity"]) * flt(item.qty)})
+ row.update({"item_code": item.item_code, "qty": flt(row["qty"]) * flt(item.qty)})

**Doctype(s) Covered:**
🔹 Packed Item

**Test Cases Implemented:**
🔹 **TC_SCK_416**: test_on_doctype_update_TC_SCK_416
Validates the correction of the item unpacking logic, including successful handling of field mappings and address/GST validations. Confirms that validation is triggered when required fields like Company are missing from the unpacking context.

**Expected Results:**
 Correct field qty is used in bundle unpacking logic, eliminating the KeyError.

**Key Enhancements:**
✔ Fixed mapping error by replacing quantity with qty.
✔ Improved test case to simulate real-world GST and delivery validation flows.
✔ Ensured delivery notes and product bundles interact without runtime issues.
✔ Reinforced reliability in Packed Item update flows through proper data mocking.

**Technology Used:**
 Python unittest framework
 Frappe ORM utilities: frappe.get_doc, frappe.db.exists, frappe.throw
 ERPNext Doctypes: Product Bundle, Packed Item, Delivery Note, Address

**Linked Feature/Bug:**
#2709 