### PR TITLE
test: resolved fiscal year issue and changed test case id for multiple reports

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-from datetime import datetime
+from datetime import date, datetime
 
 import frappe
 from frappe.tests.utils import FrappeTestCase, change_settings
@@ -5969,12 +5969,11 @@ class TestPurchaseReceipt(FrappeTestCase):
 		frappe.db.set_value("Purchase Order Item", po_item.name, "billed_amt", 800)
 
 		# Debug: Check PR items linked to PO
-		pr_items = frappe.get_all(
+		frappe.get_all(
 			"Purchase Receipt Item",
 			filters={"purchase_order_item": po_item.name},
 			fields=["name", "parent", "purchase_order_item"],
 		)
-		print("PR Items linked to PO:", pr_items)
 
 		po_details = [po_item.name]
 
@@ -6168,15 +6167,8 @@ class TestPurchaseReceipt(FrappeTestCase):
 			item.purchase_receipt = pr.name
 		pi2.save().submit()
 
-		# Debug: Check PI items linked to PR
-		pi_items = frappe.get_all(
-			"Purchase Invoice Item", filters={"pr_detail": pr_item.name}, fields=["name", "qty", "parent"]
-		)
-		print("PI Items linked to PR:", pi_items)
-
 		# Run the method under test
 		invoiced_qty_map = get_invoiced_qty_map(pr.name)
-		print("Invoiced Qty Map:", invoiced_qty_map)
 
 		# Assert the PR detail was added and quantity was aggregated (4 + 6 = 10)
 		self.assertIn(pr_item.name, invoiced_qty_map)
@@ -6888,34 +6880,53 @@ def setup_fy_gls_cost_center():
 			}
 		).insert()
 
-	# Setup Fiscal Year
-	fiscal_year = frappe.get_all(
+	current_date = datetime.today().date()
+
+	matching_fy_list = frappe.get_all(
 		"Fiscal Year",
-		filters={"year_start_date": ["<=", today()], "year_end_date": [">=", today()], "disabled": 0},
-		fields=["name"],
-		limit=1,
+		filters={
+			"disabled": 0,
+			"year_start_date": ["<=", current_date],
+			"year_end_date": [">=", current_date],
+		},
+		fields=["name", "year_start_date", "year_end_date"],
 	)
+	is_company = False
+	if len(matching_fy_list) > 0:
+		for fy in matching_fy_list:
+			fiscal_year = frappe.get_doc("Fiscal Year", fy["name"])
+			for years in fiscal_year.companies:
+				if years.company == company:
+					is_company = True
+					break
+			if is_company:
+				break
 
-	if fiscal_year:
-		fy_doc = frappe.get_doc("Fiscal Year", fiscal_year[0]["name"])
-		linked_companies = [d.company for d in fy_doc.companies]
+		if not is_company:
+			for rows in matching_fy_list:
+				try:
+					fiscal_year = frappe.get_doc("Fiscal Year", rows.name)
+					fiscal_year.append("companies", {"company": company})
+					fiscal_year.save()
+					break
+				except Exception as e:
+					print(f"Failed to get Fiscal Year {fy['name']}: {e}")
+					continue
 
-		if company.name not in linked_companies:
-			fy_doc.append("companies", {"company": company.name})
-			fy_doc.save()
 	else:
-		# If not exists create new FY
-		fy_doc = frappe.get_doc(
-			{
-				"doctype": "Fiscal Year",
-				"year": f"FY {today()[:4]}",
-				"year_start_date": today(),
-				"year_end_date": add_days(today(), 364),
-				"disabled": 0,
-			}
-		)
-		fy_doc.append("fiscal_year_company", {"company": company.name})
-		fy_doc.insert()
+		# No fiscal year includes current date — create a new one
+		current_year = current_date.year
+		first_date = date(current_year, 1, 1)
+		last_date = date(current_year, 12, 31)
+
+		fiscal_year = frappe.new_doc("Fiscal Year")
+		fiscal_year.year = f"{current_year}-{company}"
+		fiscal_year.year_start_date = first_date
+		fiscal_year.year_end_date = last_date
+		fiscal_year.company = company  # Required to avoid overlap error
+		fiscal_year.append("companies", {"company": company})
+		fiscal_year.save()
+
 	expense_account = f"T Cost of Goods Sold - {company_abbr}"
 	cost_center = f"_Test Cost Center - {company_abbr}"
 	return fiscal_year, expense_account, cost_center
@@ -7230,36 +7241,54 @@ def create_company(company):
 
 
 def get_or_create_fiscal_year(company):
-	from datetime import datetime
+	from datetime import date, datetime
 
-	current_date = datetime.today()
-	formatted_date = current_date.strftime("%d-%m-%Y")
-	existing_fy = frappe.get_all(
+	import frappe
+
+	current_date = datetime.today().date()
+
+	matching_fy_list = frappe.get_all(
 		"Fiscal Year",
 		filters={
-			"year_start_date": ["<=", formatted_date],
-			"year_end_date": [">=", formatted_date],
 			"disabled": 0,
+			"year_start_date": ["<=", current_date],
+			"year_end_date": [">=", current_date],
 		},
-		fields=["name"],
+		fields=["name", "year_start_date", "year_end_date"],
 	)
+	is_company = False
+	if len(matching_fy_list) > 0:
+		for fy in matching_fy_list:
+			fiscal_year = frappe.get_doc("Fiscal Year", fy["name"])
+			for years in fiscal_year.companies:
+				if years.company == company:
+					is_company = True
+					break
+			if is_company:
+				break
 
-	if existing_fy:
-		fiscal_year = frappe.get_doc("Fiscal Year", existing_fy[0].name)
-		for years in fiscal_year.companies:
-			if years.company == company:
-				pass
-			else:
-				fiscal_year.append("companies", {"company": company})
-				fiscal_year.save()
+		if not is_company:
+			for rows in matching_fy_list:
+				try:
+					fiscal_year = frappe.get_doc("Fiscal Year", rows.name)
+					fiscal_year.append("companies", {"company": company})
+					fiscal_year.save()
+					break
+				except Exception as e:
+					print(f"Failed to get Fiscal Year {fy['name']}: {e}")
+					continue
+
 	else:
-		current_year = datetime.now().year
-		first_date = f"01-01-{current_year}"
-		last_date = f"31-12-{current_year}"
+		# No fiscal year includes current date — create a new one
+		current_year = current_date.year
+		first_date = date(current_year, 1, 1)
+		last_date = date(current_year, 12, 31)
+
 		fiscal_year = frappe.new_doc("Fiscal Year")
-		fiscal_year.year = f"{current_year}"
+		fiscal_year.year = f"{current_year}-{company}"
 		fiscal_year.year_start_date = first_date
 		fiscal_year.year_end_date = last_date
+		fiscal_year.company = company  # Required to avoid overlap error
 		fiscal_year.append("companies", {"company": company})
 		fiscal_year.save()
 

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
 
+from datetime import date, datetime
+
 import frappe
 from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import add_days, nowdate, today
@@ -1227,34 +1229,53 @@ def setup_fy_gls_cost_center():
 			}
 		).insert()
 
-	# Setup Fiscal Year
-	fiscal_year = frappe.get_all(
+	current_date = datetime.today().date()
+
+	matching_fy_list = frappe.get_all(
 		"Fiscal Year",
-		filters={"year_start_date": ["<=", today()], "year_end_date": [">=", today()], "disabled": 0},
-		fields=["name"],
-		limit=1,
+		filters={
+			"disabled": 0,
+			"year_start_date": ["<=", current_date],
+			"year_end_date": [">=", current_date],
+		},
+		fields=["name", "year_start_date", "year_end_date"],
 	)
+	is_company = False
+	if len(matching_fy_list) > 0:
+		for fy in matching_fy_list:
+			fiscal_year = frappe.get_doc("Fiscal Year", fy["name"])
+			for years in fiscal_year.companies:
+				if years.company == company:
+					is_company = True
+					break
+			if is_company:
+				break
 
-	if fiscal_year:
-		fy_doc = frappe.get_doc("Fiscal Year", fiscal_year[0]["name"])
-		linked_companies = [d.company for d in fy_doc.companies]
+		if not is_company:
+			for rows in matching_fy_list:
+				try:
+					fiscal_year = frappe.get_doc("Fiscal Year", rows.name)
+					fiscal_year.append("companies", {"company": company})
+					fiscal_year.save()
+					break
+				except Exception as e:
+					print(f"Failed to get Fiscal Year {fy['name']}: {e}")
+					continue
 
-		if company.name not in linked_companies:
-			fy_doc.append("companies", {"company": company.name})
-			fy_doc.save()
 	else:
-		# If not exists create new FY
-		fy_doc = frappe.get_doc(
-			{
-				"doctype": "Fiscal Year",
-				"year": f"FY {today()[:4]}",
-				"year_start_date": today(),
-				"year_end_date": add_days(today(), 364),
-				"disabled": 0,
-			}
-		)
-		fy_doc.append("fiscal_year_company", {"company": company.name})
-		fy_doc.insert()
+		# No fiscal year includes current date — create a new one
+		current_year = current_date.year
+		first_date = date(current_year, 1, 1)
+		last_date = date(current_year, 12, 31)
+
+		fiscal_year = frappe.new_doc("Fiscal Year")
+		fiscal_year.year = f"{current_year}-{company}"
+		fiscal_year.year_start_date = first_date
+		fiscal_year.year_end_date = last_date
+		fiscal_year.company = company  # Required to avoid overlap error
+		fiscal_year.append("companies", {"company": company})
+		fiscal_year.save()
+
 	expense_account = f"T Cost of Goods Sold - {company_abbr}"
 	cost_center = f"_Test Cost Center - {company_abbr}"
 	return fiscal_year, expense_account, cost_center

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2,7 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 
-from datetime import date
+from datetime import date, datetime
 
 from frappe.desk.query_report import run
 from frappe.permissions import add_user_permission, remove_user_permission
@@ -461,7 +461,7 @@ class TestStockEntry(FrappeTestCase):
 				rec["doctype"] = "Company"
 				frappe.get_doc(rec).insert()
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
-		create_fiscal_with_company(company)
+		get_or_create_fiscal_year(company)
 		make_stock_entry(
 			item_code="_Test Item",
 			target="Stores - TCP1",
@@ -2414,7 +2414,7 @@ class TestStockEntry(FrappeTestCase):
 		company = "_Test Company"
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
 
-		create_fiscal_with_company("_Test Company")
+		get_or_create_fiscal_year("_Test Company")
 		self.source_warehouse = create_warehouse(
 			"Stores-test", properties={"parent_warehouse": "All Warehouses - _TC"}, company="_Test Company"
 		)
@@ -4114,7 +4114,7 @@ class TestStockEntry(FrappeTestCase):
 		company = "_Test Company"
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
 
-		get_fiscal_year(company)
+		get_or_create_fiscal_year(company)
 		create_warehouse("_Test Warehouse Group - _TC", company=company)
 		if not frappe.db.exists("Company", company):
 			company_doc = frappe.new_doc("Company")
@@ -4174,7 +4174,7 @@ class TestStockEntry(FrappeTestCase):
 		create_company()
 		company = "_Test Company"
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
-		get_fiscal_year(company)
+		get_or_create_fiscal_year(company)
 		create_warehouse("_Test Warehouse Group - _TC", company=company)
 
 		if not frappe.db.exists("Company", company):
@@ -4407,7 +4407,7 @@ class TestStockEntry(FrappeTestCase):
 		create_company()
 		company = "_Test Company"
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
-		get_fiscal_year(company)
+		get_or_create_fiscal_year(company)
 		create_warehouse("_Test Warehouse Group - _TC", company=company)
 
 		if not frappe.db.exists("Company", company):
@@ -6306,55 +6306,6 @@ def create_company(company):
 		company.insert()
 
 
-def create_fiscal_with_company(company):
-	from datetime import date
-
-	today = date.today()
-	if today.month >= 4:  # Fiscal year starts in April
-		start_date = date(today.year, 4, 1)
-		end_date = date(today.year + 1, 3, 31)
-	else:
-		start_date = date(today.year - 1, 4, 1)
-		end_date = date(today.year, 3, 31)
-
-	FiscalYear = frappe.qb.DocType("Fiscal Year")
-
-	existing_fiscal_years = (
-		frappe.qb.from_(FiscalYear)
-		.select(FiscalYear.name)
-		.where(
-			(FiscalYear.year_start_date <= start_date) & (FiscalYear.year_end_date >= start_date)
-			| (FiscalYear.year_start_date <= end_date) & (FiscalYear.year_end_date >= end_date)
-			| (start_date <= FiscalYear.year_start_date) & (end_date >= FiscalYear.year_start_date)
-			| (start_date <= FiscalYear.year_end_date) & (end_date >= FiscalYear.year_end_date)
-		)
-	).run(as_dict=True)
-
-	# fix for overlapping fiscal year
-	if existing_fiscal_years != []:
-		for fiscal_years in existing_fiscal_years:
-			fy_doc = frappe.get_doc("Fiscal Year", fiscal_years.get("name"))
-			if not frappe.db.exists("Fiscal Year Company", {"company": company, "parent": fy_doc.name}):
-				fy_doc.append("companies", {"company": company})
-				fy_doc.save()
-	else:
-		fy_doc = frappe.new_doc("Fiscal Year")
-		fy_doc.year = "2024-2025"
-		fy_doc.year_start_date = start_date
-		fy_doc.year_end_date = end_date
-		fy_doc.append("companies", {"company": company})
-		fy_doc.submit()
-
-
-def get_fiscal_year(company):
-	if frappe.db.exists("Fiscal Year", "2024-2025"):
-		fiscal_year = frappe.get_doc("Fiscal Year", "2024-2025")
-		fiscal_year.append("companies", {"company": company})
-		fiscal_year.save()
-	else:
-		create_fiscal_with_company(company)
-
-
 def generate_serial_nos(item_code, qty):
 	"""Generate and insert serial numbers for an item."""
 	serial_nos = []
@@ -6377,42 +6328,50 @@ def generate_serial_nos(item_code, qty):
 
 
 def get_or_create_fiscal_year(company):
-	from datetime import datetime
-
-	import frappe
-
 	current_date = datetime.today().date()
-	existing_fy = frappe.get_all(
-		"Fiscal Year", filters={"disabled": 0}, fields=["name", "year_start_date", "year_end_date"]
+
+	matching_fy_list = frappe.get_all(
+		"Fiscal Year",
+		filters={
+			"disabled": 0,
+			"year_start_date": ["<=", current_date],
+			"year_end_date": [">=", current_date],
+		},
+		fields=["name", "year_start_date", "year_end_date"],
 	)
-	updated_existing_fy = None
-
-	for d in existing_fy:
-		start_date = (
-			d.year_start_date.date() if isinstance(d.year_start_date, datetime) else d.year_start_date
-		)
-		end_date = d.year_end_date.date() if isinstance(d.year_end_date, datetime) else d.year_end_date
-		if start_date <= current_date <= end_date:
-			updated_existing_fy = d.name
-			break
-
 	is_company = False
-	if updated_existing_fy:
-		fiscal_year = frappe.get_doc("Fiscal Year", updated_existing_fy)
-		for years in fiscal_year.companies:
-			if years.company == company:
-				is_company = True
+	if len(matching_fy_list) > 0:
+		for fy in matching_fy_list:
+			fiscal_year = frappe.get_doc("Fiscal Year", fy["name"])
+			for years in fiscal_year.companies:
+				if years.company == company:
+					is_company = True
+					break
+			if is_company:
+				break
+
 		if not is_company:
-			fiscal_year.append("companies", {"company": company})
-			fiscal_year.save()
+			for rows in matching_fy_list:
+				try:
+					fiscal_year = frappe.get_doc("Fiscal Year", rows.name)
+					fiscal_year.append("companies", {"company": company})
+					fiscal_year.save()
+					break
+				except Exception as e:
+					print(f"Failed to get Fiscal Year {fy['name']}: {e}")
+					continue
+
 	else:
-		current_year = datetime.now().year
+		# No fiscal year includes current date — create a new one
+		current_year = current_date.year
 		first_date = date(current_year, 1, 1)
 		last_date = date(current_year, 12, 31)
+
 		fiscal_year = frappe.new_doc("Fiscal Year")
 		fiscal_year.year = f"{current_year}-{company}"
 		fiscal_year.year_start_date = first_date
 		fiscal_year.year_end_date = last_date
+		fiscal_year.company = company  # Required to avoid overlap error
 		fiscal_year.append("companies", {"company": company})
 		fiscal_year.save()
 

--- a/erpnext/stock/report/available_batch_report/test_available_batch_report.py
+++ b/erpnext/stock/report/available_batch_report/test_available_batch_report.py
@@ -52,7 +52,7 @@ class TestAvailableBatchReport(FrappeTestCase):
 		default_filters.update(overrides)
 		return SimpleNamespace(**default_filters)
 
-	def test_get_batchwise_data_to_date_T_ABR_001(self):
+	def test_get_batchwise_data_to_date_TC_SCK_498(self):
 		filters = self.make_filters(to_date="2025-12-31")
 		columns, data = available_batch_report.execute(filters)
 		self.assertEqual(len(data), 6)
@@ -75,7 +75,7 @@ class TestAvailableBatchReport(FrappeTestCase):
 			self.assertIsInstance(row["balance_qty"], float)
 			self.assertIn(row["item_code"], [d["item_code"] for d in data])
 
-	def test_get_batchwise_data_multiple_filters_T_ABR_002(self):
+	def test_get_batchwise_data_multiple_filters_TC_SCK_499(self):
 		filters = self.make_filters(
 			item_code=self.item.name,
 			warehouse=self.warehouse,
@@ -110,7 +110,7 @@ class TestAvailableBatchReport(FrappeTestCase):
 		self.assertTrue(expected_fieldnames.issubset(returned_fieldnames))
 
 	# Added: test for execute()
-	def test_execute_function_T_ABR_003(self):
+	def test_execute_function_TC_SCK_500(self):
 		filters = self.make_filters(
 			item_code=self.item.name,
 			warehouse=self.warehouse,
@@ -138,7 +138,7 @@ class TestAvailableBatchReport(FrappeTestCase):
 		actual_column_fields = {col["fieldname"] for col in columns}
 		self.assertTrue(expected_column_fields.issubset(actual_column_fields))
 
-	def test_to_date_today_with_expiry_check_T_ABR_004(self):
+	def test_to_date_today_with_expiry_check_TC_SCK_501(self):
 		self.batch.expiry_date = today()
 		self.batch.reload()
 		self.batch.save()
@@ -154,7 +154,7 @@ class TestAvailableBatchReport(FrappeTestCase):
 		self.assertEqual(row["warehouse"], "Stores - _TC")
 		self.assertEqual(row["balance_qty"], 30.0)
 
-	def test_to_date_today_with_expired_batches_included_T_ABR_005(self):
+	def test_to_date_today_with_expired_batches_included_TC_SCK_502(self):
 		# Expired batch with include_expired_batches=True
 		self.batch.expiry_date = "2000-01-01"
 		self.batch.reload()
@@ -168,7 +168,7 @@ class TestAvailableBatchReport(FrappeTestCase):
 		self.assertEqual(row["warehouse"], "Stores - _TC")
 		self.assertEqual(row["balance_qty"], 25.0)
 
-	def test_get_batchwise_data_from_serial_batch_bundle_T_ABR_006(self):
+	def test_get_batchwise_data_from_serial_batch_bundle_TC_SCK_503(self):
 		from frappe import generate_hash
 		from frappe.utils import now_datetime
 

--- a/erpnext/stock/report/item_price_stock/test_item_price_stock.py
+++ b/erpnext/stock/report/item_price_stock/test_item_price_stock.py
@@ -42,7 +42,7 @@ class TestItemPriceReport(FrappeTestCase):
 		frappe.delete_doc("Price List", self.buying_pl.name, force=1)
 		frappe.delete_doc("Price List", self.selling_pl.name, force=1)
 
-	def test_item_price_stock_execute_T_IPS_001(self):
+	def test_item_price_stock_execute_TC_SCK_510(self):
 		filters = {"item_code": self.item.name}
 		columns, data = item_price_stock.execute(filters)
 

--- a/erpnext/stock/report/stock_and_account_value_comparison/test_stock_and_account_value_comparison.py
+++ b/erpnext/stock/report/stock_and_account_value_comparison/test_stock_and_account_value_comparison.py
@@ -22,7 +22,7 @@ class TestStockAndAccountValueComparison(FrappeTestCase):
 		self.create_stock_ledger_entry()
 		self.create_gl_entry()
 
-	def test_report_execute_and_columns_and_data_T_SAAVC_001(self):
+	def test_report_execute_and_columns_and_data_TC_SCK_511(self):
 		filters = frappe._dict({"company": self.company, "as_on_date": self.posting_date})
 		columns, data = execute(filters)
 		# Columns structure
@@ -50,7 +50,7 @@ class TestStockAndAccountValueComparison(FrappeTestCase):
 				row["difference_value"], row["stock_value"] - row["account_value"], places=2
 			)
 
-	def test_report_execute_with_account_filter_T_SAAVC_002(self):
+	def test_report_execute_with_account_filter_TC_SCK_512(self):
 		filters = frappe._dict(
 			{"company": self.company, "as_on_date": self.posting_date, "account": self.account}
 		)
@@ -60,7 +60,7 @@ class TestStockAndAccountValueComparison(FrappeTestCase):
 			self.assertIn("account_value", row)
 			self.assertIn("stock_value", row)
 
-	def test_report_perpetual_inventory_disabled_T_SAAVC_003(self):
+	def test_report_perpetual_inventory_disabled_TC_SCK_513(self):
 		import erpnext
 
 		filters = frappe._dict({"company": self.company, "as_on_date": self.posting_date})
@@ -70,7 +70,7 @@ class TestStockAndAccountValueComparison(FrappeTestCase):
 			execute(filters)
 		erpnext.is_perpetual_inventory_enabled = original
 
-	def test_data_difference_filtering_T_SAAVC_004(self):
+	def test_data_difference_filtering_TC_SCK_514(self):
 		# Manipulate GL Entry to force a difference > 0.1
 		frappe.db.set_value(
 			"GL Entry",
@@ -82,7 +82,7 @@ class TestStockAndAccountValueComparison(FrappeTestCase):
 		_, data = execute(filters)
 		self.assertTrue(any(abs(row["difference_value"]) > 0.1 for row in data))
 
-	def test_posting_time_conversion_T_SAAVC_005(self):
+	def test_posting_time_conversion_TC_SCK_515(self):
 		filters = frappe._dict({"company": self.company, "as_on_date": self.posting_date})
 		_, data = execute(filters)
 		for row in data:
@@ -91,7 +91,7 @@ class TestStockAndAccountValueComparison(FrappeTestCase):
 
 				self.assertIsInstance(row["posting_time"], timedelta)
 
-	def test_create_reposting_entries_T_SAAVC_006(self):
+	def test_create_reposting_entries_TC_SCK_516(self):
 		from unittest.mock import patch
 
 		from erpnext.stock.report.stock_and_account_value_comparison.stock_and_account_value_comparison import (

--- a/erpnext/stock/report/total_stock_summary/test_total_stock_summary.py
+++ b/erpnext/stock/report/total_stock_summary/test_total_stock_summary.py
@@ -41,7 +41,7 @@ class TestTotalStockSummary(FrappeTestCase):
 
 		self.filters = {"group_by": "Warehouse", "company": "_Test Company"}
 
-	def test_execute_without_filters_T_TSS_001(self):
+	def test_execute_without_filters_TC_SCK_517(self):
 		from erpnext.stock.report.total_stock_summary.total_stock_summary import execute
 
 		# Test with filters - group by Warehouse


### PR DESCRIPTION
### Bug Description
- An error occurs when executing a test that attempts to create a new fiscal year using get_or_create_fiscal_year("_Test Company"). The operation fails during validation due to overlapping fiscal year dates.

### Root Cause
- The Fiscal Year document being created or saved has start and/or end dates that overlap with an existing fiscal year (2024-2025). This leads to a frappe.exceptions.NameError being raised in the validate_overlap method.
The issue may also stem from the company field not being set, which could cause the validation to check against global fiscal years instead of company-specific ones.

### Expected Result
- The test should create a new fiscal year successfully for _Test Company without any overlap errors, and the fiscal year should be properly associated with the company.

### Actual Result
- A frappe.exceptions.NameError is raised:
"Year start date or end date is overlapping with 2024-2025. To avoid please set company"
- This interrupts the test flow and fails the setup.

### Fix Summary
- Ensure that the Fiscal Year document includes a valid company field ("_Test Company" in this case).
- Update the get_or_create_fiscal_year function to check for existing fiscal years specific to the company before creating a new one.
- Optionally, clean up test data or isolate it with mock/fake data to prevent conflicts with existing records.

### Affected Module
- ERPNext > Accounts > Fiscal Year

### Test Case Id:
**Report**
- item_price_stock
- stock_and_account_value_comparison
- total_stock_summary
- available_batch_report
 **Test Case**
 - TC_SCK_266
 - TC_SCK_286
 - TC_SCK_288

### Issue Id:
 #2646 
