### PR TITLE
test:  Payment Term is Required in Payment Entry Reference Issue

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -3666,7 +3666,9 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 	def test_fully_paid_of_pi_to_pr_to_pe_with_gst_TC_B_084(self):
 		frappe.set_user("Administrator")
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
 
+		frappe.set_value("Supplier", "_Test Supplier", "payment_terms", None)
 		template = frappe.get_all(
 			"Purchase Taxes and Charges Template",
 			filters={


### PR DESCRIPTION
### Bug Description
- When saving a Payment Entry linked to a Purchase Invoice that has Payment Term based allocation enabled, the system throws a validation error requiring a Payment Term selection in the Payment References section. This prevents the Payment Entry from being saved without specifying the Payment Term.

### Root Cause
- The Purchase Invoice has Payment Term based allocation enabled, but the Payment Entry references do not include the required payment_term field for the linked invoice. The validation logic in validate_allocated_amount_with_latest_data() enforces this requirement and raises an error if the Payment Term is not selected.

### Expected Result
- The Payment Entry should allow saving only when a Payment Term is selected for each referenced Purchase Invoice with Payment Term based allocation enabled.

### Actual Result
- Attempting to save a Payment Entry without specifying the Payment Term for the Purchase Invoice reference raises a ValidationError with the message:
<Purchase Invoice ID> has Payment Term based allocation enabled. Select a Payment Term for Row #1 in Payment References section

### Fix Summary
- Ensure that when creating or updating a Payment Entry that references a Purchase Invoice with Payment Term based allocation enabled, the correct payment_term value is included in each reference entry. Update test cases and payment entry creation logic to append the relevant Payment Term to the references list before saving.

### Affected Module
- erpnext.accounts.doctype.payment_entry
- Related to Purchase Invoice and Payment Entry doctypes, specifically in Payment Term based allocation and payment reference validation logic.

### Test Case Id:
- TC_B_084

### Issue Id:
#2722 

