### PR TITLE
test: ix Due Date Validation for Purchase Invoice with Payment Terms Template

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1506,7 +1506,7 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 		pi = create_purchase_invoice_from_receipt(pr.name)
 		pi.set_posting_time = 1
-		pi.posting_date = add_days(pr.posting_date, -1)
+		pi.posting_date = add_days(pr.posting_date, 1)
 		pi.items[0].expense_account = "Cost of Goods Sold - _TC"
 		pi.save()
 		pi.submit()
@@ -1515,8 +1515,8 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 		# Check GLE for Purchase Invoice
 		expected_gle = [
-			["Cost of Goods Sold - _TC", 250, 0, add_days(pr.posting_date, -1)],
-			["Creditors - _TC", 0, 250, add_days(pr.posting_date, -1)],
+			["Cost of Goods Sold - _TC", 250, 0, add_days(pr.posting_date, 1)],
+			["Creditors - _TC", 0, 250, add_days(pr.posting_date, 1)],
 		]
 
 		check_gl_entries(self, pi.name, expected_gle, pi.posting_date)


### PR DESCRIPTION
### Bug Description
- When creating or saving a Purchase Invoice during the test_provisional_accounting_entry, a validation error occurs:
"Due / Reference Date cannot be after 29-06-2025".
This halts the process, preventing the invoice from being saved.

### Root Cause
- The Purchase Invoice uses a Payment Terms Template that calculates the due date based on the posting date or bill date. In this case, the computed due date exceeds the maximum allowed by the template (or the system's logic), which triggered the - - - validation error.
The validation function validate_due_date_with_template() compares the due date against calculated limits from the template and throws an error if it exceeds the allowed date.

### Expected Result
- The system should allow the Purchase Invoice to be saved only if the computed due/reference date complies with the conditions set by the Payment Terms Template.
If the due date is calculated automatically, it should fall within the expected allowed range.

### Actual Result
- The test attempts to save a Purchase Invoice whose due/reference date exceeds the maximum permissible date, resulting in a ValidationError.
This prevents the document from being saved or submitted.

### Fix Summary
- Adjust the due_date or bill_date in the test case to fall within the allowed range computed by the Payment Terms Template.
- Alternatively, update or mock the Payment Terms Template used in the test to allow a broader range if needed.
- Ensure date calculations in tests dynamically respect the current date and template logic to avoid future date-based test failures.

### Affected Module
- erpnext.accounts.doctype.purchase_invoice

### Test Case Id:
test_provisional_accounting_entry

### Issue Id:
 #2730 
