### PR TITLE
test: Test case to cover for Bank Clearance document validation rules as well to verifying mandatory field requirements when fetching payment entries

### DIFF
--- a/erpnext/accounts/doctype/bank_account_subtype/bank_account_subtype.py
+++ b/erpnext/accounts/doctype/bank_account_subtype/bank_account_subtype.py
@@ -11,7 +11,7 @@ class BankAccountSubtype(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		account_subtype: DF.Data | None

--- a/erpnext/accounts/doctype/bank_account_type/bank_account_type.py
+++ b/erpnext/accounts/doctype/bank_account_type/bank_account_type.py
@@ -12,7 +12,7 @@ class BankAccountType(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		account_type: DF.Data | None

--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -20,7 +20,7 @@ class BankClearance(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.bank_clearance_detail.bank_clearance_detail import (
@@ -157,7 +157,6 @@ def get_payment_entries_for_bank_clearance(
 		{"account": account, "from": from_date, "to": to_date},
 		as_dict=1,
 	)
-
 
 	payment_entries = frappe.db.sql(
 		f"""

--- a/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
@@ -5,16 +5,18 @@ import unittest
 
 import frappe
 from frappe.utils import add_months, getdate
+
 from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 from erpnext.accounts.doctype.mode_of_payment.test_mode_of_payment import (
 	set_default_account_for_mode_of_payment,
 )
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
-from erpnext.tests.utils import if_lending_app_installed, if_lending_app_not_installed
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+from erpnext.tests.utils import if_lending_app_installed, if_lending_app_not_installed
+
 
 class TestBankClearance(unittest.TestCase):
 	@classmethod
@@ -96,7 +98,7 @@ class TestBankClearance(unittest.TestCase):
 		bank_clearance.to_date = getdate()
 		bank_clearance.get_payment_entries()
 		self.assertEqual(len(bank_clearance.payment_entries), 3)
-	
+
 	def test_update_clearance_date_on_si(self):
 		sales_invoice = make_pos_sales_invoice()
 		date = getdate()
@@ -117,6 +119,49 @@ class TestBankClearance(unittest.TestCase):
 			"clearance_date",
 		)
 		self.assertEqual(si_clearance_date, date)
+
+	def test_get_payment_entries_TC_ACC_276(self):
+		self.bank_account = create_bank_account()
+		bank_clearance = frappe.get_doc(
+			{
+				"doctype": "Bank Clearance",
+				"account": self.bank_account,
+				"from_date": "2023-01-01",
+				"to_date": "2023-01-31",
+			}
+		)
+		bank_clearance.from_date = None
+		bank_clearance.to_date = None
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			bank_clearance.get_payment_entries()
+
+		self.assertEqual(str(cm.exception), "From Date and To Date are Mandatory")
+
+		bank_clearance.from_date = "2023-01-01"
+		bank_clearance.to_date = "2023-01-31"
+		bank_clearance.account = None
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			bank_clearance.get_payment_entries()
+
+		self.assertEqual(str(cm.exception), "Account is mandatory to get payment entries")
+
+
+def create_bank_account():
+	"""Utility function to create a test bank account"""
+	if not frappe.db.exists("Account", "_Test Bank Account - _TC"):
+		acc = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": "_Test Bank Account",
+				"parent_account": "Bank Accounts - _TC",
+				"company": "_Test Company",
+				"account_type": "Bank",
+			}
+		).insert()
+		return acc.name
+	return "_Test Bank Account - _TC"
 
 
 def clear_payment_entries():
@@ -155,6 +200,7 @@ def add_transactions():
 
 def make_payment_entry():
 	from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+
 	supplier = create_supplier(supplier_name="_Test Supplier")
 	pi = make_purchase_invoice(
 		supplier=supplier,
@@ -169,6 +215,7 @@ def make_payment_entry():
 	pe.reference_date = "2018-10-24"
 	pe.insert(ignore_permissions=True)
 	pe.submit()
+
 
 def make_pos_sales_invoice():
 	from erpnext.accounts.doctype.opening_invoice_creation_tool.test_opening_invoice_creation_tool import (

--- a/erpnext/accounts/doctype/bank_clearance_detail/bank_clearance_detail.py
+++ b/erpnext/accounts/doctype/bank_clearance_detail/bank_clearance_detail.py
@@ -11,7 +11,7 @@ class BankClearanceDetail(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		against_account: DF.Data | None


### PR DESCRIPTION
**Description:**
This PR introduces test coverage for Bank Clearance document validation rules, specifically verifying mandatory field requirements when fetching payment entries.

Test Case:
>TC_ACC_276 (test_get_payment_entries_TC_ACC_276)

- Validates mandatory field checks for payment entry retrieval
- Tests both date range and account field validation
- Verifies proper error messages for missing:
-- From Date and To Date
-- Bank Account
- Ensures error messages are specific and actionable

**Scenarios Covered:**
Missing date range validation
Missing account validation
Error message accuracy
Field requirement enforcement

**Technology Stack:**
Frappe Framework
Python unittest
ERPNext Banking Module
ERPNext Accounts Integration