### PR TITLE
fix: Maintenance Visit Button Fails After Reopening a Closed Warranty Claim #2743

### DIFF
--- a/erpnext/support/doctype/warranty_claim/warranty_claim.py
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.py
@@ -92,7 +92,6 @@ def make_maintenance_visit(source_name, target_doc=None):
 		and t1.docstatus=1 and t1.completion_status='Fully Completed'""",
 		source_name,
 	)
-
 	if not visit:
 		target_doc = get_mapped_doc(
 			"Warranty Claim",
@@ -107,3 +106,5 @@ def make_maintenance_visit(source_name, target_doc=None):
 			map_child_doc(source_doc, target_doc, table_map, source_doc)
 
 		return target_doc
+	else :
+		frappe.throw(_("Maintenance Visit {0} already exists").format(visit[0][0]))


### PR DESCRIPTION
Title: Fix: Properly handle existing Maintenance Visit case in make_maintenance_visit method

Description:

Bug Description
The make_maintenance_visit server-side method did not appropriately handle the scenario where a Maintenance Visit already exists for a given Warranty Claim. The else condition was not structured correctly, leading to potential continuation of logic or ambiguity in behavior when a duplicate visit was already completed.

Root Cause
The previous implementation lacked a clearly defined else block after checking for existing Maintenance Visits. As a result, even if an existing visit was found, the function might not correctly stop further execution or give a clear error.

Steps to reproduce:

Create a Warranty Claim.

Create and submit a Maintenance Visit with status "Fully Completed" linked to the Warranty Claim.

Call make_maintenance_visit() on the same Warranty Claim.

Actual/Observed Result:
A new Maintenance Visit could still be created or the function may behave inconsistently.

Expected Result:
The function should throw an error stating that a Maintenance Visit already exists and must not proceed to create a new one.

Fix Summary
Added a proper else block to halt execution and throw a descriptive error when a completed Maintenance Visit is already present.

Ensured the logic only allows creation if no such visit exists.

Affected Module
Warranty Claim to Maintenance Visit Mapping

Maintenance Visit creation flow


Linked Issue
Fixes #2743
