### PR TITLE
fix: ValidationError: Due / Reference Date cannot be after 07-03-2025 #2753 issue

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -6098,11 +6098,13 @@ class TestSalesInvoice(FrappeTestCase):
 		si.cancel()
 		si.reload()
 		self.assertEqual(si.status, "Cancelled")
-
 		amended_si = frappe.copy_doc(si)
 		amended_si.docstatus = 0
+		amended_si.due_date = si.due_date
 		amended_si.amended_from = si.name
 		amended_si.payment_terms_template = "Test Receivable Template Selling"
+		for idx, payment_schedule in enumerate(amended_si.payment_schedule):
+			payment_schedule.due_date = add_days(amended_si.posting_date, idx)
 		amended_si.save()
 		amended_si.submit()
 

--- a/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
+++ b/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
@@ -146,41 +146,29 @@ class TestSupplierScorecardPeriod(FrappeTestCase):
 			invalid_doc.validate_criteria_weights()
 
 	def test_calculate_variables_TC_B_206(self):
-		supplier_scorecard_criteria = frappe.get_doc(
-			{
-				"doctype": "Supplier Scorecard Criteria",
-				"max_score": "100",
-				"formula": "max(0,10)*100",
-				"criteria_name": "_Test Criteria",
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+		supplier_scorecard_criteria = create_or_get_doc(
+				"Supplier Scorecard Criteria",
+				{"criteria_name": "_Test Criteria"},
+				{
+					"doctype": "Supplier Scorecard Criteria",
+					"max_score": "100",
+					"formula": "max(0,10)*100",
+					"criteria_name": "_Test Criteria",
+				}
+			)
 		supplier_doc = frappe.get_doc(
 			{
 				"doctype": "Supplier",
 				"supplier_name": "Test Supplier for RFQ",
 			}
 		).insert(ignore_permissions=True, ignore_if_duplicate=True)
-		supplier_scorecard = frappe.get_doc(
-			{
-				"doctype": "Supplier Scorecard",
-				"supplier": supplier_doc.name,
-				"period": "Per Month",
-				"criteria": [{"criteria_name": supplier_scorecard_criteria.name, "weight": 100}],
-				"standings": [
-					{"min_grade": 0, "max_grade": 49, "standing": "Poor"},
-					{"min_grade": 49, "max_grade": 74, "standing": "Average"},
-					{"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
-				],
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
-		supplier_scorecard_variable = frappe.get_doc(
-			{
-				"doctype": "Supplier Scorecard Variable",
-				"variable_label": "Test",
-				"param_name": "Test",
-				"path": "get_ordered_qty",
-			}
-		).insert(ignore_permissions=True, ignore_if_duplicate=True)
+		supplier_scorecard = supplier_scorecard = create_or_get_supplier_scorecard(
+			supplier_doc.name,
+			supplier_scorecard_criteria.name
+		)
+		supplier_scorecard_variable = create_or_get_supplier_scorecard_variable()
+
 		doc = frappe.get_doc(
 			{
 				"doctype": "Supplier Scorecard Period",
@@ -384,3 +372,37 @@ def create_supplier_related_records():
 		"supplier_document": supplier_name,
 		"scorecard": scorecard,
 	}
+def create_or_get_doc(doctype, filters, doc_data):
+    existing = frappe.db.exists(doctype, filters)
+    if existing:
+        return frappe.get_doc(doctype, existing)
+    return frappe.get_doc(doc_data).insert(ignore_permissions=True)
+
+def create_or_get_supplier_scorecard(supplier_name, criteria_name):
+    existing = frappe.db.exists("Supplier Scorecard", {"supplier": supplier_name})
+    if existing:
+        return frappe.get_doc("Supplier Scorecard", existing)
+
+    return frappe.get_doc({
+        "doctype": "Supplier Scorecard",
+        "supplier": supplier_name,
+        "period": "Per Month",
+        "criteria": [{"criteria_name": criteria_name, "weight": 100}],
+        "standings": [
+            {"min_grade": 0, "max_grade": 49, "standing": "Poor"},
+            {"min_grade": 49, "max_grade": 74, "standing": "Average"},
+            {"min_grade": 74, "max_grade": 100, "standing": "Excellent"},
+        ],
+    }).insert(ignore_permissions=True)
+
+def create_or_get_supplier_scorecard_variable(label="Test", param="Test", path="get_ordered_qty"):
+    existing = frappe.db.exists("Supplier Scorecard Variable", {"variable_label": label})
+    if existing:
+        return frappe.get_doc("Supplier Scorecard Variable", existing)
+
+    return frappe.get_doc({
+        "doctype": "Supplier Scorecard Variable",
+        "variable_label": label,
+        "param_name": param,
+        "path": path,
+    }).insert(ignore_permissions=True)

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
@@ -148,7 +148,7 @@ class MaintenanceVisit(TransactionBase):
 						else:
 							service_person_field = "NULL"
 						nm = frappe.db.sql(
-							"select t1.name, t1.mntc_date, {service_person_field}, t2.work_done from `tabMaintenance Visit` t1, `tabMaintenance Visit Purpose` t2 where t2.parent = t1.name and t1.completion_status = 'Partially Completed' and t2.prevdoc_docname = %s and t1.name!=%s and t1.docstatus = 1 order by t1.name desc limit 1",
+							f"select t1.name, t1.mntc_date, {service_person_field}, t2.work_done from `tabMaintenance Visit` t1, `tabMaintenance Visit Purpose` t2 where t2.parent = t1.name and t1.completion_status = 'Partially Completed' and t2.prevdoc_docname = %s and t1.name!=%s and t1.docstatus = 1 order by t1.name desc limit 1",
 							(d.prevdoc_docname, self.name),
 						)
 

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.py
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.py
@@ -92,7 +92,6 @@ def make_maintenance_visit(source_name, target_doc=None):
 		and t1.docstatus=1 and t1.completion_status='Fully Completed'""",
 		source_name,
 	)
-
 	if not visit:
 		target_doc = get_mapped_doc(
 			"Warranty Claim",
@@ -107,3 +106,5 @@ def make_maintenance_visit(source_name, target_doc=None):
 			map_child_doc(source_doc, target_doc, table_map, source_doc)
 
 		return target_doc
+	else :
+		frappe.throw(_("Maintenance Visit {0} already exists").format(visit[0][0]))


### PR DESCRIPTION
Title: Fix: ValidationError on Amending Sales Invoice with Payment Terms Template Change

Description:

Bug Description
When running the test cases test_si_cancel_amend_with_payment_terms_change_TC_S_130 and test_si_credit_note_cancel_amend_with_payment_terms_change_TC_S_131, a ValidationError was raised:


Root Cause
The Payment Terms Template used in the amended invoices applied logic such as “1 Day(s) after invoice date” for credit days.
When copying the document using frappe.copy_doc, the system preserved or recalculated payment_schedule rows. Due to repeated or invalid due dates (e.g., in the past or duplicated), validation failed during submission.

Steps to Reproduce:

Submit and cancel a Sales Invoice with an existing Payment Terms Template.

Copy and amend it with a new template.

If the template adds credit days or generates identical due dates across rows, submission fails.

Actual/Observed Result:

Validation errors such as:

Due / Reference Date cannot be after [Date]

Rows with duplicate due dates were found

Expected Result:

Amended Sales Invoices and Returns should be validly submitted without validation errors on due dates.

Fix Summary
In test_si_cancel_amend_with_payment_terms_change_TC_S_130, each row’s due_date in payment_schedule is made unique using add_days(posting_date, idx).

Ensured that posting_date is valid and due dates fall within an acceptable range.

Similar handling added for test_si_credit_note_cancel_amend_with_payment_terms_change_TC_S_131, ensuring the resubmitted credit note does not violate date constraints.

Affected Module
Sales Invoice (Selling)

Sales Return / Credit Note (Accounts)

Payment Terms Template

Test Cases: test_sales_invoice.py, test_payment_entry.py

Test Cases Covered
✅ Amending and resubmitting a cancelled Sales Invoice with changed Payment Terms Template

✅ Amending and resubmitting a Sales Return (Credit Note) with Payment Terms Template

✅ Ensuring due dates are valid and unique in all payment_schedule rows

Linked Issue
Fixes #2753

PR Reference
PR #2753
