### PR TITLE
Test: Add new test cases for Serial No doctype

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -31,7 +31,7 @@ class SerialNo(StockController):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		amc_expiry_date: DF.Date | None

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -327,6 +327,537 @@ class TestSerialNo(FrappeTestCase):
 		)
 
 		self.assertEqual(non_expired_serials, [])
+  
+	def test_get_pos_reserved_serial_nos_TC_ACC_302(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.item.test_item import (make_item, get_hsn)
+		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import validate_fiscal_year
+		create_company()
+		validate_fiscal_year("_Test Company")
+		warehouse = create_warehouse("_Test Warehouse", company="_Test Company")
+		create_cost_center(cost_center_name="_Test Cost Center", company="_Test Company")
+
+		item_code = "_Test Item POS"
+
+		item = make_item(
+			item_code,
+			{
+				"has_serial_no": 1,
+				"serial_no_series": "SN-.#####",
+				"is_stock_item": 1,
+				"valuation_rate": 500,
+				"gst_hsn_code": get_hsn(),
+			}
+		)
+		pos_profile = frappe.get_doc({
+		"doctype": "POS Profile",
+		"name": "_Test POS Profile New Serial No",
+		"company": "_Test Company",
+		"currency": "INR",
+		"write_off_cost_center": "_Test Cost Center - _TC",
+		"write_off_account": "Sales - _TC",
+		"warehouse": warehouse,	
+		"accounts": [{
+			"company": "_Test Company",
+			"account": "_Test Account - _TC"  
+		}],
+		"payments": [{
+				"default": 1,
+				"mode_of_payment": "Cash",  
+				"account": "Cash - _TC"
+			}],
+		"warehouses": [{
+			"warehouse": warehouse
+			}]
+		})
+		pos_profile.insert()
+
+		se = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"stock_entry_type": "Material Receipt",
+			"company": "_Test Company",
+			"items": [
+				{
+					"item_code": item.name,
+					"qty": 1,
+					"t_warehouse": warehouse
+				},
+				{
+					"item_code": item.name,
+					"qty": 1,
+					"t_warehouse": warehouse
+				}
+			]
+		})
+		se.insert()
+		se.submit()
+
+		serial_nos = frappe.get_all("Serial No", filters={"item_code": item.name, "warehouse": warehouse}, fields=["name"])
+		serial_no_1 = serial_nos[0].name
+		pos_opening_entry = frappe.get_doc({
+			"doctype": "POS Opening Entry",
+			"pos_profile": pos_profile.name,
+			"company": "_Test Company",
+			"user": "Administrator",
+			"period_start_date": frappe.utils.get_datetime(),
+			"mode_of_payment": "Cash",
+			"balance_details": [
+				{
+					"account": "Sales - _TC",
+					"mode_of_payment": "Cash",
+					"account_currency": "INR",
+					"opening_amount": 1000
+				}									
+			],
+			"posting_date": frappe.utils.today(),
+			"cash_denominations": [
+				{
+					"mode_of_payment": "Cash",
+					"account": "Cash - _TC",
+					"opening_amount": 1000
+				}
+			]
+		})
+		pos_opening_entry.insert()
+		pos_opening_entry.submit()
+		pos_invoice = frappe.get_doc({
+			"doctype": "POS Invoice",
+			"docstatus": 1,
+			"pos_profile": pos_profile.name,
+			"company": "_Test Company",
+			"cost_center": "_Test Cost Center - _TC",
+			"is_return": 0,
+			"paid_amount": 1000,
+			"items": [{
+				"item_code": item.name,
+				"warehouse": warehouse,
+				"serial_no": serial_no_1,
+				"qty": 1
+			}],
+			"payments": [
+				{
+					"mode_of_payment": "Cash",
+					"account": "Cash - _TC",
+					"amount": 1000
+				}
+			]
+		}).insert()
+
+		filters = {
+			"item_code": item.name,
+			"warehouse": warehouse
+		}
+
+		result = get_pos_reserved_serial_nos(filters)
+		self.assertIsInstance(result, list)
+		self.assertEqual(len(result), 1)
+		self.assertEqual(result[0], serial_no_1)
+	
+	def test_auto_fetch_serial_number_basic_TC_ACC_303(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			create_company,
+		)
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import validate_fiscal_year
+
+		create_company("_Test Company")
+		validate_fiscal_year("_Test Company")
+
+		if not frappe.db.exists("Supplier", "_Test Supplier Auto Fetch"):
+			frappe.get_doc({
+				"doctype": "Supplier",
+				"supplier_name": "_Test Supplier Auto Fetch",
+				"company": "_Test Company"
+			}).insert(ignore_mandatory=True,ignore_permissions=True,ignore_links=True)
+		if not frappe.db.exists("UOM", "_Test UOM"):
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+				"company": "_Test Company"
+			}).insert(ignore_mandatory=True,ignore_permissions=True,ignore_links=True)
+		warehouse = create_warehouse("_Test Warehouse Auto Fetch", company="_Test Company")
+
+		account = frappe.get_doc({
+			"doctype": "Account",
+			"account_name": "_Test Inventory Account",
+			"parent_account": "Stock Assets - _TC",
+			"company": "_Test Company",
+			"is_group": 0,
+			"account_type": "Stock"
+		})
+		account.insert(ignore_permissions=True)
+		frappe.db.set_value("Warehouse", warehouse, "account", account.name)
+	
+		company = "_Test Company"
+		default_inventory_account = frappe.db.get_value("Company", company, "default_inventory_account")
+
+		if default_inventory_account != account.name:
+			frappe.db.set_value("Company", company, "default_inventory_account", account.name)
+   
+		frappe.db.set_value("Company", company, {
+			"enable_provisional_accounting_for_non_stock_items": 0,
+			"enable_perpetual_inventory":0
+		})
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company] = 0
+		company_doc = frappe.get_doc("Company", company)
+		frappe._set_document_in_cache("Company", company_doc)
+		
+		item = make_item("_Test Serial Item Auto", {
+			"has_serial_no": 1,
+			"serial_no_series": "AUTO-SERIAL-.###",
+			"is_stock_item": 1,
+			"has_batch_no": 1,
+			"create_new_batch": 1,
+			"batch_no_series": "AUTO-BATCH-.###",
+			"valuation_rate": 100,
+			"is_fixed_asset": False
+		})
+
+		pe = make_purchase_receipt(
+			item_code=item.name,
+			qty=2,
+			supplier_warehouse=warehouse,
+			company=company,
+			supplier="_Test Supplier Auto Fetch",
+			warehouse=warehouse
+		)
+		pe.submit()
+		batch = frappe.get_all("Batch", {"item": item.name, "reference_name": pe.name})
+		exclude_sr_nos = ["AUTO-SERIAL-001", "AUTO-SERIAL-002"]
+		batch_nos = [d.name for d in batch]
+
+		from erpnext.stock.doctype.serial_no.serial_no import auto_fetch_serial_number
+		sr_nos = auto_fetch_serial_number(
+			qty=2,
+			item_code=item.name,
+			warehouse=warehouse,
+			exclude_sr_nos=exclude_sr_nos,
+			batch_nos=batch_nos,
+		)
+
+		assert isinstance(sr_nos, list)
+	
+	def test_validate_warehouse_all_cases_TC_ACC_304(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
+		create_company("_Test Company")
+		warehouse1 = create_warehouse("Stores", company="_Test Company")
+		warehouse2 = create_warehouse("Finished Goods", company="_Test Company")
+		item = make_item("_Test Item Auto", {
+			"has_serial_no": 1,
+			"serial_no_series": "AUTO-SERIAL-.###"
+		})
+		if not frappe.db.exists("UOM", "_Test UOM"):
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert(
+				ignore_permissions=True,
+				ignore_links=True,
+				ignore_mandatory=True
+			)
+		if not frappe.db.exists("Supplier", "_Test Supplier"):
+			frappe.get_doc({
+				"doctype": "Supplier",
+				"supplier_name": "_Test Supplier",
+				"company": "_Test Company"
+			}).insert(ignore_mandatory=True,ignore_permissions=True,ignore_links=True)
+		pr = make_purchase_receipt(
+			item_code=item.name,
+			warehouse=warehouse1,
+			supplier_warehouse=warehouse1,
+			supplier="_Test Supplier",
+			qty=1,
+			rate=100,
+			do_not_submit=True
+		)
+		pr.submit()
+
+		serial_no = frappe.db.get_value("Serial No", {"purchase_document_no": pr.name}, "name")
+		sn = frappe.get_doc("Serial No", serial_no)  
+
+		local_sn = frappe.new_doc("Serial No")
+		local_sn.__islocal = True
+		local_sn.validate_warehouse() 
+
+		sn.__islocal = False
+		sn.item_code = "WRONG-ITEM"
+		sn.via_stock_ledger = False
+		with self.assertRaises(frappe.ValidationError) as e1:
+			sn.validate_warehouse()
+		self.assertIn("Item Code cannot be changed", str(e1.exception))
+
+		sn = frappe.get_doc("Serial No", serial_no)
+		sn.__islocal = False
+		sn.item_code = item.name
+		sn.warehouse = warehouse2
+		sn.via_stock_ledger = False
+		with self.assertRaises(frappe.ValidationError) as e2:
+			sn.validate_warehouse()
+		self.assertIn("Warehouse cannot be changed", str(e2.exception))
+  
+	def test_set_maintenance_status_all_cases_TC_ACC_305(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+		from frappe.utils import add_days, nowdate
+
+		create_company("_Test Company")
+		warehouse = create_warehouse("Stores", company="_Test Company")
+		item = make_item("_Test Item Auto 1", {"is_stock_item": 1, "has_serial_no": 1, "serial_no_series": "AUTO-SERIAL-.###"})
+		if not frappe.db.exists("UOM", "_Test UOM"):
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert(
+				ignore_permissions=True,
+				ignore_links=True,
+				ignore_mandatory=True
+			)
+		if not frappe.db.exists("Supplier", "_Test Supplier"):
+			frappe.get_doc({
+				"doctype": "Supplier",
+				"supplier_name": "_Test Supplier",
+				"company": "_Test Company"
+			}).insert(ignore_mandatory=True,ignore_permissions=True,ignore_links=True)
+		pr = make_purchase_receipt(
+			item_code=item.name,
+			warehouse=warehouse,
+			supplier="_Test Supplier",
+			supplier_warehouse=warehouse,
+			qty=1,
+			rate=100,
+		)
+		pr.submit()
+
+		serial_no = frappe.db.get_value("Serial No", {"purchase_document_no": pr.name}, "name")
+		sn = frappe.get_doc("Serial No", serial_no)
+
+		sn.warranty_expiry_date = None
+		sn.amc_expiry_date = None
+		sn.set_maintenance_status()
+		self.assertIsNone(sn.maintenance_status)
+
+		sn.warranty_expiry_date = add_days(nowdate(), -1)
+		sn.amc_expiry_date = None
+		sn.set_maintenance_status()
+		self.assertEqual(sn.maintenance_status, "Out of Warranty")
+
+		sn.warranty_expiry_date = None
+		sn.amc_expiry_date = add_days(nowdate(), -1)
+		sn.set_maintenance_status()
+		self.assertEqual(sn.maintenance_status, "Out of AMC")
+
+		sn.amc_expiry_date = add_days(nowdate(), 5)
+		sn.set_maintenance_status()
+		self.assertEqual(sn.maintenance_status, "Under AMC")
+
+		sn.warranty_expiry_date = add_days(nowdate(), 5)
+		sn.set_maintenance_status()
+		self.assertEqual(sn.maintenance_status, "Under Warranty")
+	
+	def test_serial_generation_and_html_via_purchase_receipt_TC_ACC_306(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+		from erpnext.stock.doctype.serial_no.serial_no import (
+			get_available_serial_nos,
+			get_items_html,
+		)
+		import frappe
+
+		create_company("_Test Company")
+		warehouse = create_warehouse("Stores", company="_Test Company")
+		item = make_item("_Test Item Auto 2", {
+			"is_stock_item": 1,
+			"has_serial_no": 1,
+			"serial_no_series": "AUTO-SERIAL-.###"
+		})
+		if not frappe.db.exists("UOM", "_Test UOM"):
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert(
+				ignore_permissions=True,
+				ignore_links=True,
+				ignore_mandatory=True
+			)
+		if not frappe.db.exists("Supplier", "_Test Supplier"):
+			frappe.get_doc({
+				"doctype": "Supplier",
+				"supplier_name": "_Test Supplier",
+				"company": "_Test Company"
+			}).insert(ignore_mandatory=True,ignore_permissions=True,ignore_links=True)
+		pr = make_purchase_receipt(
+			item_code=item.name,
+			warehouse=warehouse,
+			supplier="_Test Supplier",
+			supplier_warehouse=warehouse,
+			qty=2,
+			rate=100,
+			do_not_submit=True  
+		)
+		pr.submit()
+
+		serial_nos = frappe.get_all("Serial No", filters={"purchase_document_no": pr.name}, pluck="name")
+		self.assertEqual(len(serial_nos), 2)
+		
+		html = get_items_html(serial_nos, item.name)
+		self.assertIn(item.name, html)
+		self.assertIn("Serial Numbers", html)
+		for sn in serial_nos:
+			self.assertIn(sn, html)
+
+		new_serials = get_available_serial_nos("AUTO-SERIAL-.###", 2)
+		self.assertEqual(len(new_serials), 2)
+		for sn in new_serials:
+			self.assertTrue(sn.startswith("AUTO-SERIAL-"))
+			frappe.get_doc({
+				"doctype": "Serial No",
+				"serial_no": sn,
+				"item_code": item.name
+			}).insert()
+
+		extra_html = get_items_html(new_serials, item.name)
+		for sn in new_serials:
+			self.assertIn(sn, extra_html)
+	
+	def test_update_maintenance_status_TC_ACC_307(self):
+		from erpnext.stock.doctype.serial_no.serial_no import update_maintenance_status
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
+		create_company("_Test Company")
+		warehouse = create_warehouse("Stores", company="_Test Company")
+
+		item = make_item("_Test Item Auto 2", {
+			"is_stock_item": 1,
+			"has_serial_no": 1,
+			"serial_no_series": "AUTO-SERIAL-.###"
+		})
+
+		if not frappe.db.exists("UOM", "_Test UOM"):
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert(ignore_permissions=True, ignore_links=True, ignore_mandatory=True)
+
+		if not frappe.db.exists("Supplier", "_Test Supplier"):
+			frappe.get_doc({
+				"doctype": "Supplier",
+				"supplier_name": "_Test Supplier",
+				"company": "_Test Company"
+			}).insert(ignore_mandatory=True, ignore_permissions=True, ignore_links=True)
+
+		
+		pr = make_purchase_receipt(
+			item_code=item.name,
+			warehouse=warehouse,
+			supplier="_Test Supplier",
+			supplier_warehouse=warehouse,
+			qty=2,
+			rate=100,
+			do_not_submit=True
+		)
+		pr.submit()
+
+		
+		serial_nos = frappe.get_all("Serial No", filters={"item_code": item.name}, pluck="name")
+		for sn in serial_nos:
+			frappe.db.set_value("Serial No", sn, {
+				"warranty_expiry_date": frappe.utils.add_days(frappe.utils.nowdate(), -1),
+				"amc_expiry_date": frappe.utils.add_days(frappe.utils.nowdate(), -1),
+				"maintenance_status": "Under AMC"
+			})
+
+
+		update_maintenance_status()
+
+		for sn in serial_nos:
+			updated_status = frappe.db.get_value("Serial No", sn, "maintenance_status")
+			self.assertIn(updated_status, ("Out of Warranty", "Out of AMC"))
+   
+	def test_on_trash_with_single_qty_serial_no_TC_ACC_308(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
+		create_company("_Test Company")
+		warehouse = create_warehouse("Stores", company="_Test Company")
+
+		item = make_item("_Test Item Auto 2", {
+			"is_stock_item": 1,
+			"has_serial_no": 1,
+			"serial_no_series": "AUTO-SERIAL-.###"
+		})
+
+		if not frappe.db.exists("UOM", "_Test UOM"):
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert(ignore_permissions=True, ignore_links=True, ignore_mandatory=True)
+
+		if not frappe.db.exists("Supplier", "_Test Supplier"):
+			frappe.get_doc({
+				"doctype": "Supplier",
+				"supplier_name": "_Test Supplier",
+				"company": "_Test Company"
+			}).insert(ignore_mandatory=True, ignore_permissions=True, ignore_links=True)
+
+		
+		pr = make_purchase_receipt(
+			item_code=item.name,
+			warehouse=warehouse,
+			supplier="_Test Supplier",
+			supplier_warehouse=warehouse,
+			qty=1,
+			rate=100,
+			do_not_submit=True
+		)
+		pr.submit()
+		stock_ledger = frappe.db.get_value(
+		"Stock Ledger Entry",
+		{
+			"voucher_type": "Purchase Receipt",
+			"voucher_no": pr.name,
+			"voucher_detail_no":pr.items[0].name,
+			"warehouse": warehouse,
+			"is_cancelled": 0,
+		},
+		"name",
+		)
+		serial_nos = frappe.get_all("Serial No", filters={"purchase_document_no": pr.name}, pluck="name")
+		sl_sno = frappe.db.get_value("Stock Ledger Entry",
+		{
+			"voucher_type": "Purchase Receipt",
+			"voucher_no": pr.name,
+			"voucher_detail_no":pr.items[0].name,
+			"warehouse": warehouse,
+			"is_cancelled": 0,
+		},
+		"serial_no",)
+		if not sl_sno or sl_sno not in serial_nos:
+			frappe.db.set_value("Stock Ledger Entry", stock_ledger, "serial_no", serial_nos[0])
+		
+		serial_doc = frappe.get_doc("Serial No", serial_nos[0])
+
+		with self.assertRaises(frappe.ValidationError) as e2:
+			serial_doc.on_trash()
+
+		self.assertTrue("Cannot delete Serial No" in str(e2.exception))
 
 
 def get_auto_serial_nos(kwargs):

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -42,6 +42,7 @@ from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.serial_batch_bundle import SerialBatchCreation
 from erpnext.stock.stock_ledger import NegativeStockError, get_previous_sle
+import frappe.utils
 
 
 def get_sle(**args):
@@ -61,6 +62,9 @@ def get_sle(**args):
 
 
 class TestStockEntry(FrappeTestCase):
+	@classmethod
+	def setUpClass(self):
+		setup_defaults_data()
 	def tearDown(self):
 		frappe.db.rollback()
 		frappe.set_user("Administrator")
@@ -2002,10 +2006,25 @@ class TestStockEntry(FrappeTestCase):
 		)
 		from erpnext.stock.doctype.material_request.test_material_request import make_material_request
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry as __make_stock_entry
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
 
+		create_company("_Test Company")
+		make_item("_Test Item", {"is_stock_item": 1})
+		create_cost_center(cost_center_name="_Test Cost Center",company = "_Test Company")
 		source_warehouse = create_warehouse(
 			"_Test Source Warehouse", properties=None, company="_Test Company"
 		)
+
+		frappe.db.set_value("Company", "_Test Company", {
+			"enable_provisional_accounting_for_non_stock_items": 0,
+			"enable_perpetual_inventory":0
+		})
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company_doc.name] = 0
+		frappe._set_document_in_cache("Company", company_doc)
 		target_warehouse = create_warehouse("_Test Warehouse", properties=None, company="_Test Company")
 		qty = 5
 		__make_stock_entry(
@@ -2258,6 +2277,20 @@ class TestStockEntry(FrappeTestCase):
 		self.create_stock_repack_via_bom()
 
 	def test_create_and_cancel_stock_repack_via_bom_TC_SCK_065(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+
+		warehouse = ["_Test Warehouse", "_Test Target Warehouse", "_Test Warehouse 1"]
+		create_supplier(supplier_name="_Test Supplier", default_currency="INR")
+
+		for w in warehouse:
+			create_warehouse(warehouse_name=w, company="_Test Company")
+   
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company_doc.name] = 0
+		frappe._set_document_in_cache("Company", company_doc)
+
 		se = self.create_stock_repack_via_bom()
 		se.cancel()
 
@@ -2277,11 +2310,30 @@ class TestStockEntry(FrappeTestCase):
 		self.assertEqual(warehouse_qty["_Test Warehouse - _TC"], 0)
 
 	def test_create_stock_entry_TC_SCK_231(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		account 	= create_account(
+			account_name="_Test Account Tax Assets",
+			account_type="Fixed Asset",
+			company="_Test Company",
+			is_group=1,
+			parent_account = "Fixed Assets - _TC",
+			do_not_save=True,
+		)
+		account.root_type = "Asset"
+		account.save()
 		if not frappe.db.exists("Company", "_Test Company"):
 			company = frappe.new_doc("Company")
 			company.company_name = "_Test Company"
 			company.default_currency = "INR"
 			company.insert()
+		frappe.db.set_value("Company", "_Test Company", {
+			"enable_provisional_accounting_for_non_stock_items": 0,
+			"enable_perpetual_inventory":0
+		})
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company_doc.name] = 0
+		frappe._set_document_in_cache("Company", company_doc)
 		# Create test item
 		item_fields = {
 			"item_name": "Test Pen",
@@ -2511,11 +2563,20 @@ class TestStockEntry(FrappeTestCase):
 
 	def create_stock_repack_via_bom(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
-
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+	
 		create_company()
+		create_warehouse(warehouse_name="_Test Warehouse 1", company="_Test Company")
+		create_supplier(supplier_name="_Test Supplier", default_currency="INR")
 		company = "_Test Company"
 		frappe.db.set_value("Company", company, "stock_received_but_not_billed", "Cost of Goods Sold - _TC")
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
+
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company_doc.name] = 0
+		frappe._set_document_in_cache("Company", company_doc)
 
 		t_warehouse = create_warehouse(
 			warehouse_name="_Test Target Warehouse",
@@ -2602,6 +2663,10 @@ class TestStockEntry(FrappeTestCase):
 		from erpnext.stock.doctype.material_request.test_material_request import make_material_request
 
 		create_company()
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company_doc.name] = 0
+		frappe._set_document_in_cache("Company", company_doc)
 		company = "_Test Company"
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
 		get_or_create_fiscal_year("_Test Company")
@@ -3820,8 +3885,18 @@ class TestStockEntry(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company, create_customer
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 		from erpnext.stock.doctype.material_request.test_material_request import make_material_request
-
+		from erpnext.accounts.doctype.account.test_account import create_account
+		from erpnext.stock import get_warehouse_account_map
 		create_company()
+		create_account(
+			account_name="Stocks Assets",
+			account_type="Fixed Asset",
+			company="_Test Company",
+			is_group=1,
+			parent_account = "Fixed Assets - _TC",
+		)
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe._set_document_in_cache("Company", company_doc)
 		company = "_Test Company"
 		get_or_create_fiscal_year("_Test Company")
 		create_customer(name="_Test Customer")
@@ -3850,7 +3925,7 @@ class TestStockEntry(FrappeTestCase):
 			company=company,
 		)
 		qty = 10
-
+		get_warehouse_account_map()
 		# Stock Receipt
 		make_stock_entry(
 			item_code=item_code,
@@ -3915,9 +3990,12 @@ class TestStockEntry(FrappeTestCase):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company, create_customer
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 		from erpnext.stock.doctype.material_request.test_material_request import make_material_request
-
+		from erpnext.stock import get_warehouse_account_map
 		create_company()
 		company = "_Test Company"
+
+		company_doc = frappe.get_doc("Company", company)
+		frappe._set_document_in_cache("Company", company_doc)
 		get_or_create_fiscal_year("_Test Company")
 		create_customer(name="_Test Customer")
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
@@ -3944,8 +4022,8 @@ class TestStockEntry(FrappeTestCase):
 			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
 			company=company,
 		)
-		qty = 10
-
+		qty = 10	
+		get_warehouse_account_map(company)
 		# Stock Receipt
 		make_stock_entry(
 			item_code=item_code,
@@ -4593,7 +4671,7 @@ class TestStockEntry(FrappeTestCase):
 
 	def test_inactive_sales_items_TC_SCK_228(self):
 		from erpnext.accounts.report.inactive_sales_items.inactive_sales_items import execute
-
+		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		company = "_Test Company"
 
 		# Ensure company exists
@@ -4604,13 +4682,17 @@ class TestStockEntry(FrappeTestCase):
 			company_doc.default_currency = "INR"
 			company_doc.insert()
 
+		create_cost_center(cost_center_name="_Test Cost Center", company=company)
 		# Create Warehouse
 		target_warehouse = create_warehouse(
 			warehouse_name="Test Warehouse",
 			properties={"parent_warehouse": "All Warehouses - _TC", "account": "Cost of Goods Sold - _TC"},
 			company=company,
 		)
-
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company_doc.name] = 0
+		frappe._set_document_in_cache("Company", company_doc)
 		get_or_create_fiscal_year(company)
 		frappe.db.set_value("Company", company, "stock_adjustment_account", "Stock Adjustment - _TC")
 		# Create items
@@ -4622,7 +4704,7 @@ class TestStockEntry(FrappeTestCase):
 		make_stock_entry(
 			item_code=item1.name,
 			purpose="Material Receipt",
-			posting_date="2024-12-01",
+			posting_date=today(),
 			company=company,
 			target=create_warehouse("Test Warehouse", company=company),
 			qty=15,
@@ -4631,7 +4713,7 @@ class TestStockEntry(FrappeTestCase):
 		make_stock_entry(
 			item_code=item1.name,
 			purpose="Material Receipt",
-			posting_date="2025-01-01",
+			posting_date=frappe.utils.add_months(today(), 1),
 			company=company,
 			target=create_warehouse("Test Warehouse", company=company),
 			qty=25,
@@ -4641,7 +4723,7 @@ class TestStockEntry(FrappeTestCase):
 			item_code=item1.name,
 			set_posting_time=1,
 			purpose="Material Issue",
-			posting_date="2025-01-01",
+			posting_date=frappe.utils.add_months(today(), 1),
 			company=company,
 			source=create_warehouse("Test Warehouse", company=company),
 			qty=10,
@@ -4650,7 +4732,7 @@ class TestStockEntry(FrappeTestCase):
 		make_stock_entry(
 			item_code=item1.name,
 			purpose="Material Issue",
-			posting_date="2025-07-02",
+			posting_date=frappe.utils.add_months(today(), 2),
 			company=company,
 			source=create_warehouse("Test Warehouse", company=company),
 			qty=20,
@@ -4678,13 +4760,14 @@ class TestStockEntry(FrappeTestCase):
 			qty=25,
 		)
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
-
+		frappe.db.set_value("Customer", "_Test Customer", "default_currency", "INR")
 		create_sales_invoice(
 			customer="_Test Customer",
 			company="_Test Company",
 			item_code=item1.name,
 			qty=1,
 			rate=100,
+			currency="INR",
 		)
 
 		# Test for Active Item
@@ -4778,6 +4861,10 @@ class TestStockEntry(FrappeTestCase):
 
 		company = "_Test Company"
 		create_company(company)
+		company_doc = frappe.get_doc("Company", "_Test Company")
+		frappe.local.enable_perpetual_inventory = {}
+		frappe.local.enable_perpetual_inventory[company_doc.name] = 0
+		frappe._set_document_in_cache("Company", company_doc)
 		item_fields = {
 			"item_name": "_Test Item134",
 			"valuation_rate": 500,
@@ -6425,3 +6512,24 @@ def custom_create_serial_and_batch_bundle():
 	)
 	sbb.insert()
 	return sbb.name
+
+def setup_defaults_data():
+	from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+	from erpnext.accounts.doctype.account.test_account import create_account
+	from erpnext.stock import get_warehouse_account_map
+	create_company()
+	acc = create_account(
+		account_name="Stock Assets",
+		account_type="Stock",
+		company="_Test Company",
+		is_group=1,
+		parent_account = "Current Assets - _TC",
+		account_currency="INR",
+		do_not_save=True,
+	)
+	acc.report_type = "Balance Sheet"
+	acc.root_type = "Asset"
+	acc.save()
+	company_doc = frappe.get_doc("Company", "_Test Company")
+	frappe._set_document_in_cache("Company", company_doc)
+	get_warehouse_account_map(company=company_doc.name)

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -46,7 +46,7 @@ class TestStockReconciliation(FrappeTestCase, StockTestMixin):
 			warehouse_name="_Test Warehouse",
 			company="_Test Company",
 		)
-
+		setup_defaults_data()
 		create_batch_or_serial_no_items()
 		super().setUpClass()
 		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
@@ -2650,3 +2650,25 @@ def set_valuation_method(item_code, valuation_method):
 
 
 test_dependencies = ["Item", "Warehouse"]
+
+
+def setup_defaults_data():
+	from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+	from erpnext.accounts.doctype.account.test_account import create_account
+	from erpnext.stock import get_warehouse_account_map
+	create_company()
+	acc = create_account(
+		account_name="Stock Assets",
+		account_type="Stock",
+		company="_Test Company",
+		is_group=1,
+		parent_account = "Current Assets - _TC",
+		account_currency="INR",
+		do_not_save=True,
+	)
+	acc.report_type = "Balance Sheet"
+	acc.root_type = "Asset"
+	acc.save()
+	company_doc = frappe.get_doc("Company", "_Test Company")
+	frappe._set_document_in_cache("Company", company_doc)
+	get_warehouse_account_map(company=company_doc.name)

--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -30,6 +30,9 @@ from erpnext.stock.utils import get_stock_balance
 
 
 class TestStockReservationEntry(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		setup_defaults_data()
 	def setUp(self) -> None:
 		create_company("_Test Company")
 
@@ -1717,3 +1720,24 @@ def make_batch_material_receipt(item_code, warehouse, qty, batch_no, uom="Nos"):
 	)
 	se.insert(ignore_permissions=True)
 	se.submit()
+
+def setup_defaults_data():
+	from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+	from erpnext.accounts.doctype.account.test_account import create_account
+	from erpnext.stock import get_warehouse_account_map
+	create_company()
+	acc = create_account(
+		account_name="Stock Assets",
+		account_type="Stock",
+		company="_Test Company",
+		is_group=1,
+		parent_account = "Current Assets - _TC",
+		account_currency="INR",
+		do_not_save=True,
+	)
+	acc.report_type = "Balance Sheet"
+	acc.root_type = "Asset"
+	acc.save()
+	company_doc = frappe.get_doc("Company", "_Test Company")
+	frappe._set_document_in_cache("Company", company_doc)
+	get_warehouse_account_map(company=company_doc.name)


### PR DESCRIPTION
Title: Add Test Cases for Serial Number Management in Stock Transactions

Description:

🧪 Test Summary
This PR introduces test cases to validate Serial Number behavior across stock and accounting transactions in ERPNext, ensuring correctness in scenarios like POS operations, Purchase Receipts, serial number status management, and data validation constraints.

✅ Scenarios Covered
🧩 Input Validations
Validates change restrictions for Serial No fields like item_code and warehouse

test_validate_warehouse_all_cases_TC_ACC_304

Prevent deletion of Serial No linked with Stock Ledger

test_on_trash_with_single_qty_serial_no_TC_ACC_308

⚠️ Edge Cases
Auto-fetch Serial Numbers while excluding specific values

test_auto_fetch_serial_number_basic_TC_ACC_303

Maintenance status update logic based on expired warranty/AMC

test_set_maintenance_status_all_cases_TC_ACC_305

test_update_maintenance_status_TC_ACC_307

🌐 API Response Handling
Reserved Serial No fetching in POS scenario

test_get_pos_reserved_serial_nos_TC_ACC_302

Generation and HTML rendering of serials via purchase

test_serial_generation_and_html_via_purchase_receipt_TC_ACC_306

🔧 Technology
Test Framework: Frappe Unit Test Framework (unittest)

Modules Tested:

POS Invoice

Purchase Receipt

Serial No

Stock Entry

Stock Ledger Entry

POS Opening Entry