### PR TITLE
test: Test Scenarios for Purchase Invoice Validations and POS Opening Entry

### DIFF
--- a/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
@@ -15,7 +15,7 @@ class POSOpeningEntry(StatusUpdater):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.pos_opening_entry_detail.pos_opening_entry_detail import (
@@ -72,4 +72,4 @@ class POSOpeningEntry(StatusUpdater):
 		self.set_status(update=True)
 
 	def on_cancel(self):
- 		self.set_status(update=True)
+		self.set_status(update=True)

--- a/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
@@ -1,51 +1,53 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
-import unittest
-
-from erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry import make_closing_entry_from_opening
 import frappe
-from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_customer
+from frappe.tests.utils import FrappeTestCase
 
-class TestPOSOpeningEntry(unittest.TestCase):
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_customer
+from erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry import make_closing_entry_from_opening
+
+
+class TestPOSOpeningEntry(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
 
 	def test_pos_opening_to_pos_closing_TC_S_099(self):
-		create_customer("_Test Customer",currency = "INR")
+		create_customer("_Test Customer", currency="INR")
+		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile
 		from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import create_pos_invoice
-		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile		
+
 		test_user, pos_profile = init_user_and_profile()
 
 		opening_entry = create_opening_entry(pos_profile=pos_profile, user=test_user.name)
 		self.assertEqual(opening_entry.status, "Open")
 
-
 		pos_inv1 = create_pos_invoice(rate=3500, do_not_submit=1)
 		pos_inv1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3500})
 		pos_inv1.paid_amount = pos_inv1.grand_total
-		pos_inv1.outstanding_amount = 0	
+		pos_inv1.outstanding_amount = 0
 		pos_inv1.submit()
 
 		pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
 		pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
 		pos_inv2.paid_amount = pos_inv2.grand_total
-		pos_inv2.outstanding_amount = 0	
+		pos_inv2.outstanding_amount = 0
 		pos_inv2.submit()
 
-		closing_enrty= make_closing_entry_from_opening(opening_entry)
+		closing_enrty = make_closing_entry_from_opening(opening_entry)
 		closing_enrty.submit()
 		opening_entry.reload()
 		self.assertEqual(opening_entry.status, "Closed")
 
 	def test_pos_opening_to_closing_enrty_check_cashire_and_posprofile_TC_S_100(self):
+		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile
 		from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import create_pos_invoice
-		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile		
+
 		test_user, pos_profile = init_user_and_profile()
 
 		opening_entry = create_opening_entry(pos_profile=pos_profile, user=test_user.name)
 		self.assertEqual(opening_entry.status, "Open")
-		self.assertEqual(opening_entry.pos_profile,  pos_profile.name)
-		self.assertEqual(opening_entry.user,test_user.name)
-		
+		self.assertEqual(opening_entry.pos_profile, pos_profile.name)
+		self.assertEqual(opening_entry.user, test_user.name)
 
 		pos_inv1 = create_pos_invoice(rate=3500, do_not_submit=1)
 		pos_inv1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3500})
@@ -55,17 +57,18 @@ class TestPOSOpeningEntry(unittest.TestCase):
 		pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
 		pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
 		pos_inv2.paid_amount = pos_inv2.grand_total
-		pos_inv2.outstanding_amount = 0	
+		pos_inv2.outstanding_amount = 0
 		pos_inv2.submit()
 
-		closing_enrty= make_closing_entry_from_opening(opening_entry)
+		closing_enrty = make_closing_entry_from_opening(opening_entry)
 		closing_enrty.submit()
 		opening_entry.reload()
 		self.assertEqual(opening_entry.status, "Closed")
-	
+
 	def test_pos_opening_to_closing_enrty_with_opening_balance_TC_S_101(self):
+		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile
 		from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import create_pos_invoice
-		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile		
+
 		test_user, pos_profile = init_user_and_profile()
 
 		opening_entry = frappe.new_doc("POS Opening Entry")
@@ -77,32 +80,98 @@ class TestPOSOpeningEntry(unittest.TestCase):
 		# Add opening balance details
 		balance_details = []
 		for d in pos_profile.payments:
-			balance_details.append({
-				"mode_of_payment": d.mode_of_payment,
-				"opening_amount": 1000
-			})
+			balance_details.append({"mode_of_payment": d.mode_of_payment, "opening_amount": 1000})
 
 		opening_entry.set("balance_details", balance_details)
 		opening_entry.save()
 		opening_entry.submit()
 		self.assertEqual(opening_entry.status, "Open")
-		
+
 		pos_inv1 = create_pos_invoice(rate=3500, do_not_submit=1)
 		pos_inv1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3500})
 		pos_inv1.paid_amount = pos_inv1.grand_total
-		pos_inv1.outstanding_amount = 0	
+		pos_inv1.outstanding_amount = 0
 		pos_inv1.submit()
 
 		pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
 		pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
 		pos_inv2.paid_amount = pos_inv2.grand_total
-		pos_inv2.outstanding_amount = 0	
+		pos_inv2.outstanding_amount = 0
 		pos_inv2.submit()
 
-		closing_enrty= make_closing_entry_from_opening(opening_entry)
+		closing_enrty = make_closing_entry_from_opening(opening_entry)
 		closing_enrty.submit()
 		opening_entry.reload()
 		self.assertEqual(opening_entry.status, "Closed")
+
+	def test_validate_pos_profile_and_cashier_TC_ACC_318(self):
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": frappe.generate_hash(length=10) + "@gmail.com",
+				"first_name": frappe.generate_hash(length=5),
+				"send_welcome_email": 0,
+				"enabled": 0,
+			}
+		)
+		user.insert(ignore_permissions=True)
+		pos_profile = frappe.get_doc(
+			{
+				"doctype": "POS Profile",
+				"__newname": frappe.generate_hash(length=5),
+				"company": "_Test Company",
+				"warehouse": "Stores - _TC",
+				"write_off_account": "Sales - _TC",
+				"write_off_cost_center": "Main - _TC",
+				"write_off_limit": 1,
+				"payments": [{"default": 1, "mode_of_payment": "Cash"}],
+			}
+		)
+		pos_profile.insert()
+
+		poe = frappe.get_doc(
+			{
+				"doctype": "POS Opening Entry",
+				"company": "_Test Company 1",
+				"period_start_date": frappe.utils.now_datetime,
+				"posting_date": frappe.utils.today(),
+				"pos_profile": pos_profile.name,
+				"balance_details": [{"mode_of_payment": "Cash", "opening_amount": 100}],
+			}
+		)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			poe.insert(ignore_mandatory=True, ignore_permissions=True)
+		self.assertIn(
+			f"POS Profile {pos_profile.name} does not belongs to company {poe.company}", str(cm.exception)
+		)
+
+		poe.company = pos_profile.company
+		poe.user = user.name
+		with self.assertRaises(frappe.ValidationError) as cm:
+			poe.insert()
+		self.assertIn(f"User {user.name} is disabled. Please select valid user/cashier", str(cm.exception))
+
+		user.enabled = 1
+		user.save()
+
+		poe_1 = frappe.get_doc(
+			{
+				"doctype": "POS Opening Entry",
+				"company": "_Test Company",
+				"period_start_date": frappe.utils.now_datetime,
+				"posting_date": frappe.utils.today(),
+				"pos_profile": pos_profile.name,
+				"user": user.name,
+				"balance_details": [{"mode_of_payment": get_mode_of_payment(), "opening_amount": 100}],
+			}
+		)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			poe_1.insert()
+		self.assertIn(
+			"Please set default Cash or Bank account in Mode of Payments __Test Mode Payment",
+			str(cm.exception),
+		)
+
 
 def create_opening_entry(pos_profile, user):
 	entry = frappe.new_doc("POS Opening Entry")
@@ -119,3 +188,12 @@ def create_opening_entry(pos_profile, user):
 	entry.submit()
 
 	return entry
+
+
+def get_mode_of_payment():
+	mode = "__Test Mode Payment"
+	if not frappe.db.exists("Mode of Payment", mode):
+		frappe.get_doc({"doctype": "Mode of Payment", "mode_of_payment": mode}).insert(
+			ignore_permissions=True
+		)
+	return mode

--- a/erpnext/accounts/doctype/pos_opening_entry_detail/pos_opening_entry_detail.py
+++ b/erpnext/accounts/doctype/pos_opening_entry_detail/pos_opening_entry_detail.py
@@ -12,7 +12,7 @@ class POSOpeningEntryDetail(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		mode_of_payment: DF.Link

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -9,6 +9,7 @@ from frappe.utils import (
 	add_days,
 	cint,
 	flt,
+	formatdate,
 	get_quarter_start,
 	get_year_ending,
 	get_year_start,
@@ -5460,6 +5461,140 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			po.cancel()
 
 		self.assertIn("this WBS is locked", str(cm.exception))
+
+	@change_settings("Buying Settings", {"po_required": "Yes"})
+	def test_po_required_in_pi_TC_ACC_308(self):
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pi.insert(ignore_permissions=True)
+		self.assertIn(
+			"Purchase Order Required for item _Test ItemTo submit the invoice without purchase order please set Purchase Order Required as No in Buying Settings",
+			str(cm.exception),
+		)
+
+	@change_settings("Buying Settings", {"pr_required": "Yes"})
+	def test_pr_required_in_pi_TC_ACC_309(self):
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pi.insert(ignore_permissions=True)
+		self.assertIn(
+			"Purchase Receipt Required for item _Test ItemTo submit the invoice without purchase receipt please set Purchase Receipt Required as No in Buying Settings",
+			str(cm.exception),
+		)
+
+	def test_validate_write_off_account_TC_ACC_310(self):
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		pi.write_off_amount = 100
+		pi.write_off_account = ""
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pi.save()
+		self.assertIn("Please enter Write Off Account", str(cm.exception))
+
+	def test_validate_supplier_invoice_date_TC_ACC_311(self):
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		pi.posting_date = today()
+		pi.bill_date = add_days(today(), 1)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pi.save()
+		self.assertIn("Supplier Invoice Date cannot be greater than Posting Date", str(cm.exception))
+
+	def test_block_and_unblock_purchase_invoice_TC_ACC_312(self):
+		from .purchase_invoice import block_invoice, change_release_date, unblock_invoice
+
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		pi.insert(ignore_permissions=True)
+		pi.submit()
+
+		block_invoice(pi.name, release_date=today(), hold_comment="Test Comment")
+		pi.load_from_db()
+
+		self.assertEqual(pi.on_hold, 1)
+		self.assertEqual(pi.docstatus, 1)
+
+		unblock_invoice(pi.name)
+		pi.load_from_db()
+
+		self.assertEqual(pi.on_hold, 0)
+		self.assertEqual(pi.docstatus, 1)
+
+		change_release_date(name=pi.name, release_date=add_days(today(), 1))
+		pi.load_from_db()
+		self.assertEqual(getdate(pi.release_date), getdate(add_days(today(), 1)))
+
+	def test_get_list_context_313(self):
+		from .purchase_invoice import get_list_context
+
+		data = get_list_context()
+		self.assertTrue(data.get("title"), "Purchase Invoices")
+		self.assertTrue(data.get("no_breadcrumbs"), True)
+		self.assertTrue(data.get("show_sidebar"), True)
+		self.assertTrue(data.get("show_search"), True)
+
+	def test_check_prev_docstatus_314(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
+		po = create_purchase_order(do_not_save=True)
+		po.insert(ignore_permissions=True)
+
+		pi = make_purchase_invoice(do_not_save=True)
+		pi.items[0].purchase_order = po.name
+		pi.insert(ignore_permissions=True)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pi.submit()
+		self.assertIn(f"{po.doctype} {po.name} is not submitted", str(cm.exception))
+
+		pr = make_purchase_receipt(do_not_save=True)
+		pr.insert(ignore_permissions=True)
+
+		pi_1 = make_purchase_invoice(do_not_save=True)
+		pi_1.items[0].purchase_receipt = pr.name
+		pi_1.insert(ignore_permissions=True)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pi_1.submit()
+		self.assertIn(f"{pr.doctype} {pr.name} is not submitted", str(cm.exception))
+
+	def test_make_write_off_gl_entry_with_writeoff_account_TC_ACC_315(self):
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		pi.write_off_amount = 100
+		pi.write_off_account = "Cash - _TC"
+		pi.insert(ignore_permissions=True)
+		pi.submit()
+
+		self.assertEqual(pi.status, "Partly Paid")
+		self.assertEqual(pi.docstatus, 1)
+
+	def test_create_remarks_TC_ACC_316(self):
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		pi.remarks = ""
+		pi.bill_no = "test-1122"
+		pi.bill_date = today()
+		pi.insert(ignore_permissions=True)
+		pi.submit()
+		self.assertEqual(pi.remarks, f"Against Supplier Invoice {pi.bill_no} dated {formatdate(today())}")
+
+	def test_validate_credit_to_acc_TC_ACC_317(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+
+		account = create_account(
+			account_name="Deferred Expense", parent_account="Current Assets - _TC", company="_Test Company"
+		)
+		args = {"qty": 1, "rate": 200, "do_not_save": True}
+		pi = make_purchase_invoice(**args)
+		pi.credit_to = account
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pi.insert(ignore_mandatory=True)
+		self.assertIn(
+			"Please ensure that the Credit To account Deferred Expense - _TC is a Payable account. You can change the account type to Payable or select a different account.",
+			str(cm.exception),
+		)
 
 
 def set_advance_flag(company, flag, default_account):

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -5463,7 +5463,7 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		self.assertIn("this WBS is locked", str(cm.exception))
 
 	@change_settings("Buying Settings", {"po_required": "Yes"})
-	def test_po_required_in_pi_TC_ACC_308(self):
+	def test_po_required_in_pi_TC_ACC_319(self):
 		args = {"qty": 1, "rate": 200, "do_not_save": True}
 		pi = make_purchase_invoice(**args)
 		with self.assertRaises(frappe.ValidationError) as cm:

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -7511,6 +7511,7 @@ class TestSalesInvoice(FrappeTestCase):
 		)
 
 	def test_on_recurring_TC_ACC_257(self):
+		frappe.flags.in_test = True
 		reference_si = create_sales_invoice(do_not_save=1)
 		reference_si.insert(ignore_permissions=True)
 		reference_si.submit()

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -7582,11 +7582,15 @@ class TestSalesInvoice(FrappeTestCase):
 		si = create_sales_invoice()
 		mode_of_pmt = get_all_mode_of_payments(si)
 		if mode_of_pmt:
-			self.assertEqual(mode_of_pmt[0].get("default_account"), "Cash - _TC")
+			for row in mode_of_pmt:
+				if row.get("parent") == "Cash":
+					self.assertEqual(row.get("default_account"), "Cash - _TC")
 
 		pmt_info = get_mode_of_payment_info("Cash", si.company)
 		if pmt_info:
-			self.assertEqual(pmt_info[0].get("default_account"), "Cash - _TC")
+			for row_1 in pmt_info:
+				if row_1.get("parent") == "Cash":
+					self.assertEqual(row_1.get("default_account"), "Cash - _TC")
 
 	@change_settings("Accounts Settings", {"unlink_payment_on_cancellation_of_invoice": 1})
 	def test_check_if_return_invoice_linked_with_payment_entry_TC_ACC_261(self):


### PR DESCRIPTION
### Test Summary
 - These test cases validate critical validations, configurations, and lifecycle behaviors in Purchase Invoices and POS Opening Entry operations within ERPNext. They ensure that compliance settings like Purchase Order and Purchase Receipt requirements are enforced as per Buying Settings, and that accounting integrity is maintained through proper write-off handling, credit account validation, and supplier invoice date logic.

 - Additionally, the tests ensure robust POS Profile configuration by verifying alignment of company, user (cashier) status, and mode of payment settings, preventing misconfigurations at the point of sale. Tests also simulate hold/release cycles on Purchase Invoices and validate document state dependencies across Purchase Orders and Receipts.

**Doctype – Purchase Invoice & POS Opening Entry**

 - **TC_ACC_309**: Similar to the above, this test ensures that the Purchase Receipt requirement is respected. Submitting a Purchase Invoice without a Purchase Receipt triggers a validation error when the setting is enabled.

- **TC_ACC_310**: Tests validation for Write Off Account in Purchase Invoices. If a write-off amount is specified without linking a write-off account, the system should prevent saving and raise a meaningful error.

 - **TC_ACC_311**: Ensures temporal accuracy by validating that the Supplier Invoice Date cannot be after the Posting Date. This protects against future-dated billing inconsistencies.

- **TC_ACC_312**: Validates the block, unblock, and release date update lifecycle for Purchase Invoices. This test simulates blocking a submitted invoice with a release comment, unblocking it, and finally modifying the release date, ensuring all transitions work reliably and as intended.

 - **TC_ACC_313**: Tests the get_list_context method to ensure proper context metadata for the Purchase Invoice list view. Asserts presence of UI flags like title, search, and sidebar visibility.

 - **TC_ACC_314**: Validates link document docstatus constraints. Ensures a Purchase Invoice cannot be submitted if the linked Purchase Order or Purchase Receipt is not yet submitted. This prevents premature transactional finalization.

- **TC_ACC_315**: Tests the creation of GL Entries for Write Offs. Ensures that when a write-off amount and account are provided, the system processes the entry and marks the invoice as “Partly Paid.”

 - **TC_ACC_316**: Validates auto-generation of remarks from bill details. When bill number and date are set but remarks are left empty, the system should auto-generate descriptive remarks on submission.

 - **TC_ACC_317**: Verifies that the Credit To account must be of type “Payable.” If a non-payable account like “Deferred Expense” is selected, the system must raise a validation error, maintaining accounting integrity.
 -  **TC_ACC_319**: Validates enforcement of the Purchase Order requirement in Buying Settings. The test confirms that attempting to submit a Purchase Invoice without a linked Purchase Order raises a validation error, ensuring purchase policy adherence.

**Doctype – POS Opening Entry**
 - **TC_ACC_318**: This scenario tests POS Profile and User validations during POS Opening Entry creation, Ensures that the POS Profile’s company matches the selected company. Validates that the assigned user (cashier) is enabled. Confirms that the Mode of Payment includes a linked default Cash/Bank account.

### Scenarios Covered
 - Purchase Policy Enforcement:
 - PO and PR requirement enforcement via Buying Settings.
 - Blocking invoice submission with incorrect document states.
 - Validation of Accounting Entries:
 - Mandatory fields: Write Off Account, Supplier Invoice Date.
 - Write Off GL generation and status update.
 - Correct POS profile assignment to company and user.
 - Default mode of payment with valid bank/cash account.

### Technology
 - Python unittest framework
 - Frappe test utilities and mocks
### Linked Feature/Bug
- N/A
### Issue Tracker ID
 - N/A