### PR TITLE
fix: added pragama no cover command for type checking line

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry_taxes/pos_closing_entry_taxes.py
+++ b/erpnext/accounts/doctype/pos_closing_entry_taxes/pos_closing_entry_taxes.py
@@ -11,7 +11,7 @@ class POSClosingEntryTaxes(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		account_head: DF.Link | None

--- a/erpnext/accounts/doctype/pos_customer_group/pos_customer_group.py
+++ b/erpnext/accounts/doctype/pos_customer_group/pos_customer_group.py
@@ -11,7 +11,7 @@ class POSCustomerGroup(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		customer_group: DF.Link

--- a/erpnext/accounts/doctype/pos_field/pos_field.py
+++ b/erpnext/accounts/doctype/pos_field/pos_field.py
@@ -12,7 +12,7 @@ class POSField(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		default_value: DF.Data | None

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -21,7 +21,8 @@ from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 
 
 class PartialPaymentValidationError(frappe.ValidationError):
- 	pass
+	pass
+
 
 class POSInvoice(SalesInvoice):
 	# begin: auto-generated types
@@ -29,17 +30,22 @@ class POSInvoice(SalesInvoice):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
+		from frappe.types import DF
+
 		from erpnext.accounts.doctype.payment_schedule.payment_schedule import PaymentSchedule
 		from erpnext.accounts.doctype.pos_invoice_item.pos_invoice_item import POSInvoiceItem
 		from erpnext.accounts.doctype.pricing_rule_detail.pricing_rule_detail import PricingRuleDetail
 		from erpnext.accounts.doctype.sales_invoice_advance.sales_invoice_advance import SalesInvoiceAdvance
 		from erpnext.accounts.doctype.sales_invoice_payment.sales_invoice_payment import SalesInvoicePayment
-		from erpnext.accounts.doctype.sales_invoice_timesheet.sales_invoice_timesheet import SalesInvoiceTimesheet
-		from erpnext.accounts.doctype.sales_taxes_and_charges.sales_taxes_and_charges import SalesTaxesandCharges
+		from erpnext.accounts.doctype.sales_invoice_timesheet.sales_invoice_timesheet import (
+			SalesInvoiceTimesheet,
+		)
+		from erpnext.accounts.doctype.sales_taxes_and_charges.sales_taxes_and_charges import (
+			SalesTaxesandCharges,
+		)
 		from erpnext.selling.doctype.sales_team.sales_team import SalesTeam
 		from erpnext.stock.doctype.packed_item.packed_item import PackedItem
-		from frappe.types import DF
 
 		account_for_change_amount: DF.Link | None
 		additional_discount_percentage: DF.Float
@@ -136,7 +142,20 @@ class POSInvoice(SalesInvoice):
 		shipping_address: DF.SmallText | None
 		shipping_address_name: DF.Link | None
 		shipping_rule: DF.Link | None
-		status: DF.Literal["", "Draft", "Return", "Credit Note Issued", "Consolidated", "Submitted", "Paid", "Unpaid", "Unpaid and Discounted", "Overdue and Discounted", "Overdue", "Cancelled"]
+		status: DF.Literal[
+			"",
+			"Draft",
+			"Return",
+			"Credit Note Issued",
+			"Consolidated",
+			"Submitted",
+			"Paid",
+			"Unpaid",
+			"Unpaid and Discounted",
+			"Overdue and Discounted",
+			"Overdue",
+			"Cancelled",
+		]
 		tax_category: DF.Link | None
 		tax_id: DF.Data | None
 		taxes: DF.Table[SalesTaxesandCharges]
@@ -478,7 +497,7 @@ class POSInvoice(SalesInvoice):
 		is_partial_payment_allowed = frappe.db.get_value(
 			"POS Profile", self.pos_profile, "allow_partial_payment"
 		)
- 
+
 		if self.docstatus == 1 and not is_partial_payment_allowed:
 			if self.is_return and self.paid_amount != invoice_total:
 				frappe.throw(

--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
@@ -12,7 +12,7 @@ class POSInvoiceItem(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		actual_batch_qty: DF.Float

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -18,7 +18,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 
 
-class POSInvoiceMergeLog(Document):  # pragma: no cover
+class POSInvoiceMergeLog(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -14,11 +14,11 @@ from frappe.utils.background_jobs import enqueue, is_job_enqueued
 from frappe.utils.scheduler import is_scheduler_inactive
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
- 	get_checks_for_pl_and_bs_accounts,
- )
+	get_checks_for_pl_and_bs_accounts,
+)
 
 
-class POSInvoiceMergeLog(Document):
+class POSInvoiceMergeLog(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
@@ -147,7 +147,7 @@ class POSInvoiceMergeLog(Document):
 
 		sales_invoice.is_consolidated = 1
 		sales_invoice.set_posting_time = 1
-		
+
 		if not sales_invoice.posting_date:
 			sales_invoice.posting_date = getdate(self.posting_date)
 		if not sales_invoice.posting_time:
@@ -331,7 +331,8 @@ class POSInvoiceMergeLog(Document):
 
 		if "projects" in frappe.get_installed_apps():
 			invoice.set(
-				"project", data[0].get("project") if data[0].get("project") else dimension_values.get("project")
+				"project",
+				data[0].get("project") if data[0].get("project") else dimension_values.get("project"),
 			)
 
 		if self.merge_invoices_based_on == "Customer Group":
@@ -379,6 +380,7 @@ class POSInvoiceMergeLog(Document):
 			.where(sle_table.serial_and_batch_bundle.isin(bundles) & sle_table.is_cancelled == 1)
 		)
 		query.run()
+
 	def get_serial_and_batch_bundles(self):
 		pos_invoices = []
 		for d in self.pos_invoices:
@@ -462,6 +464,7 @@ def get_invoice_customer_map(pos_invoices):
 
 	return pos_invoice_customer_map
 
+
 def split_invoices_by_accounting_dimension(pos_invoices):
 	# pos_invoices = {
 	# 	{'dim_field1': 'dim_field1_value1', 'dim_field2': 'dim_field2_value1'}: [],
@@ -482,6 +485,7 @@ def split_invoices_by_accounting_dimension(pos_invoices):
 		pos_invoice_accounting_dimensions_map[accounting_dimensions_dic_hash].append(invoice)
 
 	return pos_invoice_accounting_dimensions_map
+
 
 def consolidate_pos_invoices(pos_invoices=None, closing_entry=None):
 	invoices = pos_invoices or (closing_entry and closing_entry.get("pos_transactions"))

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -9,8 +9,9 @@ from frappe.model.document import Document
 from frappe.utils import get_link_to_form, now
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
- 	get_checks_for_pl_and_bs_accounts,
- )
+	get_checks_for_pl_and_bs_accounts,
+)
+
 
 class POSProfile(Document):
 	# begin: auto-generated types
@@ -18,12 +19,13 @@ class POSProfile(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
+		from frappe.types import DF
+
 		from erpnext.accounts.doctype.pos_customer_group.pos_customer_group import POSCustomerGroup
 		from erpnext.accounts.doctype.pos_item_group.pos_item_group import POSItemGroup
 		from erpnext.accounts.doctype.pos_payment_method.pos_payment_method import POSPaymentMethod
 		from erpnext.accounts.doctype.pos_profile_user.pos_profile_user import POSProfileUser
-		from frappe.types import DF
 
 		account_for_change_amount: DF.Link | None
 		allow_discount_change: DF.Check
@@ -75,10 +77,10 @@ class POSProfile(Document):
 		acc_dims = get_checks_for_pl_and_bs_accounts()
 		for acc_dim in acc_dims:
 			if (
- 				self.company == acc_dim.company
- 				and not self.get(acc_dim.fieldname)
- 				and (acc_dim.mandatory_for_pl or acc_dim.mandatory_for_bs)
- 			):
+				self.company == acc_dim.company
+				and not self.get(acc_dim.fieldname)
+				and (acc_dim.mandatory_for_pl or acc_dim.mandatory_for_bs)
+			):
 				frappe.throw(
 					_(
 						"{0} is a mandatory Accounting Dimension. <br>"
@@ -209,16 +211,17 @@ def get_item_groups(pos_profile):
 		for data in pos_profile.get("item_groups"):
 			item_groups.extend(
 				[
- 					"%s" % frappe.db.escape(d.name)
- 					for d in get_child_nodes("Item Group", data.item_group)
- 					if not permitted_item_groups or d.name in permitted_item_groups
- 				]
+					"%s" % frappe.db.escape(d.name)
+					for d in get_child_nodes("Item Group", data.item_group)
+					if not permitted_item_groups or d.name in permitted_item_groups
+				]
 			)
-		
+
 	if not item_groups and permitted_item_groups:
 		item_groups = ["%s" % frappe.db.escape(d) for d in permitted_item_groups]
 
 	return list(set(item_groups))
+
 
 def get_permitted_nodes(group_type):
 	nodes = []

--- a/erpnext/accounts/doctype/pos_search_fields/pos_search_fields.py
+++ b/erpnext/accounts/doctype/pos_search_fields/pos_search_fields.py
@@ -12,7 +12,7 @@ class POSSearchFields(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		field: DF.Literal

--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
@@ -16,7 +16,7 @@ class ProcessPaymentReconciliation(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		amended_from: DF.Link | None

--- a/erpnext/accounts/doctype/process_payment_reconciliation_log/process_payment_reconciliation_log.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation_log/process_payment_reconciliation_log.py
@@ -11,7 +11,7 @@ class ProcessPaymentReconciliationLog(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.process_payment_reconciliation_log_allocations.process_payment_reconciliation_log_allocations import (

--- a/erpnext/accounts/doctype/process_payment_reconciliation_log_allocations/process_payment_reconciliation_log_allocations.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation_log_allocations/process_payment_reconciliation_log_allocations.py
@@ -11,7 +11,7 @@ class ProcessPaymentReconciliationLogAllocations(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		allocated_amount: DF.Currency

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -28,11 +28,16 @@ class ProcessStatementOfAccounts(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from erpnext.accounts.doctype.process_statement_of_accounts_cc.process_statement_of_accounts_cc import ProcessStatementOfAccountsCC
-		from erpnext.accounts.doctype.process_statement_of_accounts_customer.process_statement_of_accounts_customer import ProcessStatementOfAccountsCustomer
-		from erpnext.accounts.doctype.psoa_cost_center.psoa_cost_center import PSOACostCenter
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
+
+		from erpnext.accounts.doctype.process_statement_of_accounts_cc.process_statement_of_accounts_cc import (
+			ProcessStatementOfAccountsCC,
+		)
+		from erpnext.accounts.doctype.process_statement_of_accounts_customer.process_statement_of_accounts_customer import (
+			ProcessStatementOfAccountsCustomer,
+		)
+		from erpnext.accounts.doctype.psoa_cost_center.psoa_cost_center import PSOACostCenter
 
 		account: DF.Link | None
 		ageing_based_on: DF.Literal["Due Date", "Posting Date"]
@@ -208,7 +213,7 @@ def get_gl_filters(doc, entry, tax_id, presentation_currency):
 
 
 def get_ar_filters(doc, entry):
-	filters =  {
+	filters = {
 		"report_date": doc.posting_date if doc.posting_date else None,
 		"party_type": "Customer",
 		"party": [entry.customer],
@@ -226,9 +231,8 @@ def get_ar_filters(doc, entry):
 	if frappe.db.has_column("Process Statement Of Accounts", "sales_partner"):
 		filters["sales_partner"] = doc.sales_partner if doc.sales_partner else None
 	if frappe.db.has_column("Process Statement Of Accounts", "sales_person"):
-		filters["sales_person"] = doc.sales_person if doc.sales_person else None,
+		filters["sales_person"] = (doc.sales_person if doc.sales_person else None,)
 	return filters
-
 
 
 def get_html(doc, filters, entry, col, res, ageing):
@@ -324,7 +328,7 @@ def get_recipients_and_cc(customer, doc):
 			if clist.billing_email:
 				for email in clist.billing_email.split(","):
 					recipients.append(email.strip())
-					
+
 			if doc.primary_mandatory and clist.primary_email:
 				for email in clist.primary_email.split(","):
 					recipients.append(email.strip())

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -10,13 +10,14 @@ from frappe.utils.data import comma_and
 
 from erpnext.stock import get_warehouse_account_map
 
+
 class RepostAccountingLedger(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.repost_accounting_ledger_items.repost_accounting_ledger_items import (
@@ -207,8 +208,11 @@ def get_allowed_types_from_settings():
 	return [
 		x.document_type
 		for x in frappe.db.get_all(
-			"Repost Allowed Types", filters={"allowed": True},  fields=["distinct(document_type)", "modified"],  # Include "modified" in the fields list
-    		order_by="modified desc")
+			"Repost Allowed Types",
+			filters={"allowed": True},
+			fields=["distinct(document_type)", "modified"],  # Include "modified" in the fields list
+			order_by="modified desc",
+		)
 	]
 
 
@@ -265,8 +269,11 @@ def get_repost_allowed_types(doctype, txt, searchfield, start, page_len, filters
 		filters.update({"document_type": ("like", f"%{txt}%")})
 
 	if allowed_types := frappe.db.get_all(
-		"Repost Allowed Types", filters=filters,  fields=["distinct(document_type)", "modified"],  # Include "modified" in the fields list
-    	order_by="modified desc", as_list=1
+		"Repost Allowed Types",
+		filters=filters,
+		fields=["distinct(document_type)", "modified"],  # Include "modified" in the fields list
+		order_by="modified desc",
+		as_list=1,
 	):
 		return allowed_types
 	return []

--- a/erpnext/accounts/doctype/repost_payment_ledger/repost_payment_ledger.py
+++ b/erpnext/accounts/doctype/repost_payment_ledger/repost_payment_ledger.py
@@ -57,7 +57,7 @@ class RepostPaymentLedger(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.repost_payment_ledger_items.repost_payment_ledger_items import (

--- a/erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.py
+++ b/erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.py
@@ -11,7 +11,7 @@ class RepostPaymentLedgerItems(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		parent: DF.Data

--- a/erpnext/accounts/doctype/supplier_quotation_qty/supplier_quotation_qty.py
+++ b/erpnext/accounts/doctype/supplier_quotation_qty/supplier_quotation_qty.py
@@ -11,7 +11,7 @@ class SupplierQuotationQty(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING:  # pragma: no cover
 		from frappe.types import DF
 
 		item: DF.Link | None


### PR DESCRIPTION
**Title:**
Add pragma no-cover to type checking blocks for doctypes

**Test Summary:**
No test written, just add pragma no-cover to type checking blocks for doctypes

Doctypes Covered:

1. POS Closing Entry Taxes
2. POS Customer Group
3. POS Invoice Item
4. POS Invoice
5. POS Invoice Merge Log
6. Process Payment Reconciliation
7. Process Payment Reconciliation Log
8. POS Fields
9. POS Search Fields
10. Supplier Quotation Qty
11. POS Profile
12. Repost payment Ledger
13. Repost Accounting Ledger
14. Process Payment Reconciliation Log Allocations
15. Process Statement Of Accounts
16. Repost Payment Ledger Items
 