### PR TITLE
fix:Validation error on valuation rate,company gstin

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase, change_settings, timeout
 from frappe.utils import add_days, add_months, add_to_date, cint, flt, now, today
 
+from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 from erpnext.manufacturing.doctype.job_card.job_card import JobCardCancelError
 from erpnext.manufacturing.doctype.job_card.job_card import make_stock_entry as make_stock_entry_from_jc
 from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
@@ -31,7 +32,6 @@ from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.stock_entry import test_stock_entry
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.utils import get_bin
-from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
 
 test_dependencies = ["BOM"]
 
@@ -509,11 +509,11 @@ class TestWorkOrder(FrappeTestCase):
 		stock_entries.reverse()
 		for stock_entry in stock_entries:
 			stock_entry.cancel()
-	
+
 	def test_work_order_material_transferred_qty_with_process_loss(self):
 		stock_entries = []
 		bom = frappe.get_doc("BOM", {"docstatus": 1, "with_operations": 1, "company": "_Test Company"})
-		
+
 		work_order = make_wo_order_test_record(
 			item=bom.item,
 			qty=2,
@@ -521,23 +521,23 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="_Test Warehouse - _TC",
 			transfer_material_against="Job Card",
 		)
-		
+
 		self.assertEqual(work_order.qty, 2)
-		
+
 		for row in work_order.required_items:
 			stock_entry_doc = test_stock_entry.make_stock_entry(
 				item_code=row.item_code, target="_Test Warehouse - _TC", qty=row.required_qty, basic_rate=100
 			)
 			stock_entries.append(stock_entry_doc)
-		
+
 		job_cards = frappe.get_all(
 			"Job Card", filters={"work_order": work_order.name}, order_by="creation asc"
 		)
-		
+
 		for row in job_cards:
 			transfer_entry_1 = make_stock_entry_from_jc(row.name)
 			transfer_entry_1.submit()
-			
+
 			doc = frappe.get_doc("Job Card", row.name)
 			for row in doc.scheduled_time_logs:
 				doc.append(
@@ -549,17 +549,17 @@ class TestWorkOrder(FrappeTestCase):
 						"completed_qty": 1,
 					},
 				)
-			
+
 			doc.save()
 			doc.submit()
-			
+
 			self.assertEqual(doc.total_completed_qty, 1)
 			self.assertEqual(doc.process_loss_qty, 1)
-		
+
 		work_order.reload()
-		
+
 		self.assertEqual(work_order.material_transferred_for_manufacturing, 2)
-		
+
 		for row in work_order.operations:
 			self.assertEqual(row.completed_qty, 1)
 			self.assertEqual(row.process_loss_qty, 1)
@@ -988,9 +988,6 @@ class TestWorkOrder(FrappeTestCase):
 			.on((JobCardTimeLog.parent == sub.parent) & (JobCardTimeLog.creation == sub.creation))
 			.select(JobCardTimeLog.parent.as_("name"), JobCardTimeLog.docstatus)
 		).run(as_dict=True)
-
-
-
 
 		for job_card in job_cards:
 			if job_card.docstatus == 1:
@@ -2192,7 +2189,6 @@ class TestWorkOrder(FrappeTestCase):
 
 		stock_entry.submit()
 
-
 	def test_components_alternate_item_for_bom_based_manufacture_entry(self):
 		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
 		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 1)
@@ -2235,53 +2231,6 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertTrue(manufacture_entry.items[0].original_item == raw_materials[0])
 		manufacture_entry.submit()
 		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 0)
-
-
-	def test_components_alternate_item_for_bom_based_manufacture_entry(self):
-		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
-		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 1)
-		fg_item = "Test FG Item For Component Validation for alternate item"
-		source_warehouse = "Stores - _TC"
-		raw_materials = ["Test Component Validation RM Item 112", "Test Component Validation RM Item 22"]
-		alternate_item = ["Alternate Test Component Validation RM Item 1"]
-		make_item(fg_item, {"is_stock_item": 1})
-		for item in raw_materials + alternate_item:
-			make_item(item, {"is_stock_item": 1, "allow_alternative_item": 1})
-			test_stock_entry.make_stock_entry(
-				item_code=item,
-				target=source_warehouse,
-				qty=10,
-				basic_rate=100,
-			)
-		frappe.get_doc(
-			{
-				"doctype": "Item Alternative",
-				"item_code": raw_materials[0],
-				"alternative_item_code": alternate_item[0],
-				"two_way": 1,
-			}
-		).insert()
-		make_bom(item=fg_item, source_warehouse=source_warehouse, raw_materials=raw_materials)
-		wo = make_wo_order_test_record(
-			item=fg_item,
-			qty=10,
-			source_warehouse=source_warehouse,
-		)
-		transfer_entry = frappe.get_doc(make_stock_entry(wo.name, "Material Transfer for Manufacture", 10))
-		transfer_entry.save()
-		transfer_entry.items[0].item_code = alternate_item[0]
-		transfer_entry.items[0].original_item = raw_materials[0]
-		transfer_entry.submit()
-		self.assertTrue(transfer_entry.docstatus == 1)
-		manufacture_entry = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 10))
-		manufacture_entry.save()
-		self.assertTrue(manufacture_entry.items[0].item_code == alternate_item[0])
-		self.assertTrue(manufacture_entry.items[0].original_item == raw_materials[0])
-		manufacture_entry.submit()
-		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 0)
-
-
-
 
 	def test_components_qty_for_bom_based_manufacture_entry(self):
 		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
@@ -2363,7 +2312,7 @@ class TestWorkOrder(FrappeTestCase):
 		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 0)
 
 	def test_manufacture_with_work_order_batch_TC_SCK_169(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2377,16 +2326,14 @@ class TestWorkOrder(FrappeTestCase):
 				"has_batch_no": 1,
 				"create_new_batch": 1,
 				"batch_number_series": "TBMK.#####",
+				"valuation_rate": 100,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -2412,7 +2359,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -2422,11 +2369,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_manufacture_with_work_order_batch_serial_TC_SCK_170(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2442,16 +2391,14 @@ class TestWorkOrder(FrappeTestCase):
 				"create_new_batch": 1,
 				"batch_number_series": "BT.#####",
 				"serial_no_series": "SN-TEST.#####",
+				"valuation_rate": 100,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -2477,7 +2424,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -2487,11 +2434,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name,'has_serial_no':1, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_serial_no": 1, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_manufacture_with_work_order_without_consum_TC_SCK_171(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2504,14 +2453,11 @@ class TestWorkOrder(FrappeTestCase):
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -2542,7 +2488,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.status, "Completed")
 
 	def test_manufacture_with_work_order_batch_without_consum_TC_SCK_172(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2558,14 +2504,11 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -2586,7 +2529,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		ste_doc.load_from_db()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -2596,11 +2539,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_manufacture_with_work_order_batch_serial_without_consum_TC_SCK_173(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2618,14 +2563,11 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -2646,7 +2588,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		ste_doc.load_from_db()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -2656,11 +2598,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name,'has_serial_no':1, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_serial_no": 1, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_manfu_wo_scrap_without_consum_TC_SCK_174(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2673,7 +2617,7 @@ class TestWorkOrder(FrappeTestCase):
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -2681,10 +2625,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -2745,7 +2689,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(manufacture_entry.items[0].s_warehouse, "Stores - _TC")
 
 	def test_manfu_wo_scrap_with_consum_TC_SCK_195(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2758,7 +2702,7 @@ class TestWorkOrder(FrappeTestCase):
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -2766,10 +2710,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -2806,7 +2750,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.status, "Completed")
 
 	def test_mafac_wo_btch_scp_with_consum_TC_SCK_196(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2822,17 +2766,14 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "stock_qty": 1})
 		bom_doc.submit()
 
@@ -2857,7 +2798,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -2867,11 +2808,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_mafac_wo_btch_serial_scp_TC_SCK_197(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2889,17 +2832,14 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "stock_qty": 1})
 		bom_doc.submit()
 
@@ -2926,7 +2866,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -2936,11 +2876,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name,'has_serial_no':1, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_serial_no": 1, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_mafac_wo_btch_scp_without_consum_TC_SCK_175(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -2956,17 +2898,14 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "stock_qty": 1})
 		bom_doc.submit()
 
@@ -2986,7 +2925,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		ste_doc.load_from_db()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -2996,11 +2935,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_mafac_wo_btch_sril_scp_without_consum_TC_SCK_176(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -3018,17 +2959,14 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "stock_qty": 1})
 		bom_doc.submit()
 
@@ -3048,7 +2986,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		ste_doc.load_from_db()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -3058,11 +2996,13 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name,'has_serial_no':1, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_serial_no": 1, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_mafac_wo_withconsum_TC_SCK_158(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -3073,16 +3013,14 @@ class TestWorkOrder(FrappeTestCase):
 			"Test FG Item To Test Return Case",
 			{
 				"is_stock_item": 1,
+				"valuation_rate": 100,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -3101,12 +3039,11 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		ste_doc.load_from_db()
-
 		# Create a stock entry to consumption the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -3116,7 +3053,9 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 0)
 
 	def test_manfu_pp_wo_scrap_with_consum_TC_SCK_198(self):
@@ -3132,7 +3071,7 @@ class TestWorkOrder(FrappeTestCase):
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3140,10 +3079,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -3192,7 +3131,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.status, "Completed")
 
 	def test_manfu_pp_wo_scrap_with_consum_TC_SCK_199(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
 			"backflush_raw_materials_based_on",
@@ -3208,7 +3147,7 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3216,10 +3155,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -3266,7 +3205,9 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_manfu_pp_wo_scp_with_cnsm_bch_srl_tc_sck_200(self):
@@ -3286,7 +3227,7 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3294,10 +3235,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -3344,7 +3285,9 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	def test_manfu_pp_wo_scrap_without_consum_tc_sck_201(self):
@@ -3360,7 +3303,7 @@ class TestWorkOrder(FrappeTestCase):
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3368,10 +3311,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -3430,7 +3373,7 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3438,10 +3381,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -3501,7 +3444,7 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3509,10 +3452,10 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
@@ -3554,15 +3497,18 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.submit()
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
-		"material_consumption":1,
-		"get_rm_cost_from_consumption_entry": 0
-		}
+		"Manufacturing Settings",
+		{
+			"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
+			"material_consumption": 1,
+			"get_rm_cost_from_consumption_entry": 0,
+		},
 	)
 	def test_mafac_wo_wth_consum_skp_transf_tc_sck_214(self):
 		item = make_item(
@@ -3571,18 +3517,15 @@ class TestWorkOrder(FrappeTestCase):
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
-		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10,do_not_submit=1)
+		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10, do_not_submit=1)
 		wo_doc.skip_transfer = 1
 		wo_doc.save()
 		wo_doc.submit()
@@ -3590,23 +3533,25 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.status, "Not Started")
 
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Material Consumption for Manufacture", 10))
-		stock_entry = frappe.get_doc({
-			"doctype": "Stock Entry",
-			"stock_entry_type": "Material Receipt",
-			"company": wo_doc.company,
-			"posting_date": frappe.utils.nowdate(),
-			"posting_time": frappe.utils.nowtime(),
-			"items": [
-				{
-					"item_code": item_raw.name,
-					"qty": 100,
-					"uom": "Nos",
-					"stock_uom": "Nos",
-					"t_warehouse": "Stores - _TC",
-					"basic_rate": 50
-				}
-			]
-		})
+		stock_entry = frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"stock_entry_type": "Material Receipt",
+				"company": wo_doc.company,
+				"posting_date": frappe.utils.nowdate(),
+				"posting_time": frappe.utils.nowtime(),
+				"items": [
+					{
+						"item_code": item_raw.name,
+						"qty": 100,
+						"uom": "Nos",
+						"stock_uom": "Nos",
+						"t_warehouse": "Stores - _TC",
+						"basic_rate": 50,
+					}
+				],
+			}
+		)
 		stock_entry.insert()
 		stock_entry.submit()
 		# Create a stock entry to consumption the item
@@ -3617,7 +3562,7 @@ class TestWorkOrder(FrappeTestCase):
 			)
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		ste_doc.save()
@@ -3627,11 +3572,12 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
-		"material_consumption":1,
-		"get_rm_cost_from_consumption_entry": 0
-		}
+		"Manufacturing Settings",
+		{
+			"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
+			"material_consumption": 1,
+			"get_rm_cost_from_consumption_entry": 0,
+		},
 	)
 	def test_mafac_wo_wth_consum_skp_transf_btch_tc_sck_215(self):
 		item = make_item(
@@ -3643,18 +3589,15 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
-		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10,do_not_submit=1)
+		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10, do_not_submit=1)
 		wo_doc.skip_transfer = 1
 		wo_doc.save()
 		wo_doc.submit()
@@ -3668,25 +3611,27 @@ class TestWorkOrder(FrappeTestCase):
 				item_code=row.item_code, target="Stores - _TC", qty=row.qty, basic_rate=100
 			)
 		ste_doc.save()
-		ste_doc.submit()	
-		
-		stock_entry = frappe.get_doc({
-			"doctype": "Stock Entry",
-			"stock_entry_type": "Material Receipt",
-			"company": wo_doc.company,
-			"posting_date": frappe.utils.nowdate(),
-			"posting_time": frappe.utils.nowtime(),
-			"items": [
-				{
-					"item_code": item_raw.name,
-					"qty": 100,
-					"uom": "Nos",
-					"stock_uom": "Nos",
-					"t_warehouse": "Stores - _TC",
-					"basic_rate": 50
-				}
-			]
-		})
+		ste_doc.submit()
+
+		stock_entry = frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"stock_entry_type": "Material Receipt",
+				"company": wo_doc.company,
+				"posting_date": frappe.utils.nowdate(),
+				"posting_time": frappe.utils.nowtime(),
+				"items": [
+					{
+						"item_code": item_raw.name,
+						"qty": 100,
+						"uom": "Nos",
+						"stock_uom": "Nos",
+						"t_warehouse": "Stores - _TC",
+						"basic_rate": 50,
+					}
+				],
+			}
+		)
 		stock_entry.insert()
 		stock_entry.submit()
 
@@ -3697,26 +3642,29 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
-		"material_consumption":1,
-		"get_rm_cost_from_consumption_entry": 0
-		}
+		"Manufacturing Settings",
+		{
+			"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
+			"material_consumption": 1,
+			"get_rm_cost_from_consumption_entry": 0,
+		},
 	)
 	@change_settings(
-		"Stock Settings", 
+		"Stock Settings",
 		{
 			"allow_negative_stock": 1,
-		}
+		},
 	)
 	def test_mafac_wo_wth_consum_skp_transf_btch_srl_tc_sck_216(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		item = make_item(
 			"Test FG Item To Test Return Case",
 			{
@@ -3728,18 +3676,15 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
-		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10,do_not_submit=1)
+		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10, do_not_submit=1)
 		wo_doc.skip_transfer = 1
 		wo_doc.save()
 		wo_doc.submit()
@@ -3754,7 +3699,7 @@ class TestWorkOrder(FrappeTestCase):
 			)
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		for row in ste_doc.items:
@@ -3762,17 +3707,20 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1,'has_serial_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1, "has_serial_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
-		"material_consumption":1,
-		"get_rm_cost_from_consumption_entry": 0
-		}
+		"Manufacturing Settings",
+		{
+			"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
+			"material_consumption": 1,
+			"get_rm_cost_from_consumption_entry": 0,
+		},
 	)
 	def test_wo_wth_consum_skp_transf_scp_tc_sck_217(self):
 		item = make_item(
@@ -3781,7 +3729,7 @@ class TestWorkOrder(FrappeTestCase):
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3789,38 +3737,40 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
 		# Create a work order
-		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10,do_not_submit=1)
+		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10, do_not_submit=1)
 		wo_doc.skip_transfer = 1
 		wo_doc.save()
 		wo_doc.submit()
 		self.assertEqual(wo_doc.bom_no, bom_doc.name)
 		self.assertEqual(wo_doc.status, "Not Started")
 
-		stock_entry = frappe.get_doc({
-			"doctype": "Stock Entry",
-			"stock_entry_type": "Material Receipt",
-			"company": wo_doc.company,
-			"posting_date": frappe.utils.nowdate(),
-			"posting_time": frappe.utils.nowtime(),
-			"items": [
-				{
-					"item_code": item_raw.name,
-					"qty": 100,
-					"uom": "Nos",
-					"stock_uom": "Nos",
-					"t_warehouse": "Stores - _TC",
-					"basic_rate": 50
-				}
-			]
-		})
+		stock_entry = frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"stock_entry_type": "Material Receipt",
+				"company": wo_doc.company,
+				"posting_date": frappe.utils.nowdate(),
+				"posting_time": frappe.utils.nowtime(),
+				"items": [
+					{
+						"item_code": item_raw.name,
+						"qty": 100,
+						"uom": "Nos",
+						"stock_uom": "Nos",
+						"t_warehouse": "Stores - _TC",
+						"basic_rate": 50,
+					}
+				],
+			}
+		)
 		stock_entry.insert()
 		stock_entry.submit()
 
@@ -3832,7 +3782,7 @@ class TestWorkOrder(FrappeTestCase):
 			)
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		ste_doc.save()
@@ -3842,11 +3792,12 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
-		"material_consumption":1,
-		"get_rm_cost_from_consumption_entry": 0
-		}
+		"Manufacturing Settings",
+		{
+			"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
+			"material_consumption": 1,
+			"get_rm_cost_from_consumption_entry": 0,
+		},
 	)
 	def test_wo_wth_consum_skp_transf_scp_btch_tc_sck_218(self):
 		item = make_item(
@@ -3858,7 +3809,7 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3866,38 +3817,40 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
 		# Create a work order
-		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10,do_not_submit=1)
+		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10, do_not_submit=1)
 		wo_doc.skip_transfer = 1
 		wo_doc.save()
 		wo_doc.submit()
 		self.assertEqual(wo_doc.bom_no, bom_doc.name)
 		self.assertEqual(wo_doc.status, "Not Started")
 
-		stock_entry = frappe.get_doc({
-			"doctype": "Stock Entry",
-			"stock_entry_type": "Material Receipt",
-			"company": wo_doc.company,
-			"posting_date": frappe.utils.nowdate(),
-			"posting_time": frappe.utils.nowtime(),
-			"items": [
-				{
-					"item_code": item_raw.name,
-					"qty": 100,
-					"uom": "Nos",
-					"stock_uom": "Nos",
-					"t_warehouse": "Stores - _TC",
-					"basic_rate": 50
-				}
-			]
-		})
+		stock_entry = frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"stock_entry_type": "Material Receipt",
+				"company": wo_doc.company,
+				"posting_date": frappe.utils.nowdate(),
+				"posting_time": frappe.utils.nowtime(),
+				"items": [
+					{
+						"item_code": item_raw.name,
+						"qty": 100,
+						"uom": "Nos",
+						"stock_uom": "Nos",
+						"t_warehouse": "Stores - _TC",
+						"basic_rate": 50,
+					}
+				],
+			}
+		)
 		stock_entry.insert()
 		stock_entry.submit()
 
@@ -3909,23 +3862,26 @@ class TestWorkOrder(FrappeTestCase):
 			)
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
 
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
-		"material_consumption":1,
-		"get_rm_cost_from_consumption_entry": 0
-		}
+		"Manufacturing Settings",
+		{
+			"backflush_raw_materials_based_on": "Material Transferred for Manufacture",
+			"material_consumption": 1,
+			"get_rm_cost_from_consumption_entry": 0,
+		},
 	)
 	def test_wo_wth_consum_skp_transf_scp_btch_srl_tc_sck_219(self):
 		item = make_item(
@@ -3939,7 +3895,7 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
@@ -3947,38 +3903,40 @@ class TestWorkOrder(FrappeTestCase):
 			source_warehouse="Stores - _TC",
 			raw_materials=[item_raw],
 			rm_qty=10,
-			do_not_submit=True
+			do_not_submit=True,
 		)
 		item_scrap = make_item("Test scrap material1")
-		frappe.db.set_value('Item',item_scrap.item_code,'valuation_rate',20)
+		frappe.db.set_value("Item", item_scrap.item_code, "valuation_rate", 20)
 		bom_doc.append("scrap_items", {"item_code": item_scrap.item_code, "qty": 1})
 		bom_doc.submit()
 
 		# Create a work order
-		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10,do_not_submit=1)
+		wo_doc = make_wo_order_test_record(production_item=item_code, qty=10, do_not_submit=1)
 		wo_doc.skip_transfer = 1
 		wo_doc.save()
 		wo_doc.submit()
 		self.assertEqual(wo_doc.bom_no, bom_doc.name)
 		self.assertEqual(wo_doc.status, "Not Started")
 
-		stock_entry = frappe.get_doc({
-			"doctype": "Stock Entry",
-			"stock_entry_type": "Material Receipt",
-			"company": wo_doc.company,
-			"posting_date": frappe.utils.nowdate(),
-			"posting_time": frappe.utils.nowtime(),
-			"items": [
-				{
-					"item_code": item_raw.name,
-					"qty": 100,
-					"uom": "Nos",
-					"stock_uom": "Nos",
-					"t_warehouse": "Stores - _TC",
-					"basic_rate": 50
-				}
-			]
-		})
+		stock_entry = frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"stock_entry_type": "Material Receipt",
+				"company": wo_doc.company,
+				"posting_date": frappe.utils.nowdate(),
+				"posting_time": frappe.utils.nowtime(),
+				"items": [
+					{
+						"item_code": item_raw.name,
+						"qty": 100,
+						"uom": "Nos",
+						"stock_uom": "Nos",
+						"t_warehouse": "Stores - _TC",
+						"basic_rate": 50,
+					}
+				],
+			}
+		)
 		stock_entry.insert()
 		stock_entry.submit()
 
@@ -3990,37 +3948,33 @@ class TestWorkOrder(FrappeTestCase):
 			)
 		ste_doc.save()
 		ste_doc.submit()
-		
+
 		# Create a stock entry to manufacture the item
 		ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 10))
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
 
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1,'has_serial_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1, "has_serial_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 		self.assertEqual(wo_doc.status, "Completed")
 
-	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "BOM"}
-	)
+	@change_settings("Manufacturing Settings", {"backflush_raw_materials_based_on": "BOM"})
 	def test_wo_without_consum_bom_TC_SCK_234(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		item = make_item(
 			"Test FG Item To Test Return Case",
 			{
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -4050,12 +4004,9 @@ class TestWorkOrder(FrappeTestCase):
 		wo_doc.load_from_db()
 		self.assertEqual(wo_doc.status, "Completed")
 
-	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "BOM"}
-	)
+	@change_settings("Manufacturing Settings", {"backflush_raw_materials_based_on": "BOM"})
 	def test_wo_without_consum_bom_bth_TC_SCK_235(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		item = make_item(
 			"Test FG Item To Test Return Case",
 			{
@@ -4065,14 +4016,11 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -4100,16 +4048,15 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 		self.assertEqual(wo_doc.status, "Completed")
 
-	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "BOM"}
-	)
+	@change_settings("Manufacturing Settings", {"backflush_raw_materials_based_on": "BOM"})
 	def test_wo_without_consum_bom_bth_srl_TC_SCK_236(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		item = make_item(
 			"Test FG Item To Test Return Case",
 			{
@@ -4121,14 +4068,11 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -4156,30 +4100,28 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1,'has_serial_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1, "has_serial_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture"}
+		"Manufacturing Settings", {"backflush_raw_materials_based_on": "Material Transferred for Manufacture"}
 	)
 	def test_wo_without_consum_manu_TC_SCK_237(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		item = make_item(
 			"Test FG Item To Test Return Case",
 			{
 				"is_stock_item": 1,
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -4210,11 +4152,10 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture"}
+		"Manufacturing Settings", {"backflush_raw_materials_based_on": "Material Transferred for Manufacture"}
 	)
 	def test_wo_without_consum_manu_bth_TC_SCK_238(self):
-		get_or_create_fiscal_year('_Test Company')
+		get_or_create_fiscal_year("_Test Company")
 		item = make_item(
 			"Test FG Item To Test Return Case",
 			{
@@ -4224,14 +4165,11 @@ class TestWorkOrder(FrappeTestCase):
 				"batch_number_series": "TBMK.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -4259,13 +4197,14 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 		self.assertEqual(wo_doc.status, "Completed")
 
 	@change_settings(
-		"Manufacturing Settings", 
-		{"backflush_raw_materials_based_on": "Material Transferred for Manufacture"}
+		"Manufacturing Settings", {"backflush_raw_materials_based_on": "Material Transferred for Manufacture"}
 	)
 	def test_wo_without_consum_manu_bth_srl_tc_sck_239(self):
 		item = make_item(
@@ -4279,14 +4218,11 @@ class TestWorkOrder(FrappeTestCase):
 				"serial_no_series": "SN-TEST.#####",
 			},
 		)
-		
+
 		item_raw = make_item("Test raw material")
 		item_code = item.name
 		bom_doc = make_bom(
-			item=item_code,
-			source_warehouse="Stores - _TC",
-			raw_materials=[item_raw],
-			rm_qty=10
+			item=item_code, source_warehouse="Stores - _TC", raw_materials=[item_raw], rm_qty=10
 		)
 
 		# Create a work order
@@ -4314,7 +4250,9 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.save()
 		ste_doc.submit()
 		wo_doc.load_from_db()
-		serial_cnt = frappe.db.count('Serial and Batch Bundle',{'voucher_no':ste_doc.name, 'has_batch_no':1,'has_serial_no':1})
+		serial_cnt = frappe.db.count(
+			"Serial and Batch Bundle", {"voucher_no": ste_doc.name, "has_batch_no": 1, "has_serial_no": 1}
+		)
 		self.assertEqual(serial_cnt, 1)
 		self.assertEqual(wo_doc.status, "Completed")
 
@@ -4495,6 +4433,7 @@ def make_stock_in_entries_and_get_batches(rm_item, source_warehouse, wip_warehou
 		batch_doc.db_set("expiry_date", add_to_date(now(), days=10))
 
 	return batches
+
 
 def make_operation(**kwargs):
 	kwargs = frappe._dict(kwargs)

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -3945,6 +3945,12 @@ class TestStockEntry(FrappeTestCase):
 			company=company,
 		)
 		qty = 10
+		if frappe.db.exists("Company", "PP2 Ltd"):
+			frappe.db.set_value("Company", "PP2 Ltd", "default_inventory_account", "Stock In Hand - _TC")
+
+			if frappe.db.exists("Warehouse", "Stores - PP2 Ltd"):
+				frappe.db.set_value("Warehouse", "Stores - PP2 Ltd", "account", "Stock In Hand - _TC")
+
 		get_warehouse_account_map()
 		# Stock Receipt
 		make_stock_entry(

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -210,6 +210,12 @@ class TestStockLedgerEntry(FrappeTestCase, StockTestMixin):
 
 		self.assertEqual(outgoing_rate, 100)
 		self.assertEqual(stock_value_difference, -200)
+		frappe.db.set_value(
+			"Company",
+			"_Test Company",
+			"expenses_included_in_valuation",
+			"Expenses Included In Valuation - _TC",
+		)
 
 		create_landed_cost_voucher("Purchase Receipt", pr.name, pr.company)
 
@@ -1106,6 +1112,9 @@ class TestStockLedgerEntry(FrappeTestCase, StockTestMixin):
 		self.addCleanup(frappe.flags.pop, "dont_execute_stock_reposts")
 
 		item = make_item().name
+		item = frappe.get_doc("Item", item)
+		item.valuation_rate = 100
+		item.save()
 		warehouse = "_Test Warehouse - _TC"
 
 		posting_date = "2022-01-01"


### PR DESCRIPTION
**Title**
Fix Validation error on valuation rate,company gstin

**Test Summary**
These test acse having validation error and company GSTIN and removed the duplicated function of "test_components_alternate_item_for_bom_based_manufacture_entry" and fixed zero valuation ration on item creation

**Doctype**
Work Order
Stock Entry
Stock ledger Entry

**Test Cases:**
test_purchase_return_valuation_reposting
test_reposting_of_sales_return_for_packed_item
test_sales_return_valuation_reposting
test_tie_breaking
TC_SCK_158
test_manufacture_with_work_order_batch_TC_SCK_169
test_manufacture_with_work_order_batch_serial_TC_SCK_170
test_single_po_multi_pr_pi_TC_B_006
test_status_po_on_pi_cancel_TC_B_038
test_subcontrcting_supply_raw_material_TC_B_101
TC_SCK_207

Fixes an AttributeError in test_update_customer_issue_flag_0_with_previous_partial_visit caused by calling a non-existent instance method self.make_sales_person() inside the TestMaintenanceVisit.setUp() method.
Replaces the instance method call with the already defined global helper function make_sales_person() to ensure proper Sales Person creation during test setup.
This fix:

**Scenarios Covered**
Account Mapping for Companies & Warehouses
Ensures that a company (e.g., PP2 Ltd) and its warehouses are properly linked to GL accounts (Stock In Hand).
This is important for correct financial posting.

Stock Receipt Transactions
Tests that receiving stock increases inventory and generates correct stock ledger + GL entries.

Stock Issues & Transfers
Tests stock issue (outward movement) and warehouse-to-warehouse transfer, validating quantity, valuation, and GL updates.

Manufacture Entries
Tests manufacturing-related stock entries (consumption + production).

General Accounting Integration
Ensures every Stock Entry creates the expected GL impact, tied to warehouse accounts.

**Linked Issue**
https://github.com/8848digital/erpnext/issues/2787

**Issue Tracker ID**
N/A