### PR TITLE
fix: bug on report delivered items to be billed on load

### DIFF
--- a/erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py
+++ b/erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py
@@ -87,5 +87,5 @@ def get_args():
 		"date": "posting_date",
 		"order": "name",
 		"order_by": Order.desc,
- 		"reference_field": "delivery_note","order_by": "desc",
+ 		"reference_field": "delivery_note"
 	}


### PR DESCRIPTION
'str' object has no attribute 'value' error resolved by removing incorrect 'order by' filter
