### PR TITLE
test: add new test cases for Payment Request  and Payment Order

### DIFF
--- a/erpnext/accounts/doctype/payment_order/payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/payment_order.py
@@ -16,7 +16,7 @@ class PaymentOrder(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.payment_order_reference.payment_order_reference import (

--- a/erpnext/accounts/doctype/payment_order/test_payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/test_payment_order.py
@@ -100,7 +100,186 @@ class TestPaymentOrder(FrappeTestCase):
 			]
 		check_gl_entries(self,jv_doc.name,expected_accounts,jv_doc.posting_date,"Journal Entry")
 
+	def test_make_payment_records_TC_ACC_363(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from .payment_order import make_payment_records
+		from frappe.core.doctype.session_default_settings.session_default_settings import set_session_default_values
+		create_company("_Test Company")
+		if frappe.db.get_value("Company", "_Test Company", "default_currency") != "INR":
+			frappe.db.set_value("Company", "_Test Company", "default_currency", "INR")
+		set_session_default_values({"Company": "_Test Company"})
+		supplier = create_supplier(supplier_name="_Test Supplier 1")
+		supplier.default_currency = "INR"
+		supplier.save(ignore_permissions=True)
+		create_warehouse(warehouse_name="_Test Warehouse 1")
+		if not frappe.db.exists("UOM","_Test UOM"): 
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert()
+		purchase_invoice = make_purchase_invoice(supplier="_Test Supplier 1")
+		payment_request=make_payment_request( 
+			dn=purchase_invoice.name,
+			dt="Purchase Invoice",
+			return_doc=1,
+		)
+		payment_request.is_payment_order_required=1
+		payment_request.save()
+		payment_request.submit()
+		
+		payment_order = frappe.get_doc({
+			"doctype": "Payment Order",
+			"company": "_Test Company",
+			"payment_order_type": "Payment Entry",
+			"company_bank_account": self.bank_account,
+			"references": [
+				{
+					"reference_doctype": "Purchase Invoice",
+					"reference_name": purchase_invoice.name,
+					"supplier": "_Test Supplier 1",
+					"amount": payment_request.grand_total,
+					"payment_request": payment_request.name,
+					"bank_account": self.bank_account,
+					"mode_of_payment": "Cash"
+				}
+			]
+		}).insert().save().submit()
+		make_payment_records(payment_order, "_Test Supplier 1")
+		je_doc = frappe.get_all(
+			"Journal Entry",
+			filters={"payment_order": payment_order.name},
+			order_by="creation desc",
+			limit=1,
+			fields=["name"]
+		)
+		self.assertEqual(len(je_doc), 1)
+		self.assertTrue(je_doc[0].name)
 	
+	def test_get_supplier_query_TC_ACC_364(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from .payment_order import get_supplier_query
+		from frappe.core.doctype.session_default_settings.session_default_settings import set_session_default_values
+		create_company("_Test Company")
+		if frappe.db.get_value("Company", "_Test Company", "default_currency") != "INR":
+			frappe.db.set_value("Company", "_Test Company", "default_currency", "INR")
+		set_session_default_values({"Company": "_Test Company"})
+		supplier = create_supplier(supplier_name="_Test Supplier 1")
+		supplier.default_currency = "INR"
+		supplier.save(ignore_permissions=True)
+		create_warehouse(warehouse_name="_Test Warehouse 1")
+		if not frappe.db.exists("UOM","_Test UOM"): 
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert()
+		purchase_invoice = make_purchase_invoice(supplier="_Test Supplier 1")
+		payment_request=make_payment_request( 
+			dn=purchase_invoice.name,
+			dt="Purchase Invoice",
+			return_doc=1,
+		)
+		payment_request.is_payment_order_required=1
+		payment_request.save()
+		payment_request.submit()
+		
+		payment_order = frappe.get_doc({
+			"doctype": "Payment Order",
+			"company": "_Test Company",
+			"payment_order_type": "Payment Entry",
+			"company_bank_account": self.bank_account,
+			"references": [
+				{
+					"reference_doctype": "Purchase Invoice",
+					"reference_name": purchase_invoice.name,
+					"supplier": "_Test Supplier 1",
+					"amount": payment_request.grand_total,
+					"payment_request": payment_request.name,
+					"bank_account": self.bank_account,
+					"mode_of_payment": "Cash"
+				}
+			]
+		}).insert().save().submit()
+		results = get_supplier_query(
+				doctype="Payment Order Reference",
+				txt="_Test Supplier",
+				searchfield="supplier",
+				start=0,
+				page_len=10,
+				filters={"parent": payment_order.name}
+		)
+		self.assertEqual(results, [("_Test Supplier 1",)], f"Unexpected result: {results}")
+  
+	def test_get_mop_query_TC_ACC_365(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from .payment_order import get_mop_query
+		from frappe.core.doctype.session_default_settings.session_default_settings import set_session_default_values
+
+		create_company("_Test Company")
+		if frappe.db.get_value("Company", "_Test Company", "default_currency") != "INR":
+			frappe.db.set_value("Company", "_Test Company", "default_currency", "INR")
+		set_session_default_values({"Company": "_Test Company"})
+		create_warehouse(warehouse_name="_Test Warehouse 1")
+  
+		supplier = create_supplier(supplier_name="_Test Supplier MOP")
+		supplier.default_currency = "INR"
+		supplier.save(ignore_permissions=True)
+
+		create_warehouse(warehouse_name="_Test Warehouse MOP")
+		if not frappe.db.exists("UOM","_Test UOM"): 
+			frappe.get_doc({
+				"doctype": "UOM",
+				"uom_name": "_Test UOM",
+			}).insert()
+
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+		purchase_invoice = make_purchase_invoice(supplier="_Test Supplier MOP")
+		payment_request = make_payment_request( 
+			dn=purchase_invoice.name,
+			dt="Purchase Invoice",
+			return_doc=1,
+		)
+		payment_request.is_payment_order_required = 1
+		payment_request.save()
+		payment_request.submit()
+
+		payment_order = frappe.get_doc({
+			"doctype": "Payment Order",
+			"company": "_Test Company",
+			"payment_order_type": "Payment Entry",
+			"company_bank_account": self.bank_account,
+		})
+		payment_order.append("references",{
+				"reference_doctype": "Purchase Invoice",
+				"reference_name": purchase_invoice.name,
+				"supplier": "_Test Supplier MOP",
+				"amount": payment_request.grand_total,
+				"payment_request": payment_request.name,
+				"bank_account": self.bank_account,
+				"mode_of_payment": "Cash"
+		})
+		payment_order.save(ignore_permissions=True)
+		if payment_order.references and not payment_order.references[0].mode_of_payment:
+			frappe.db.set_value("Payment Order Reference", payment_order.references[0].name, "mode_of_payment", "Cash")
+		
+		results = get_mop_query(
+			doctype="Payment Order Reference",
+			txt="Cash",
+			searchfield="mode_of_payment",
+			start=0,
+			page_len=10,
+			filters={"parent": payment_order.name}
+		)
+		self.assertEqual(results, [("Cash",)], f"Unexpected result: {results}")
+  	
 def create_payment_order_against_payment_entry(ref_doc, order_type, bank_account):
 	payment_order = frappe.get_doc(
 		dict(

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -1627,6 +1627,270 @@ class TestPaymentRequest(FrappeTestCase):
 		si.load_from_db()
 		pr = make_payment_request(dt="Sales Invoice", dn=si.name, mute_email=1)
 		self.assertEqual(pr.grand_total, si.outstanding_amount)
+	
+	def test_set_payment_request_url_TC_ACC_359(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			create_company,
+			create_customer,
+			make_test_item,
+			create_sales_invoice,
+		)
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		create_company("_Test Company")
+		get_or_create_fiscal_year("_Test Company")
+		customer = create_customer("_Test Customer")
+		create_warehouse("_Test Warehouse")
+		item = make_test_item("_Test Item")
+		si = create_sales_invoice(
+			customer = customer,
+			company = "_Test Company",
+			item_code = item.name,
+			qty = 1,
+			rate = 1000,
+			currency = "INR",
+			warehouse = "_Test Warehouse - _TC"
+		)
+		pr = make_payment_request(
+			dt = "Sales Invoice",
+			dn = si.name,
+			mute_email = 1,
+			submit_doc = 0
+		)
+		pr_doc = frappe.get_doc("Payment Request", pr.name)
+		rz = frappe.get_doc({
+			"doctype": "Razorpay Settings",
+			"api_key": "test_api_key",
+			"api_secret": "test_api_secret",
+			"redirect_to": "http://localhost:8000",
+		})
+		rz.flags.ignore_validate = True
+		rz.save(ignore_permissions=True)
+		pg = create_payment_gateway_account(pg_name="Test Payment Gateway", payment_channel="Email", is_default=True)
+		pr_doc.payment_gateway_account = pg.name
+		pr_doc.payment_gateway = "Test Payment Gateway"
+		pr_doc.save(ignore_permissions=True)
+		pg_doc = frappe.get_doc("Payment Gateway", "Test Payment Gateway")
+		pg_doc.gateway_settings = rz.doctype
+		pg_doc.gateway_controller = rz.name
+		pg_doc.save(ignore_permissions=True)
+		pr_doc.set_payment_request_url()
+		self.assertTrue(pr_doc.payment_url)
+  
+	def test_request_phone_payment_TC_ACC_360(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			create_company,
+			create_customer,
+			make_test_item,
+			create_sales_invoice,
+		)
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+		rz = None
+		create_company("_Test Company")
+		get_or_create_fiscal_year("_Test Company")
+		customer = create_customer("_Test Customer")
+		create_warehouse("_Test Warehouse")
+		item = make_test_item("_Test Item")
+
+		si = create_sales_invoice(
+			customer=customer,
+			company="_Test Company",
+			item_code=item.name,
+			qty=1,
+			rate=500,
+			currency="KES",
+			warehouse="_Test Warehouse - _TC"
+		)
+
+		pr = make_payment_request(
+			dt="Sales Invoice",
+			dn=si.name,
+			mute_email=1,
+			submit_doc=0
+		)
+		pr_doc = frappe.get_doc("Payment Request", pr.name)
+
+		if not frappe.db.exists("Mpesa Settings", {"payment_gateway_name": "Test Mpesa Gateway New"}):
+			rz = frappe.get_doc({
+				"doctype": "Mpesa Settings",
+				"payment_gateway_name": "Test Mpesa Gateway New",
+				"consumer_key": "test_consumer_key",
+				"consumer_secret": "test_consumer_secret",
+				"business_shortcode": "test_business_shortcode",
+				"online_passkey": "test_online_passkey",
+				"till_number": "1234567890",
+				"transaction_limit": 15000
+			})
+			rz.flags.ignore_validate = True
+			rz.insert(ignore_permissions=True)
+		else:
+			rz = frappe.get_doc("Mpesa Settings", "Test Mpesa Gateway New")
+		m_pg = create_payment_gateway_account(
+			pg_name="Mpesa-" + rz.payment_gateway_name,
+			payment_channel="Phone",
+			is_default=True,
+			currency="USD"
+		)
+		payment_account = frappe.get_value(
+			"Payment Gateway Account",
+			{"payment_gateway": "Mpesa-" + rz.payment_gateway_name},
+			["name", "payment_account"],
+			as_dict=1
+		)
+		if payment_account and payment_account.payment_account != 'Cash - _TC':
+			frappe.db.set_value(
+				"Payment Gateway Account",
+				payment_account.name,
+				"payment_account",
+				"Cash - _TC"
+			)
+		pg = create_payment_gateway_account(pg_name="Test Phone Gateway", payment_channel="Phone", is_default=True)
+		pr_doc.payment_gateway_account = pg.name
+		pr_doc.payment_gateway = "Test Phone Gateway"
+		pr_doc.phone_number = "9999999999"
+		pr_doc.save(ignore_permissions=True)
+
+		pg_doc = frappe.get_doc("Payment Gateway", "Test Phone Gateway")
+		pg_doc.gateway_settings = rz.doctype
+		pg_doc.gateway_controller = rz.name
+		pg_doc.save(ignore_permissions=True)
+
+		pr_doc.request_phone_payment()
+
+		ir = frappe.get_all(
+			"Integration Request",
+			filters={
+				"reference_doctype": "Payment Request",
+				"reference_docname": pr_doc.name
+			},
+			limit=1
+		)
+		self.assertTrue(ir)
+		if ir:
+			frappe.db.set_value("Integration Request", ir[0], "status", "Completed")
+		request_amount = pr_doc.get_request_amount()
+		self.assertEqual(request_amount, pr_doc.grand_total)
+		frappe.delete_doc("Payment Request", pr_doc.name, force=True)
+		frappe.delete_doc("Payment Gateway Account", pg.name ,force=True)
+		frappe.delete_doc("Payment Gateway", "Test Phone Gateway" ,force=True)
+		frappe.delete_doc("Mpesa Settings", "Test Mpesa Gateway New" ,force=True)
+		frappe.db.rollback()
+  
+	def test_cancel_old_payment_requests_TC_ACC_361(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			create_company,
+			create_customer,
+			make_test_item,
+			create_sales_invoice,
+		)
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		from erpnext.accounts.doctype.payment_request.payment_request import (
+			make_payment_request,
+			cancel_old_payment_requests,
+		)
+		import json
+
+		create_company("_Test Company")
+		get_or_create_fiscal_year("_Test Company")
+		customer = create_customer("_Test Customer")
+		create_warehouse("_Test Warehouse")
+		item = make_test_item("_Test Item")
+
+		si = create_sales_invoice(
+			customer=customer,
+			company="_Test Company",
+			item_code=item.name,
+			qty=1,
+			rate=200,
+			currency="INR",
+			warehouse="_Test Warehouse - _TC"
+		)
+
+		pr = make_payment_request(
+			dt="Sales Invoice",
+			dn=si.name,
+			mute_email=1,
+			submit_doc=1  
+		)
+		pr_doc = frappe.get_doc("Payment Request", pr.name)
+		pr_doc.status = "Requested"
+		pr_doc.save(ignore_permissions=True)
+
+		ireq = frappe.get_doc({
+			"doctype": "Integration Request",
+			"reference_doctype": "Payment Request",
+			"reference_docname": pr_doc.name,
+			"status": "Queued",
+			"data": json.dumps({"request_amount": pr_doc.grand_total}),
+		})
+		ireq.insert(ignore_permissions=True)
+
+		cancel_old_payment_requests("Sales Invoice", si.name)
+
+		pr_doc.reload()
+		ireq.reload()
+
+		self.assertEqual(pr_doc.docstatus, 2)  
+
+		self.assertEqual(ireq.status, "Cancelled")
+  
+	def test_get_irequest_status_TC_ACC_362(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			create_company,
+			create_customer,
+			make_test_item,
+			create_sales_invoice,
+		)
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_or_create_fiscal_year
+		from erpnext.accounts.doctype.payment_request.payment_request import (
+			make_payment_request,
+			get_irequest_status,
+		)	
+		import json
+
+		create_company("_Test Company")
+		get_or_create_fiscal_year("_Test Company")
+		customer = create_customer("_Test Customer")
+		create_warehouse("_Test Warehouse")
+		item = make_test_item("_Test Item")
+
+		si = create_sales_invoice(
+			customer=customer,
+			company="_Test Company",
+			item_code=item.name,
+			qty=1,
+			rate=300,
+			currency="INR",
+			warehouse="_Test Warehouse - _TC"
+		)
+
+		pr = make_payment_request(
+			dt="Sales Invoice",
+			dn=si.name,
+			mute_email=1,
+			submit_doc=1
+		)
+		pr_doc = frappe.get_doc("Payment Request", pr.name)
+
+		result = get_irequest_status([pr_doc.name])
+		self.assertEqual(result, [])
+
+		ireq = frappe.get_doc({
+			"doctype": "Integration Request",
+			"reference_doctype": "Payment Request",
+			"reference_docname": pr_doc.name,
+			"status": "Completed",
+			"data": json.dumps({"request_amount": pr_doc.grand_total}),
+		})
+		ireq.insert(ignore_permissions=True)
+
+		result = get_irequest_status([pr_doc.name])
+		self.assertTrue(result)  
+		self.assertEqual(result[0]["name"], ireq.name)
 
 def test_partial_paid_invoice_with_submitted_payment_entry(self):
 	pi = make_purchase_invoice(currency="INR", qty=1, rate=5000)

--- a/erpnext/accounts/doctype/payment_schedule/payment_schedule.py
+++ b/erpnext/accounts/doctype/payment_schedule/payment_schedule.py
@@ -11,7 +11,7 @@ class PaymentSchedule(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		base_outstanding: DF.Currency

--- a/erpnext/accounts/doctype/payment_term/payment_term.py
+++ b/erpnext/accounts/doctype/payment_term/payment_term.py
@@ -11,7 +11,7 @@ class PaymentTerm(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		credit_days: DF.Int

--- a/erpnext/accounts/doctype/payment_terms_template/payment_terms_template.py
+++ b/erpnext/accounts/doctype/payment_terms_template/payment_terms_template.py
@@ -14,7 +14,7 @@ class PaymentTermsTemplate(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.payment_terms_template_detail.payment_terms_template_detail import (

--- a/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.py
+++ b/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.py
@@ -11,7 +11,7 @@ class PaymentTermsTemplateDetail(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		credit_days: DF.Int


### PR DESCRIPTION
**Description**
This PR introduces comprehensive test coverage for Payment Request and Payment Order functionality in ERPNext, validating payment URL generation, phone payment requests, cancellation of old requests, integration request status retrieval, payment record creation, and supplier/mode-of-payment query operations.

**Test Cases Added**
**TC_ACC_359 (test_set_payment_request_url_TC_ACC_359)**

Tests generation of payment request URL for a Sales Invoice.

Validates integration with Razorpay settings and payment gateway account.

Ensures payment_url is correctly set on the Payment Request document.

**TC_ACC_360 (test_request_phone_payment_TC_ACC_360)**

Validates requesting payment via phone for a Payment Request.

Tests integration with Mpesa settings and phone-based payment gateway.

Ensures Integration Request is created and request amount matches the Payment Request total.

**TC_ACC_361 (test_cancel_old_payment_requests_TC_ACC_361)**

Tests cancellation of old Payment Requests for a given document.

Validates Payment Request docstatus is updated to Cancelled.

Ensures associated Integration Request status is set to "Cancelled".

**TC_ACC_362 (test_get_irequest_status_TC_ACC_362)**

Tests retrieval of Integration Request status for Payment Requests.

Validates correct filtering based on completed or pending Integration Requests.

Ensures returned data structure contains expected Integration Request information.

**TC_ACC_363 (test_make_payment_records_TC_ACC_363)**

Tests creation of Journal Entries from Payment Orders for Purchase Invoices.

Validates proper linkage between Payment Order, Payment Request, and Supplier.

Ensures Journal Entry is created and associated with the Payment Order.

**TC_ACC_364 (test_get_supplier_query_TC_ACC_364)**

Tests supplier query retrieval for Payment Order Reference filtering.

Validates search functionality for supplier names within a Payment Order.

Ensures accurate results returned based on filters applied.

**TC_ACC_365 (test_get_mop_query_TC_ACC_365)**

Tests mode-of-payment (MOP) query retrieval for Payment Order Reference.

Validates search and filtering functionality for MOP within a Payment Order.

Ensures returned results match expected payment methods.

**Scenarios Covered**

Payment URL generation for online gateways.

Phone-based payment request handling and Integration Request creation.

Cancellation of old payment requests and status updates.

Integration Request status retrieval and validation.

Creation of Journal Entries from Payment Orders for suppliers.

Supplier and mode-of-payment query functionality in Payment Orders.

Technology Stack

Frappe Framework

Python unittest and mocking

ERPNext Payment Request and Payment Order modules

Integration Request handling for external payment gateways