### PR TITLE
fix: frappe.exceptions.MandatoryError test_paid_amount_for_supplier_TC_ACC_375

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -3557,7 +3557,7 @@ def create_purchase_invoice(**args):
 				{
 					"doctype": "Purchase Invoice Item",
 					"item_code": args.item_code,
-					"item_name": args.item_name or "_Test Item",
+					"item_name": args.item_name or args.item_code,
 					"qty": args.qty or 1,
 					"rate": args.rate or 90000,
 					"cost_center": "Main - _TC",

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -3557,6 +3557,7 @@ def create_purchase_invoice(**args):
 				{
 					"doctype": "Purchase Invoice Item",
 					"item_code": args.item_code,
+					"item_name": args.item_name or "_Test Item",
 					"qty": args.qty or 1,
 					"rate": args.rate or 90000,
 					"cost_center": "Main - _TC",


### PR DESCRIPTION
### Title: Fix: frappe.exceptions.MandatoryError
Description:
Item Name was not added while creating Purchase Invoice

Root Cause:
Item Name Missing

Actual Result:
Tests failed frappe.exceptions.MandatoryError for Item name.

Expected Result:
Tests should pass consistently both individually and at the app level.

Fix Summary:
Added Item Name

Test Cases Covered:
test_paid_amount_for_supplier_TC_ACC_375

Linked Issue:
#2861