### PR TITLE
TypeError: create_payment_gateway_account() got an unexpected keyword argument 'currency'

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -3557,6 +3557,7 @@ def create_purchase_invoice(**args):
 				{
 					"doctype": "Purchase Invoice Item",
 					"item_code": args.item_code,
+					"item_name": args.item_name or "_Test Item",
 					"qty": args.qty or 1,
 					"rate": args.rate or 90000,
 					"cost_center": "Main - _TC",


### PR DESCRIPTION
### Title: create_payment_gateway_account() got an unexpected keyword argument 'currency'
## Description:
The function create_payment_gateway_account did not support a currency parameter. Passing this argument caused failures during test execution.

## Root Cause:
Unexpected keyword argument currency was being passed to the function.

## Actual Result:
Tests failed TypeError: create_payment_gateway_account() got an unexpected keyword argument 'currency'

## Expected Result:
Tests should pass consistently both individually and at the app level.

## Fix Summary:
Removed the unsupported currency parameter from the function call.

## Test Cases Covered:
test_request_phone_payment_TC_ACC_360

## Linked Issue: 2863