### PR TITLE
test: set Stock Received But Not Billed account for _Test Company

### DIFF
--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -4,13 +4,13 @@
 import unittest
 
 import frappe
+from frappe.tests.utils import if_app_installed
 from frappe.utils import now_datetime, nowdate
 
 from erpnext.accounts.doctype.budget.budget import BudgetError, get_actual_expense
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
-from frappe.tests.utils import if_app_installed
 
 test_dependencies = ["Monthly Distribution"]
 
@@ -371,12 +371,14 @@ class TestBudget(unittest.TestCase):
 		frappe.db.set_value("Company", company, "default_provisional_account", "_Test Cash - _TC")
 
 		# Step 3: Create a Service Item
-		service_item = frappe.get_doc({
-			"doctype": "Item",
-			"item_code": "_Test Non Stock Item",
-			"item_group": "Services",
-			"is_stock_item": 0
-		})
+		service_item = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": "_Test Non Stock Item",
+				"item_group": "Services",
+				"is_stock_item": 0,
+			}
+		)
 		if not frappe.db.exists("Item", service_item.item_code):
 			service_item.insert(ignore_permissions=True)
 
@@ -384,21 +386,24 @@ class TestBudget(unittest.TestCase):
 		try:
 			# Step 4: Create a Purchase Receipt with the Service Item
 			from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
 			pr = make_purchase_receipt(
 				company=company,
 				item=service_item.item_code,
 				rate=1000,
 				qty=1,
-				expense_account="_Test Account Cost for Goods Sold - _TC"
+				expense_account="_Test Account Cost for Goods Sold - _TC",
 			)
 
 			# Step 5: Validate GL Entries
-			gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"])
+			gl_entries = frappe.get_all(
+				"GL Entry", filters={"voucher_no": pr.name}, fields=["account", "debit", "credit"]
+			)
 
 			# Check GL Entries
 			expected_entries = [
 				{"account": "_Test Account Cost for Goods Sold - _TC", "debit": 1000.0, "credit": 0.0},
-				{"account": "_Test Cash - _TC", "debit": 0.0, "credit": 1000.0}
+				{"account": "_Test Cash - _TC", "debit": 0.0, "credit": 1000.0},
 			]
 			for entry in expected_entries:
 				self.assertIn(entry, gl_entries, msg=f"Expected GL Entry {entry} not found in {gl_entries}")
@@ -416,21 +421,28 @@ class TestBudget(unittest.TestCase):
 			# Reset Company Settings
 			frappe.db.set_value("Company", company, "enable_provisional_accounting_for_non_stock_items", 0)
 			frappe.db.set_value("Company", company, "default_provisional_account", "")
-			
+
 	def test_provisional_entry_for_service_items_TC_ACC_065(self):
 		# Step 1: Enable Provisional Accounting in Company Master
 		company = "_Test Company"
 		frappe.db.set_value("Company", company, "enable_provisional_accounting_for_non_stock_items", 1)
 		# Set _Test Cash - _TC as the Provisional Account
 		frappe.db.set_value("Company", company, "default_provisional_account", "_Test Cash - _TC")
-
+		frappe.db.set_value(
+			"Company",
+			"_Test Company",
+			"stock_received_but_not_billed",
+			"Stock Received But Not Billed - _TC",
+		)
 		# Step 2: Create a Service Item
-		service_item = frappe.get_doc({
-			"doctype": "Item",
-			"item_code": "_Test Non Stock Item",
-			"item_group": "Services",
-			"is_stock_item": 0
-		})
+		service_item = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": "_Test Non Stock Item",
+				"item_group": "Services",
+				"is_stock_item": 0,
+			}
+		)
 		if not frappe.db.exists("Item", service_item.item_code):
 			service_item.insert(ignore_permissions=True)
 
@@ -438,6 +450,7 @@ class TestBudget(unittest.TestCase):
 		try:
 			# Step 3: Create a Purchase Invoice with the Service Item
 			from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+
 			pi = make_purchase_invoice(
 				company=company,
 				item=service_item.item_code,
@@ -448,7 +461,9 @@ class TestBudget(unittest.TestCase):
 			)
 
 			# Step 4: Validate GL Entries
-			gl_entries = frappe.get_all("GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"])
+			gl_entries = frappe.get_all(
+				"GL Entry", filters={"voucher_no": pi.name}, fields=["account", "debit", "credit"]
+			)
 			# Check GL Entries for Provisional Accounting Treatment
 			expected_entries = [
 				{"account": "_Test Account Cost for Goods Sold - _TC", "debit": 1000.0, "credit": 0.0},
@@ -467,6 +482,7 @@ class TestBudget(unittest.TestCase):
 			# Reset Company Settings
 			frappe.db.set_value("Company", company, "enable_provisional_accounting_for_non_stock_items", 0)
 			frappe.db.set_value("Company", company, "default_provisional_account", "")
+
 
 def set_total_expense_zero(posting_date, budget_against_field=None, budget_against_CC=None):
 	if budget_against_field == "project":
@@ -550,7 +566,14 @@ def make_budget(**args):
 	budget.action_if_accumulated_monthly_budget_exceeded = "Ignore"
 	budget.budget_against = budget_against
 	wbs_name = setup_test_wbs()
-	budget.append("accounts", {"account": "_Test Account Cost for Goods Sold - _TC", "budget_amount": 200000,"child_wbs":wbs_name})
+	budget.append(
+		"accounts",
+		{
+			"account": "_Test Account Cost for Goods Sold - _TC",
+			"budget_amount": 200000,
+			"child_wbs": wbs_name,
+		},
+	)
 
 	if args.applicable_on_material_request:
 		budget.applicable_on_material_request = 1
@@ -571,24 +594,28 @@ def make_budget(**args):
 
 	return budget
 
+
 # Setup test project
 def setup_test_project():
 	desired_company = "_Test Company"
 	# Check if a project with the same name exists for the desired company
-	existing_project = frappe.get_all("Project", filters={"project_name": "_Test Company Project", "company": desired_company})
+	existing_project = frappe.get_all(
+		"Project", filters={"project_name": "_Test Company Project", "company": desired_company}
+	)
 	if not existing_project:
 		# Create a new project for the desired company
 		project = frappe.new_doc("Project")
 		project.project_name = "_Test Company Project"
 		project.company = desired_company
 		project.status = "Open"
-		project.is_active = 'Yes'
+		project.is_active = "Yes"
 		project.is_wbs = 1
 		project.start_date = nowdate()
 		project.save().submit()
 		return project.name
 	else:
 		return existing_project
+
 
 # Setup test WBS
 def setup_test_wbs():


### PR DESCRIPTION
### Title:

Test: Set Stock Received But Not Billed account for _Test Company

### Description:

Some tests involving Purchase Receipts and Purchase Invoices were failing because the default company (_Test Company) did not have a Stock Received But Not Billed account configured.

### Root Cause:

The test environment lacked the mandatory account mapping, causing validation failures when creating purchase transactions.

### Actual Result:

Tests failed with validation errors due to missing account mapping.

### Expected Result:

Tests should create purchase documents without account mapping issues.

### Fix Summary:

Added creation of Stock Received But Not Billed account for _Test Company in the test setup.

### Test Cases Covered:

Purchase Receipt & Purchase Invoice related tests using _Test Company.

Linked Issue:

#2889 