### PR TITLE
test: reset account configuration after TC execution to run other TCs smoothly

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -6,7 +6,7 @@ import unittest
 
 import frappe
 from frappe.tests.utils import change_settings
-from frappe.utils import flt, nowdate, getdate
+from frappe.utils import flt, getdate, nowdate
 
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
 from erpnext.accounts.doctype.journal_entry.journal_entry import StockAccountInvalidTransaction
@@ -110,7 +110,7 @@ class TestJournalEntry(unittest.TestCase):
 			submitted_voucher = frappe.get_doc(test_voucher.doctype, test_voucher.name)
 			try:
 				submitted_voucher.cancel()
-			except Exception as e:
+			except Exception:
 				pass
 
 	def test_jv_against_stock_account(self):
@@ -231,7 +231,6 @@ class TestJournalEntry(unittest.TestCase):
 		]
 
 		self.expected_gle = [
-			
 			{
 				"account": "Sales - _TC",
 				"account_currency": "INR",
@@ -395,12 +394,7 @@ class TestJournalEntry(unittest.TestCase):
 
 	def test_journal_entry_credit_note_TC_ACC_051(self):
 		# Arrange: Create a Journal Entry with type 'Credit Note'
-		jv = make_journal_entry(
-			"_Test Receivable - _TC", 
-			"_Test Bank - _TC", 
-			500, 
-			save=False
-		)
+		jv = make_journal_entry("_Test Receivable - _TC", "_Test Bank - _TC", 500, save=False)
 		jv.voucher_type = "Credit Note"
 
 		# Set Party Type and Party for the receivable account
@@ -425,7 +419,6 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Cleanup: Cancel the Journal Entry
 		jv.cancel()
-
 
 	def test_repost_accounting_entries(self):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
@@ -530,9 +523,10 @@ class TestJournalEntry(unittest.TestCase):
 			if row.account == "_Test Cash - _TC":
 				self.assertEqual(row.debit_in_account_currency, 100)
 				self.assertEqual(row.credit_in_account_currency, 100)
-	
+
 	def test_toggle_debit_credit_if_negative(self):
 		from erpnext.accounts.general_ledger import process_gl_map
+
 		# Create JV with defaut cost center - _Test Cost Center
 		frappe.db.set_single_value("Accounts Settings", "merge_similar_account_heads", 0)
 		jv = frappe.new_doc("Journal Entry")
@@ -588,34 +582,35 @@ class TestJournalEntry(unittest.TestCase):
 			{"account": "_Test Receivable USD - _TC", "transaction_exchange_rate": 85.0},
 		]
 		self.assertEqual(expected, actual)
-	
+
 	def test_select_tds_payable_and_creditors_account_TC_ACC_024(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_records
 
-		create_records('_Test Supplier TDS')
+		create_records("_Test Supplier TDS")
 
 		supplier = frappe.get_doc("Supplier", "_Test Supplier TDS")
 		account = frappe.get_doc("Account", "_Test TDS Payable - _TC")
-		
+
 		if supplier and account:
-			jv=frappe.new_doc("Journal Entry")
+			jv = frappe.new_doc("Journal Entry")
 			jv.posting_date = nowdate()
 			jv.company = "_Test Company"
-			jv.set('accounts',
-				[ 
-     				{
+			jv.set(
+				"accounts",
+				[
+					{
 						"account": account.name,
 						"debit_in_account_currency": 0,
-						"credit_in_account_currency": 1000
+						"credit_in_account_currency": 1000,
 					},
 					{
-						"account": 'Creditors - _TC',
+						"account": "Creditors - _TC",
 						"party_type": "Supplier",
 						"party": supplier.name,
 						"debit_in_account_currency": 1000,
-						"credit_in_account_currency": 0
+						"credit_in_account_currency": 0,
 					},
-     			]
+				],
 			)
 			jv.save()
 			jv.submit()
@@ -630,7 +625,7 @@ class TestJournalEntry(unittest.TestCase):
 
 			self.expected_gle = [
 				{
-					"account": 'Creditors - _TC',
+					"account": "Creditors - _TC",
 					"debit_in_account_currency": 1000,
 					"credit_in_account_currency": 0,
 					"cost_center": "Main - _TC",
@@ -664,7 +659,7 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Fetch round-off GL Entry
 		round_off_entry = frappe.db.sql(
-			"""select debit, credit, account, cost_center 
+			"""select debit, credit, account, cost_center
 			from `tabGL Entry`
 			where voucher_type='Journal Entry' and voucher_no = %s
 			and account='_Test Write Off - _TC' and cost_center='_Test Cost Center - _TC'""",
@@ -680,17 +675,15 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Validate the debit and credit accounts for the main journal entry
 		debit_account = frappe.db.get_value(
-			"GL Entry", 
-			{"voucher_no": jv.name, "voucher_type": "Journal Entry", "debit": 100.01}, 
-			"account"
+			"GL Entry", {"voucher_no": jv.name, "voucher_type": "Journal Entry", "debit": 100.01}, "account"
 		)
 		credit_account = frappe.db.get_value(
-			"GL Entry", 
-			{"voucher_no": jv.name, "voucher_type": "Journal Entry", "credit": 100}, 
-			"account"
+			"GL Entry", {"voucher_no": jv.name, "voucher_type": "Journal Entry", "credit": 100}, "account"
 		)
 
-		self.assertEqual(debit_account, "_Test Account Cost for Goods Sold - _TC", "Debit account is incorrect.")
+		self.assertEqual(
+			debit_account, "_Test Account Cost for Goods Sold - _TC", "Debit account is incorrect."
+		)
 		self.assertEqual(credit_account, "_Test Bank - _TC", "Credit account is incorrect.")
 
 	def test_debit_note_entry_TC_ACC_052(self):
@@ -701,7 +694,6 @@ class TestJournalEntry(unittest.TestCase):
 		account2 = "Cash - _TC"  # Credit Account
 		amount = 1000.0
 
-
 		# Create the Journal Entry for Debit Note
 		jv = make_journal_entry(
 			account1=account1,
@@ -709,7 +701,7 @@ class TestJournalEntry(unittest.TestCase):
 			amount=amount,
 			# cost_center=cost_center,
 			save=False,
-			submit=False
+			submit=False,
 		)
 
 		# Update party details for GL entries
@@ -726,12 +718,12 @@ class TestJournalEntry(unittest.TestCase):
 				FROM `tabGL Entry`
 				WHERE voucher_no = %s AND voucher_type = 'Journal Entry'""",
 			jv.name,
-			as_dict=True
+			as_dict=True,
 		)
 
 		# Assertions
-		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL Entries created.")	
-	
+		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL Entries created.")
+
 	def test_contra_entry_TC_ACC_053(self):
 		# Set up input parameters
 		entry_type = "Contra Entry"
@@ -770,13 +762,14 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
 			self.assertEqual(entry["account"], expected["account"], "Account mismatch in GL Entry.")
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
 
 	def test_payment_of_gst_tds_TC_ACC_054(self):
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import validate_fiscal_year
+
 		# Set up input parameters
 		validate_fiscal_year("_Test Company")
 		create_custom_test_accounts()
@@ -785,14 +778,16 @@ class TestJournalEntry(unittest.TestCase):
 		amount = 20000.0
 		tax_accounts = frappe.get_all(
 			"Account",
-			filters={"company":"_Test Company","account_type": "Tax", "parent_account": ["like", "%Assets%"]},
-			fields=["name"]
+			filters={
+				"company": "_Test Company",
+				"account_type": "Tax",
+				"parent_account": ["like", "%Assets%"],
+			},
+			fields=["name"],
 		)
 
 		# Identify SGST and CGST accounts based on their name
 		debit_account = None
-		debit_account_cgst = None
-
 		for account in tax_accounts:
 			if "IGST" in account["name"]:
 				debit_account = account["name"]
@@ -831,7 +826,7 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
 			self.assertEqual(entry["account"], expected["account"], "Account mismatch in GL Entry.")
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
@@ -867,16 +862,16 @@ class TestJournalEntry(unittest.TestCase):
 			jv.name,
 			as_dict=True,
 		)
-		print("Here we are printing the GL Entries ",gl_entries )
+		print("Here we are printing the GL Entries ", gl_entries)
 		# Expected GL entries
 		expected_gl_entries = [
 			{"account": credit_account, "debit": 0, "credit": amount},
-			{"account": debit_account, "debit": amount, "credit": 0}
+			{"account": debit_account, "debit": amount, "credit": 0},
 		]
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
 			self.assertEqual(entry["account"], expected["account"], "Account mismatch in GL Entry.")
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
@@ -911,16 +906,16 @@ class TestJournalEntry(unittest.TestCase):
 		# Expected GL entries
 		expected_gl_entries = [
 			{"account": debit_account, "debit": amount, "credit": 0},
-			{"account": credit_account, "debit": 0, "credit": amount}
+			{"account": credit_account, "debit": 0, "credit": amount},
 		]
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
 			self.assertEqual(entry["account"], expected["account"], "Account mismatch in GL Entry.")
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
-	
+
 	def test_deferred_revenue_entry_TC_ACC_057(self):
 		# Set up input parameters
 		entry_type = "Deferred Revenue"
@@ -959,12 +954,12 @@ class TestJournalEntry(unittest.TestCase):
 		# Expected GL entries
 		expected_gl_entries = [
 			{"account": credit_account, "debit": 0, "credit": amount},
-			{"account": debit_account, "debit": amount, "credit": 0}
+			{"account": debit_account, "debit": amount, "credit": 0},
 		]
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
 			self.assertEqual(entry["account"], expected["account"], "Account mismatch in GL Entry.")
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
@@ -1003,13 +998,12 @@ class TestJournalEntry(unittest.TestCase):
 		# Expected GL entries
 		expected_gl_entries = [
 			{"account": debit_account, "debit": amount, "credit": 0},
-			{"account": credit_account, "debit": 0, "credit": amount}
-
+			{"account": credit_account, "debit": 0, "credit": amount},
 		]
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
 			self.assertEqual(entry["account"], expected["account"], "Account mismatch in GL Entry.")
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
@@ -1024,8 +1018,12 @@ class TestJournalEntry(unittest.TestCase):
 		# Fetch Tax Accounts dynamically
 		tax_accounts = frappe.get_all(
 			"Account",
-			filters={"company":"_Test Company","account_type": "Tax", "parent_account": ["like", "%Assets%"]},
-			fields=["name"]
+			filters={
+				"company": "_Test Company",
+				"account_type": "Tax",
+				"parent_account": ["like", "%Assets%"],
+			},
+			fields=["name"],
 		)
 		# Identify SGST and CGST accounts based on their name
 		debit_account_sgst = None
@@ -1049,28 +1047,37 @@ class TestJournalEntry(unittest.TestCase):
 		jv.user_remark = "Reversal of ITC Test Case"
 
 		# Add accounts to the Journal Entry
-		jv.append("accounts", {
-			"account": debit_account_sgst,
-			"debit_in_account_currency": amount_sgst,
-			"credit_in_account_currency": 0,
-			"cost_center": "_Test Cost Center - _TC"
-		})
+		jv.append(
+			"accounts",
+			{
+				"account": debit_account_sgst,
+				"debit_in_account_currency": amount_sgst,
+				"credit_in_account_currency": 0,
+				"cost_center": "_Test Cost Center - _TC",
+			},
+		)
 
-		jv.append("accounts", {
-			"account": debit_account_cgst,
-			"debit_in_account_currency": amount_cgst,
-			"credit_in_account_currency": 0,
-			"cost_center": "_Test Cost Center - _TC"
-		})
+		jv.append(
+			"accounts",
+			{
+				"account": debit_account_cgst,
+				"debit_in_account_currency": amount_cgst,
+				"credit_in_account_currency": 0,
+				"cost_center": "_Test Cost Center - _TC",
+			},
+		)
 
-		jv.append("accounts", {
-			"account": credit_account,
-			"debit_in_account_currency": 0,
-			"credit_in_account_currency": amount_sgst + amount_cgst,
-			"cost_center": "_Test Cost Center - _TC",
-			"party_type": "Supplier",
-			"party": "_Test Supplier"
-		})
+		jv.append(
+			"accounts",
+			{
+				"account": credit_account,
+				"debit_in_account_currency": 0,
+				"credit_in_account_currency": amount_sgst + amount_cgst,
+				"cost_center": "_Test Cost Center - _TC",
+				"party_type": "Supplier",
+				"party": "_Test Supplier",
+			},
+		)
 
 		# Save and submit the Journal Entry
 		jv.insert()
@@ -1094,8 +1101,10 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 3, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
-			self.assertEqual(entry["account"], expected["account"], f"Account mismatch in GL Entry: {entry['account']}.")
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
+			self.assertEqual(
+				entry["account"], expected["account"], f"Account mismatch in GL Entry: {entry['account']}."
+			)
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
 
@@ -1111,11 +1120,7 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Create the Journal Entry using the make_journal_entry method
 		jv = make_journal_entry(
-			account1=debit_account,
-			account2=credit_account,
-			amount=amount,
-			save=False,
-			submit=False
+			account1=debit_account, account2=credit_account, amount=amount, save=False, submit=False
 		)
 
 		for account in jv.accounts:
@@ -1145,8 +1150,10 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
-			self.assertEqual(entry["account"], expected["account"], f"Account mismatch in GL Entry: {entry['account']}.")
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
+			self.assertEqual(
+				entry["account"], expected["account"], f"Account mismatch in GL Entry: {entry['account']}."
+			)
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
 
@@ -1162,11 +1169,7 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Create the Journal Entry
 		jv = make_journal_entry(
-			account1=debit_account,
-			account2=credit_account,
-			amount=amount,
-			save=False,
-			submit=False
+			account1=debit_account, account2=credit_account, amount=amount, save=False, submit=False
 		)
 
 		for account in jv.accounts:
@@ -1196,22 +1199,24 @@ class TestJournalEntry(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(len(gl_entries), 2, "Incorrect number of GL entries created.")
-		for entry, expected in zip(gl_entries, expected_gl_entries):
-			self.assertEqual(entry["account"], expected["account"], f"Account mismatch in GL Entry: {entry['account']}.")
+		for entry, expected in zip(gl_entries, expected_gl_entries, strict=True):
+			self.assertEqual(
+				entry["account"], expected["account"], f"Account mismatch in GL Entry: {entry['account']}."
+			)
 			self.assertEqual(entry["debit"], expected["debit"], f"Debit mismatch for {entry['account']}.")
 			self.assertEqual(entry["credit"], expected["credit"], f"Credit mismatch for {entry['account']}.")
-  
+
 	def test_create_jv_for_cash_enrty_TC_ACC_082(self):
-		jv=make_journal_entry(
+		jv = make_journal_entry(
 			account1="Cash - _TC",
 			account2="_Test Payable - _TC",
 			amount=1000.0,
 			exchange_rate=0,
 			save=False,
-			submit=False
+			submit=False,
 		)
 		for account in jv.accounts:
-			if account.account=="_Test Payable - _TC":
+			if account.account == "_Test Payable - _TC":
 				account.party_type = "Supplier"
 				account.party = "_Test Supplier"
 		jv.save().submit()
@@ -1231,7 +1236,7 @@ class TestJournalEntry(unittest.TestCase):
 				"account_currency": "INR",
 				"debit": 1000,
 				"debit_in_account_currency": 1000,
-				"credit": 0 ,
+				"credit": 0,
 				"credit_in_account_currency": 0,
 			},
 			{
@@ -1244,21 +1249,21 @@ class TestJournalEntry(unittest.TestCase):
 			},
 		]
 		self.check_gl_entries()
-  
+
 	def test_create_jv_for_bank_enrty_TC_ACC_083(self):
-		jv=make_journal_entry(
+		jv = make_journal_entry(
 			account1="_Test Bank - _TC",
 			account2="_Test Receivable - _TC",
 			amount=1000.0,
 			exchange_rate=0,
 			save=False,
-			submit=False
+			submit=False,
 		)
-		jv.voucher_type="Bank Entry"
-		jv.cheque_no="112233"
-		jv.cheque_date=nowdate()
+		jv.voucher_type = "Bank Entry"
+		jv.cheque_no = "112233"
+		jv.cheque_date = nowdate()
 		for account in jv.accounts:
-			if account.account=="_Test Receivable - _TC":
+			if account.account == "_Test Receivable - _TC":
 				account.party_type = "Customer"
 				account.party = "_Test Customer"
 		jv.save().submit()
@@ -1278,7 +1283,7 @@ class TestJournalEntry(unittest.TestCase):
 				"account_currency": "INR",
 				"debit": 1000,
 				"debit_in_account_currency": 1000,
-				"credit": 0 ,
+				"credit": 0,
 				"credit_in_account_currency": 0,
 			},
 			{
@@ -1291,45 +1296,53 @@ class TestJournalEntry(unittest.TestCase):
 			},
 		]
 		self.check_gl_entries()
+
 	def test_create_jv_with_jv_template_TC_ACC_084(self):
-		
 		if not frappe.db.exists("Journal Entry Template", "_Test Template"):
 			template = frappe.new_doc("Journal Entry Template")
-			template.template_title="_Test Template"
-			template.company="_Test Company"
-			template.naming_series="ACC-JV-.YYYY.-"
-			template.append("accounts",{
-				"account":"Cash - _TC",
-			})
-			template.insert()
-		template=frappe.get_doc("Journal Entry Template","_Test Template")
-		jv = frappe.get_doc({
-			"doctype": "Journal Entry",
-			"company": "_Test Company",
-			"posting_date": frappe.utils.nowdate(),
-			"from_template": template.name,
-			"accounts": [
+			template.template_title = "_Test Template"
+			template.company = "_Test Company"
+			template.naming_series = "ACC-JV-.YYYY.-"
+			template.append(
+				"accounts",
 				{
-					"account":template.accounts[0].account,
-					"account_currency": "INR",
-					"debit": 10000,
-					"debit_in_account_currency": 10000,
-					"credit": 0,
-					"credit_in_account_currency": 0,
-				}
-			],
-		}).insert()
-		jv.append("accounts", {
-			"account": "_Test Payable - _TC",
-			"account_currency": "INR",
-			"party_type": "Supplier",
-			"party": "_Test Supplier",
-			"debit": 0,
-			"debit_in_account_currency": 0,
-			"credit": 10000,
-			"credit_in_account_currency": 10000,
-		})
-		jv.save().submit()	
+					"account": "Cash - _TC",
+				},
+			)
+			template.insert()
+		template = frappe.get_doc("Journal Entry Template", "_Test Template")
+		jv = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"company": "_Test Company",
+				"posting_date": frappe.utils.nowdate(),
+				"from_template": template.name,
+				"accounts": [
+					{
+						"account": template.accounts[0].account,
+						"account_currency": "INR",
+						"debit": 10000,
+						"debit_in_account_currency": 10000,
+						"credit": 0,
+						"credit_in_account_currency": 0,
+					}
+				],
+			}
+		).insert()
+		jv.append(
+			"accounts",
+			{
+				"account": "_Test Payable - _TC",
+				"account_currency": "INR",
+				"party_type": "Supplier",
+				"party": "_Test Supplier",
+				"debit": 0,
+				"debit_in_account_currency": 0,
+				"credit": 10000,
+				"credit_in_account_currency": 10000,
+			},
+		)
+		jv.save().submit()
 
 		self.voucher_no = jv.name
 		self.fields = [
@@ -1347,7 +1360,7 @@ class TestJournalEntry(unittest.TestCase):
 				"account_currency": "INR",
 				"debit": 10000,
 				"debit_in_account_currency": 10000,
-				"credit": 0 ,
+				"credit": 0,
 				"credit_in_account_currency": 0,
 			},
 			{
@@ -1357,54 +1370,51 @@ class TestJournalEntry(unittest.TestCase):
 				"debit_in_account_currency": 0,
 				"credit": 10000,
 				"credit_in_account_currency": 10000,
-			}
+			},
 		]
 
 		self.check_gl_entries()
-  
+
 	def test_opening_entry_TC_ACC_116(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_records
+
 		create_records("_Test Supplier")
-		jv = frappe.get_doc({
-			"doctype": "Journal Entry",
-			"voucher_type": "Opening Entry",
-			"company": "_Test Company",
-			"posting_date": frappe.utils.nowdate(),
-			"accounts":[
-				{
-					"account":"_Test Payable - _TC",
-					"party_type": "Supplier",
-					"party": "_Test Supplier",
-					"debit_in_account_currency":1000,
-				},
-				{
-					"account": "_Test Creditors - _TC",
-					"credit_in_account_currency":1000,
-					"party_type": "Supplier",
-					"party": "_Test Supplier"
-				},
-				{
-					"account":"Debtors - _TC",
-					"party_type":"Customer",
-					"party": "_Test Customer",
-					"debit_in_account_currency":1000,
-				},
-				{
-					"account":"_Test Receivable - _TC",
-					"party_type":"Customer",
-					"party": "_Test Customer",
-					"credit_in_account_currency":1000,
-				},
-				{
-					"account":"Cash - _TC",
-					"debit_in_account_currency":2000
-				},
-				{
-					"account":"Temporary Opening - _TC",
-					"credit_in_account_currency":2000
-				}
-			]
-		}).insert()
+		jv = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"voucher_type": "Opening Entry",
+				"company": "_Test Company",
+				"posting_date": frappe.utils.nowdate(),
+				"accounts": [
+					{
+						"account": "_Test Payable - _TC",
+						"party_type": "Supplier",
+						"party": "_Test Supplier",
+						"debit_in_account_currency": 1000,
+					},
+					{
+						"account": "_Test Creditors - _TC",
+						"credit_in_account_currency": 1000,
+						"party_type": "Supplier",
+						"party": "_Test Supplier",
+					},
+					{
+						"account": "Debtors - _TC",
+						"party_type": "Customer",
+						"party": "_Test Customer",
+						"debit_in_account_currency": 1000,
+					},
+					{
+						"account": "_Test Receivable - _TC",
+						"party_type": "Customer",
+						"party": "_Test Customer",
+						"credit_in_account_currency": 1000,
+					},
+					{"account": "Cash - _TC", "debit_in_account_currency": 2000},
+					{"account": "Temporary Opening - _TC", "credit_in_account_currency": 2000},
+				],
+			}
+		).insert()
 		jv.submit()
 		self.voucher_no = jv.name
 		self.fields = [
@@ -1417,66 +1427,67 @@ class TestJournalEntry(unittest.TestCase):
 		]
 
 		self.expected_gle = [
-				{
-					'account': 'Cash - _TC',
-					'account_currency': 'INR',
-					'debit': 2000.0,
-					'debit_in_account_currency': 2000.0,
-					'credit': 0.0,
-					'credit_in_account_currency': 0.0
-				},
-				{
-					'account': 'Debtors - _TC',
-					'account_currency': 'INR',
-					'debit': 1000.0,
-					'debit_in_account_currency': 1000.0,
-					'credit': 0.0,
-					'credit_in_account_currency': 0.0
-				},
-				{
-					'account': 'Temporary Opening - _TC',
-					'account_currency': 'INR',
-					'debit': 0.0,
-					'debit_in_account_currency': 0.0,
-					'credit': 2000.0,
-					'credit_in_account_currency': 2000.0
-				},
-				{
-					'account': '_Test Creditors - _TC',
-					'account_currency': 'INR',
-					'debit': 0.0,
-					'debit_in_account_currency': 0.0,
-					'credit': 1000.0,
-					'credit_in_account_currency': 1000.0
-				},
-				{
-					'account': '_Test Payable - _TC',
-					'account_currency': 'INR',
-					'debit': 1000.0,
-					'debit_in_account_currency': 1000.0,
-					'credit': 0.0,
-					'credit_in_account_currency': 0.0
-				},
-				{
-					'account': '_Test Receivable - _TC',
-					'account_currency': 'INR',
-					'debit': 0.0,
-					'debit_in_account_currency': 0.0,
-					'credit': 1000.0,
-					'credit_in_account_currency': 1000.0
-				}
-			]
+			{
+				"account": "Cash - _TC",
+				"account_currency": "INR",
+				"debit": 2000.0,
+				"debit_in_account_currency": 2000.0,
+				"credit": 0.0,
+				"credit_in_account_currency": 0.0,
+			},
+			{
+				"account": "Debtors - _TC",
+				"account_currency": "INR",
+				"debit": 1000.0,
+				"debit_in_account_currency": 1000.0,
+				"credit": 0.0,
+				"credit_in_account_currency": 0.0,
+			},
+			{
+				"account": "Temporary Opening - _TC",
+				"account_currency": "INR",
+				"debit": 0.0,
+				"debit_in_account_currency": 0.0,
+				"credit": 2000.0,
+				"credit_in_account_currency": 2000.0,
+			},
+			{
+				"account": "_Test Creditors - _TC",
+				"account_currency": "INR",
+				"debit": 0.0,
+				"debit_in_account_currency": 0.0,
+				"credit": 1000.0,
+				"credit_in_account_currency": 1000.0,
+			},
+			{
+				"account": "_Test Payable - _TC",
+				"account_currency": "INR",
+				"debit": 1000.0,
+				"debit_in_account_currency": 1000.0,
+				"credit": 0.0,
+				"credit_in_account_currency": 0.0,
+			},
+			{
+				"account": "_Test Receivable - _TC",
+				"account_currency": "INR",
+				"debit": 0.0,
+				"debit_in_account_currency": 0.0,
+				"credit": 1000.0,
+				"credit_in_account_currency": 1000.0,
+			},
+		]
 
 		self.check_gl_entries()
-  
+
 	def test_reverse_journal_entry_TC_ACC_107(self):
 		from erpnext.accounts.doctype.journal_entry.journal_entry import make_reverse_journal_entry
+
 		jv = make_journal_entry(
 			account1="Cost of Goods Sold - _TC",
 			account2="Cash - _TC",
 			amount=10000.0,
 			save=False,
-			submit=False
+			submit=False,
 		)
 		jv.voucher_type = "Journal Entry"
 		jv.save().submit()
@@ -1491,25 +1502,25 @@ class TestJournalEntry(unittest.TestCase):
 		]
 		self.expected_gle = [
 			{
-				'account': 'Cash - _TC',
-				'account_currency': 'INR',
-				'debit': 0.0,
-				'debit_in_account_currency': 0.0,
-				'credit': 10000.0,
-				'credit_in_account_currency': 10000.0
+				"account": "Cash - _TC",
+				"account_currency": "INR",
+				"debit": 0.0,
+				"debit_in_account_currency": 0.0,
+				"credit": 10000.0,
+				"credit_in_account_currency": 10000.0,
 			},
 			{
-				'account': 'Cost of Goods Sold - _TC',
-				'account_currency': 'INR',
-				'debit': 10000.0,
-				'debit_in_account_currency': 10000.0,
-				'credit': 0.0,
-				'credit_in_account_currency': 0.0
-			}
+				"account": "Cost of Goods Sold - _TC",
+				"account_currency": "INR",
+				"debit": 10000.0,
+				"debit_in_account_currency": 10000.0,
+				"credit": 0.0,
+				"credit_in_account_currency": 0.0,
+			},
 		]
 
 		self.check_gl_entries()
-		
+
 		_jv = make_reverse_journal_entry(jv.name)
 		_jv.posting_date = nowdate()
 		_jv.save().submit()
@@ -1522,56 +1533,62 @@ class TestJournalEntry(unittest.TestCase):
 			"credit",
 			"credit_in_account_currency",
 		]
-		self.expected_gle=[
+		self.expected_gle = [
 			{
-				'account': 'Cash - _TC',
-				'account_currency': 'INR',
-				'debit': 10000.0,
-				'debit_in_account_currency': 10000.0,
-				'credit': 0.0,
-				'credit_in_account_currency': 0.0
+				"account": "Cash - _TC",
+				"account_currency": "INR",
+				"debit": 10000.0,
+				"debit_in_account_currency": 10000.0,
+				"credit": 0.0,
+				"credit_in_account_currency": 0.0,
 			},
 			{
-				'account': 'Cost of Goods Sold - _TC',
-				'account_currency': 'INR',
-				'debit': 0.0,
-				'debit_in_account_currency': 0.0,
-				'credit': 10000.0,
-				'credit_in_account_currency': 10000.0
-			}
+				"account": "Cost of Goods Sold - _TC",
+				"account_currency": "INR",
+				"debit": 0.0,
+				"debit_in_account_currency": 0.0,
+				"credit": 10000.0,
+				"credit_in_account_currency": 10000.0,
+			},
 		]
 
 		self.check_gl_entries()
-  
+
 	def test_make_differnce_function_TC_ACC_108(self):
-     
-		jv = frappe.get_doc({
-			"doctype": "Journal Entry",
-			"company": "_Test Company",
-			"posting_date": nowdate(),
-			"accounts": [
-				{
-					"account":"Cash - _TC",
-					"cost_center":"Main - _TC",
-					"debit_in_account_currency":1000,
-					"credit_in_account_currency":0
-				},
-			]
-		}).insert()
+		jv = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"company": "_Test Company",
+				"posting_date": nowdate(),
+				"accounts": [
+					{
+						"account": "Cash - _TC",
+						"cost_center": "Main - _TC",
+						"debit_in_account_currency": 1000,
+						"credit_in_account_currency": 0,
+					},
+				],
+			}
+		).insert()
 		jv.get_balance()
-		jv.accounts[1].account="Cost of Goods Sold - _TC"
-		jv.accounts[1].cost_center="Main - _TC"
+		jv.accounts[1].account = "Cost of Goods Sold - _TC"
+		jv.accounts[1].cost_center = "Main - _TC"
 		jv.save()
 		self.assertEqual(jv.accounts[0].debit_in_account_currency, jv.accounts[1].credit_in_account_currency)
- 
+
 	def test_apply_tax_withholding_TC_ACC_543(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-		create_company(company_name = "_Test Company")
+
+		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
-		withholding_account = get_or_create_account("TDS Payable", company, f"Current Liabilities - {abbr}", "Tax", "Liability")
-		creditor_account = get_or_create_account("Creditors", company, f"Current Liabilities - {abbr}", "Payable", "Liability")
+		withholding_account = get_or_create_account(
+			"TDS Payable", company, f"Current Liabilities - {abbr}", "Tax", "Liability"
+		)
+		creditor_account = get_or_create_account(
+			"Creditors", company, f"Current Liabilities - {abbr}", "Payable", "Liability"
+		)
 		bank_account = get_or_create_account("Bank", company, f"Current Assets - {abbr}", "Bank", "Asset")
 		get_or_create_supplier("_Test Supplier")
 		get_or_create_tds_category("_Test TDS Category", company, withholding_account)
@@ -1591,24 +1608,41 @@ class TestJournalEntry(unittest.TestCase):
 
 	def test_get_outstanding_invoices_TC_ACC_544(self):
 		from frappe import _dict
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice, create_company
 
-		create_company(company_name = "_Test Company")
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company,
+			create_sales_invoice,
+		)
+
+		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 		customer = get_or_create_customer("_Test Customer JE")
 
-		si = create_sales_invoice(company=company, customer=customer, debit_to=f"Debtors - {abbr}", item="_Test Item", qty=1, rate=100.0)
+		si = create_sales_invoice(
+			company=company,
+			customer=customer,
+			debit_to=f"Debtors - {abbr}",
+			item="_Test Item",
+			qty=1,
+			rate=100.0,
+		)
 
-		je = make_journal_entry(account1=f"Debtors - {abbr}", account2=f"Creditors - {abbr}", amount=0, save=False)
+		je = make_journal_entry(
+			account1=f"Debtors - {abbr}", account2=f"Creditors - {abbr}", amount=0, save=False
+		)
 		je.voucher_type = "Credit Note"
 		je.write_off_based_on = "Accounts Receivable"
-		je.get_values = lambda: [_dict({
-			"name": si.name,
-			"account": si.debit_to,
-			"party": si.customer,
-			"outstanding_amount": si.outstanding_amount
-		})]
+		je.get_values = lambda: [
+			_dict(
+				{
+					"name": si.name,
+					"account": si.debit_to,
+					"party": si.customer,
+					"outstanding_amount": si.outstanding_amount,
+				}
+			)
+		]
 
 		je.get_outstanding_invoices()
 		self.assertEqual(len(je.accounts), 2)
@@ -1624,14 +1658,23 @@ class TestJournalEntry(unittest.TestCase):
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_average_exchange_rate
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
 
-		create_company(company_name = "_Test Company")
+		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		bank_account = get_or_create_account("Bank", company, f"Current Assets - {abbr}", "Bank", "Asset")
-		expense_account = get_or_create_account("Round Off", company, f"Expenses - {abbr}", "Expense Account", "Expense")
+		expense_account = get_or_create_account(
+			"Round Off", company, f"Expenses - {abbr}", "Expense Account", "Expense"
+		)
 
-		je = make_journal_entry(account1=bank_account, account2=expense_account, amount=200.0, exchange_rate=2.0, save=False, submit=False)
+		je = make_journal_entry(
+			account1=bank_account,
+			account2=expense_account,
+			amount=200.0,
+			exchange_rate=2.0,
+			save=False,
+			submit=False,
+		)
 		je.accounts[0].exchange_rate = 2.0
 		je.accounts[0].debit_in_account_currency = 200.0
 		je.accounts[0].debit = 400.0
@@ -1647,9 +1690,9 @@ class TestJournalEntry(unittest.TestCase):
 		from erpnext.accounts.doctype.journal_entry.journal_entry import make_inter_company_journal_entry
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
 
-		create_company(company_name = "_Test Company")
+		create_company(company_name="_Test Company")
 		company1 = "_Test Company"
-		create_company(company_name = "_Test Company")
+		create_company(company_name="_Test Company")
 		company2 = "_Test Company with perpetual inventory"
 		abbr1 = frappe.get_cached_value("Company", company1, "abbr")
 		abbr2 = frappe.get_cached_value("Company", company2, "abbr")
@@ -1674,20 +1717,22 @@ class TestJournalEntry(unittest.TestCase):
 			je2.validate_inter_company_accounts()
 
 	def test_validate_orders_TC_ACC_547(self):
-		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
-		create_company(company_name = "_Test Company")
+		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		def setup_je(ref_so, total):
-			je = frappe.get_doc({
-				"doctype": "Journal Entry",
-				"company": company,
-				"voucher_type": "Journal Entry",
-				"posting_date": nowdate(),
-			})
+			je = frappe.get_doc(
+				{
+					"doctype": "Journal Entry",
+					"company": company,
+					"voucher_type": "Journal Entry",
+					"posting_date": nowdate(),
+				}
+			)
 			je.reference_totals = {ref_so.name: total}
 			je.reference_types = {ref_so.name: "Sales Order"}
 			je.reference_accounts = {ref_so.name: f"Debtors - {abbr}"}
@@ -1709,11 +1754,14 @@ class TestJournalEntry(unittest.TestCase):
 
 	def test_validate_inter_company_accounts_TC_ACC_548(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-		create_company(company_name = "_Test Company")
+
+		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 		account1 = get_or_create_account("Bank", company, f"Current Assets - {abbr}", "Bank", "Asset")
-		account2 = get_or_create_account("Round Off", company, f"Expenses - {abbr}", "Expense Account", "Expense")
+		account2 = get_or_create_account(
+			"Round Off", company, f"Expenses - {abbr}", "Expense Account", "Expense"
+		)
 
 		je1 = make_journal_entry(account1=account1, account2=account2, amount=500, save=True, submit=True)
 		je2 = make_journal_entry(account1=account1, account2=account2, amount=300, save=False, submit=False)
@@ -1725,43 +1773,58 @@ class TestJournalEntry(unittest.TestCase):
 
 	def test_update_invoice_discounting_else_branch_TC_ACC_551(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-		create_company(company_name = "_Test Company")
+
+		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
-		short_term_loan_acc = get_or_create_account("Short Term Loan", company, f"Current Liabilities - {abbr}", "Bank", "Liability")
+		short_term_loan_acc = get_or_create_account(
+			"Short Term Loan", company, f"Current Liabilities - {abbr}", "Bank", "Liability"
+		)
 		bank_acc = get_or_create_account("Bank", company, f"Current Assets - {abbr}", "Bank", "Asset")
-		bank_charges_acc = get_or_create_account("Bank Charges", company, f"Indirect Expenses - {abbr}", "Expense Account", "Expense")
+		bank_charges_acc = get_or_create_account(
+			"Bank Charges", company, f"Indirect Expenses - {abbr}", "Expense Account", "Expense"
+		)
 
-		inv_disc = frappe.get_doc({
-			"doctype": "Invoice Discounting",
-			"customer": "_Test Customer",
-			"company": company,
-			"posting_date": frappe.utils.nowdate(),
-			"status": "Disbursed",
-			"invoice_discounting_amount": 1000,
-			"short_term_loan": short_term_loan_acc,
-			"bank_account": bank_acc,
-			"bank_charges_account": bank_charges_acc,
-			"accounts_receivable_credit": f"Debtors - {abbr}",
-			"accounts_receivable_discounted": f"Debtors - {abbr}",
-			"accounts_receivable_unpaid": f"Debtors - {abbr}",
-			"invoices": [{
-				"sales_invoice": frappe.get_all("Sales Invoice", filters={"company": company}, pluck="name", limit=1)[0]
-				if frappe.db.exists("Sales Invoice", {"company": company})
-				else None,
-				"amount": 1000
-			}]
-		}).insert(ignore_permissions=True)
+		inv_disc = frappe.get_doc(
+			{
+				"doctype": "Invoice Discounting",
+				"customer": "_Test Customer",
+				"company": company,
+				"posting_date": frappe.utils.nowdate(),
+				"status": "Disbursed",
+				"invoice_discounting_amount": 1000,
+				"short_term_loan": short_term_loan_acc,
+				"bank_account": bank_acc,
+				"bank_charges_account": bank_charges_acc,
+				"accounts_receivable_credit": f"Debtors - {abbr}",
+				"accounts_receivable_discounted": f"Debtors - {abbr}",
+				"accounts_receivable_unpaid": f"Debtors - {abbr}",
+				"invoices": [
+					{
+						"sales_invoice": frappe.get_all(
+							"Sales Invoice", filters={"company": company}, pluck="name", limit=1
+						)[0]
+						if frappe.db.exists("Sales Invoice", {"company": company})
+						else None,
+						"amount": 1000,
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
 
-		je1 = make_journal_entry(account1=inv_disc.short_term_loan, account2=bank_acc, amount=1000, save=True, submit=False)
+		je1 = make_journal_entry(
+			account1=inv_disc.short_term_loan, account2=bank_acc, amount=1000, save=True, submit=False
+		)
 		je1.accounts[0].reference_type = "Invoice Discounting"
 		je1.accounts[0].reference_name = inv_disc.name
 		je1.save()
 		with self.assertRaises(frappe.ValidationError):
 			je1.update_invoice_discounting()
 
-		je2 = make_journal_entry(account1=bank_acc, account2=inv_disc.short_term_loan, amount=1000, save=True, submit=False)
+		je2 = make_journal_entry(
+			account1=bank_acc, account2=inv_disc.short_term_loan, amount=1000, save=True, submit=False
+		)
 		je2.accounts[1].reference_type = "Invoice Discounting"
 		je2.accounts[1].reference_name = inv_disc.name
 		je2.save()
@@ -1772,78 +1835,16 @@ class TestJournalEntry(unittest.TestCase):
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
 
-		create_company(company_name = "_Test Company")
+		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		supplier_name = get_or_create_supplier("_Test Supplier Payable")
 		warehouse_name = get_or_create_warehouse("_Test Warehouse 1 - _TC", company)
 		bank_account_name = get_or_create_account("Bank", company, f"Cash and Bank - {abbr}", "Bank", "Asset")
-		expense_account_name = get_or_create_account("Cost of Goods Sold", company, f"Direct Expenses - {abbr}", "Expense Account", "Expense")
-
-		pi = make_purchase_invoice(company=company, supplier=supplier_name, rate=100, qty=1,
-								warehouse=warehouse_name, uom="Nos", expense_account=expense_account_name,
-								do_not_submit=False)
-
-		je = make_journal_entry(account1=pi.credit_to, account2=bank_account_name, amount=pi.grand_total, save=False)
-		je.company = company
-		je.voucher_type = "Write Off Entry"
-		je.write_off_based_on = "Accounts Payable"
-
-		je.get_values = lambda: [frappe._dict({
-			"outstanding_amount": pi.outstanding_amount,
-			"account": pi.credit_to,
-			"party": pi.supplier,
-			"name": pi.name,
-		})]
-
-		je.get_outstanding_invoices()
-		jd1, jd2 = je.accounts[0], je.accounts[1]
-
-		self.assertEqual(jd1.party_type, "Supplier")
-		self.assertEqual(jd1.reference_type, "Purchase Invoice")
-		self.assertEqual(jd1.reference_name, pi.name)
-		self.assertEqual(jd1.debit_in_account_currency, pi.outstanding_amount)
-		self.assertEqual(jd2.credit_in_account_currency, pi.outstanding_amount)
-  
-	def test_validate_cheque_info_errors_TC_ACC_553(self):
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-
-		create_company(company_name = "_Test Company")
-		company = "_Test Company"
-		abbr = frappe.get_cached_value("Company", company, "abbr")
-
-		bank_account = get_or_create_account("Bank", company, f"Current Assets - {abbr}", "Bank", "Asset")
-		expense_account = get_or_create_account("Round Off", company, f"Expenses - {abbr}", "Expense Account", "Expense")
-
-		je1 = make_journal_entry(account1=bank_account, account2=expense_account, amount=200.0, exchange_rate=2.0, save=False, submit=False)
-		je1.company = company
-		je1.voucher_type = "Bank Entry"
-		je1.insert()
-  
-		with self.assertRaises(frappe.ValidationError):
-			je1.validate_cheque_info()
-
-		je2 = make_journal_entry(account1=bank_account, account2=expense_account, amount=200.0, exchange_rate=2.0, save=False, submit=False)
-		je2.company = company
-		je2.cheque_date = nowdate()
-		je2.insert()
-  
-		with self.assertRaises(frappe.ValidationError):
-			je2.validate_cheque_info()
-   
-	def test_get_values_TC_ACC_554(self):
-		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-
-		create_company(company_name="_Test Company")
-		company = "_Test Company"
-		abbr = frappe.get_cached_value("Company", company, "abbr")
-
-		supplier_name = get_or_create_supplier("_Test Supplier Values")
-		customer_name = get_or_create_customer("_Test Customer Values")
-		warehouse_name = get_or_create_warehouse("_Test Warehouse Values - _TC", company)
-		expense_account_name = get_or_create_account("Cost of Goods Sold", company, f"Direct Expenses - {abbr}", "Expense Account", "Expense")
+		expense_account_name = get_or_create_account(
+			"Cost of Goods Sold", company, f"Direct Expenses - {abbr}", "Expense Account", "Expense"
+		)
 
 		pi = make_purchase_invoice(
 			company=company,
@@ -1856,23 +1857,118 @@ class TestJournalEntry(unittest.TestCase):
 			do_not_submit=False,
 		)
 
-		si = frappe.get_doc({
-			"doctype": "Sales Invoice",
-			"customer": customer_name,
-			"company": company,
-			"due_date": nowdate(),
-			"debit_to": f"Debtors - {abbr}",
-			"currency": "INR",
-			"items": [{
-				"item_code": "_Test Item",
-				"qty": 1,
-				"rate": 100
-			}]
-		})
+		je = make_journal_entry(
+			account1=pi.credit_to, account2=bank_account_name, amount=pi.grand_total, save=False
+		)
+		je.company = company
+		je.voucher_type = "Write Off Entry"
+		je.write_off_based_on = "Accounts Payable"
+
+		je.get_values = lambda: [
+			frappe._dict(
+				{
+					"outstanding_amount": pi.outstanding_amount,
+					"account": pi.credit_to,
+					"party": pi.supplier,
+					"name": pi.name,
+				}
+			)
+		]
+
+		je.get_outstanding_invoices()
+		jd1, jd2 = je.accounts[0], je.accounts[1]
+
+		self.assertEqual(jd1.party_type, "Supplier")
+		self.assertEqual(jd1.reference_type, "Purchase Invoice")
+		self.assertEqual(jd1.reference_name, pi.name)
+		self.assertEqual(jd1.debit_in_account_currency, pi.outstanding_amount)
+		self.assertEqual(jd2.credit_in_account_currency, pi.outstanding_amount)
+
+	def test_validate_cheque_info_errors_TC_ACC_553(self):
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+
+		create_company(company_name="_Test Company")
+		company = "_Test Company"
+		abbr = frappe.get_cached_value("Company", company, "abbr")
+
+		bank_account = get_or_create_account("Bank", company, f"Current Assets - {abbr}", "Bank", "Asset")
+		expense_account = get_or_create_account(
+			"Round Off", company, f"Expenses - {abbr}", "Expense Account", "Expense"
+		)
+
+		je1 = make_journal_entry(
+			account1=bank_account,
+			account2=expense_account,
+			amount=200.0,
+			exchange_rate=2.0,
+			save=False,
+			submit=False,
+		)
+		je1.company = company
+		je1.voucher_type = "Bank Entry"
+		je1.insert()
+
+		with self.assertRaises(frappe.ValidationError):
+			je1.validate_cheque_info()
+
+		je2 = make_journal_entry(
+			account1=bank_account,
+			account2=expense_account,
+			amount=200.0,
+			exchange_rate=2.0,
+			save=False,
+			submit=False,
+		)
+		je2.company = company
+		je2.cheque_date = nowdate()
+		je2.insert()
+
+		with self.assertRaises(frappe.ValidationError):
+			je2.validate_cheque_info()
+
+	def test_get_values_TC_ACC_554(self):
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+
+		create_company(company_name="_Test Company")
+		company = "_Test Company"
+		abbr = frappe.get_cached_value("Company", company, "abbr")
+
+		supplier_name = get_or_create_supplier("_Test Supplier Values")
+		customer_name = get_or_create_customer("_Test Customer Values")
+		warehouse_name = get_or_create_warehouse("_Test Warehouse Values - _TC", company)
+		expense_account_name = get_or_create_account(
+			"Cost of Goods Sold", company, f"Direct Expenses - {abbr}", "Expense Account", "Expense"
+		)
+
+		pi = make_purchase_invoice(
+			company=company,
+			supplier=supplier_name,
+			rate=100,
+			qty=1,
+			warehouse=warehouse_name,
+			uom="Nos",
+			expense_account=expense_account_name,
+			do_not_submit=False,
+		)
+
+		si = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": customer_name,
+				"company": company,
+				"due_date": nowdate(),
+				"debit_to": f"Debtors - {abbr}",
+				"currency": "INR",
+				"items": [{"item_code": "_Test Item", "qty": 1, "rate": 100}],
+			}
+		)
 		si.insert(ignore_permissions=True)
 		si.submit()
 
-		je1 = make_journal_entry(account1=pi.credit_to, account2=f"Cash - {abbr}", amount=pi.grand_total, save=False)
+		je1 = make_journal_entry(
+			account1=pi.credit_to, account2=f"Cash - {abbr}", amount=pi.grand_total, save=False
+		)
 		je1.company = company
 		je1.voucher_type = "Write Off Entry"
 		je1.write_off_based_on = "Accounts Payable"
@@ -1881,7 +1977,9 @@ class TestJournalEntry(unittest.TestCase):
 		values1 = je1.get_values()
 		self.assertTrue(any(v["party"] == pi.supplier for v in values1))
 
-		je2 = make_journal_entry(account1=si.debit_to, account2=f"Cash - {abbr}", amount=si.grand_total, save=False)
+		je2 = make_journal_entry(
+			account1=si.debit_to, account2=f"Cash - {abbr}", amount=si.grand_total, save=False
+		)
 		je2.company = company
 		je2.voucher_type = "Write Off Entry"
 		je2.write_off_based_on = "Accounts Receivable"
@@ -1889,24 +1987,33 @@ class TestJournalEntry(unittest.TestCase):
 
 		values2 = je2.get_values()
 		self.assertTrue(any(v["party"] == si.customer for v in values2))
-  
+
 	def test_validate_credit_debit_note_TC_ACC_555(self):
-		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
 		from erpnext.stock.doctype.item.test_item import create_item
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
 		create_company(company_name="_Test Company")
 		company = "_Test Company"
-		item = create_item(item_code = "_Test Item SE")
+		item = create_item(item_code="_Test Item SE")
 		item.is_stock_item = 1
 		item.save()
 		get_or_create_supplier("_Test Supplier")
 		get_or_create_customer("_Test Customer")
 
-		se1 = make_stock_entry(item_code=item.name, target="_Test Warehouse - _TC", qty=1, basic_rate=100, company=company,do_not_submit=True)
+		se1 = make_stock_entry(
+			item_code=item.name,
+			target="_Test Warehouse - _TC",
+			qty=1,
+			basic_rate=100,
+			company=company,
+			do_not_submit=True,
+		)
 		se1.save()
 
-		je1 = make_journal_entry(account1=f"Debtors - _TC", account2=f"Creditors - _TC", amount=100, save=False, submit=False)
+		je1 = make_journal_entry(
+			account1="Debtors - _TC", account2="Creditors - _TC", amount=100, save=False, submit=False
+		)
 		je1.company = company
 		je1.voucher_type = "Credit Note"
 		je1.stock_entry = se1.name
@@ -1914,10 +2021,19 @@ class TestJournalEntry(unittest.TestCase):
 		with self.assertRaises(frappe.ValidationError):
 			je1.validate_credit_debit_note()
 
-		se2 = make_stock_entry(item_code=item.name, target="_Test Warehouse - _TC", qty=1, basic_rate=100, company=company, do_not_submit=False,)
+		se2 = make_stock_entry(
+			item_code=item.name,
+			target="_Test Warehouse - _TC",
+			qty=1,
+			basic_rate=100,
+			company=company,
+			do_not_submit=False,
+		)
 		se2.submit()
-  
-		je2a = make_journal_entry(account1=f"Debtors - _TC", account2=f"Creditors - _TC", amount=100, save=False)
+
+		je2a = make_journal_entry(
+			account1="Debtors - _TC", account2="Creditors - _TC", amount=100, save=False
+		)
 		je2a.company = company
 		je2a.voucher_type = "Credit Note"
 		je2a.stock_entry = se2.name
@@ -1928,24 +2044,36 @@ class TestJournalEntry(unittest.TestCase):
 		je2a.save()
 		je2a.submit()
 
-		je2b = make_journal_entry(account1=f"Debtors - _TC", account2=f"Creditors - _TC", amount=50, save=False, submit=False)
+		je2b = make_journal_entry(
+			account1="Debtors - _TC", account2="Creditors - _TC", amount=50, save=False, submit=False
+		)
 		je2b.company = company
 		je2b.voucher_type = "Debit Note"
 		je2b.stock_entry = se2.name
-  
+
 		je2b.validate_credit_debit_note()
-  
+
 	def test_get_outstanding_sales_and_purchase_TC_ACC_556(self):
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice, create_company
-		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_outstanding
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company,
+			create_sales_invoice,
+		)
 
 		create_company(company_name="_Test Company")
 		company = "_Test Company"
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		customer = get_or_create_customer("_Test Customer OUT")
-		si = create_sales_invoice(company=company, customer=customer, debit_to=f"Debtors - {abbr}", item="_Test Item", qty=1, rate=150.0,)
+		si = create_sales_invoice(
+			company=company,
+			customer=customer,
+			debit_to=f"Debtors - {abbr}",
+			item="_Test Item",
+			qty=1,
+			rate=150.0,
+		)
 		args = {
 			"doctype": "Sales Invoice",
 			"docname": si.name,
@@ -1961,9 +2089,16 @@ class TestJournalEntry(unittest.TestCase):
 		self.assertEqual(result["party"], si.customer)
 
 		supplier = get_or_create_supplier("_Test Supplier OUT")
-		pi = make_purchase_invoice(company=company, supplier=supplier, rate=200, qty=1,
-			warehouse=get_or_create_warehouse("_Test Warehouse OUT - _TC", company), uom="Nos",
-			expense_account=get_or_create_account("COGS OUT", company, f"Direct Expenses - {abbr}", "Expense Account", "Expense"),
+		pi = make_purchase_invoice(
+			company=company,
+			supplier=supplier,
+			rate=200,
+			qty=1,
+			warehouse=get_or_create_warehouse("_Test Warehouse OUT - _TC", company),
+			uom="Nos",
+			expense_account=get_or_create_account(
+				"COGS OUT", company, f"Direct Expenses - {abbr}", "Expense Account", "Expense"
+			),
 			do_not_submit=False,
 		)
 		args = {
@@ -1990,23 +2125,21 @@ class TestJournalEntry(unittest.TestCase):
 		customer = get_or_create_customer("_Test Customer JE")
 		supplier = get_or_create_supplier("_Test Supplier JE")
 
-		receivable_account = get_or_create_account("Debtors - TC1", company, f"Accounts Receivable - _TC", "Receivable", "Asset")
-		payable_account = get_or_create_account("Creditors - TC1", company, f"Accounts Payable - _TC", "Payable", "Liability")
+		receivable_account = get_or_create_account(
+			"Debtors - TC1", company, "Accounts Receivable - _TC", "Receivable", "Asset"
+		)
+		payable_account = get_or_create_account(
+			"Creditors - TC1", company, "Accounts Payable - _TC", "Payable", "Liability"
+		)
 
 		customer_doc = frappe.get_doc("Customer", customer)
 		if not any(d.company == company for d in customer_doc.get("accounts")):
-			customer_doc.append("accounts", {
-				"company": company,
-				"account": receivable_account
-			})
+			customer_doc.append("accounts", {"company": company, "account": receivable_account})
 			customer_doc.save()
 
 		supplier_doc = frappe.get_doc("Supplier", supplier)
 		if not any(d.company == company for d in supplier_doc.get("accounts")):
-			supplier_doc.append("accounts", {
-				"company": company,
-				"account": payable_account
-			})
+			supplier_doc.append("accounts", {"company": company, "account": payable_account})
 			supplier_doc.save()
 
 		result = get_party_account_and_currency(company, "Customer", customer)
@@ -2016,7 +2149,7 @@ class TestJournalEntry(unittest.TestCase):
 		result = get_party_account_and_currency(company, "Supplier", supplier)
 		self.assertEqual(result["account"], payable_account)
 		self.assertIsNotNone(result["account_currency"])
-  
+
 	def test_get_payment_entry_against_order_TC_ACC_558(self):
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_payment_entry_against_order
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
@@ -2030,7 +2163,7 @@ class TestJournalEntry(unittest.TestCase):
 		receivable_account = get_or_create_account(
 			"Debtors - PE1", company, f"Accounts Receivable - {abbr}", "Receivable", "Asset"
 		)
-  
+
 		cust_doc = frappe.get_doc("Customer", customer)
 		if not any(d.company == company for d in cust_doc.get("accounts")):
 			cust_doc.append("accounts", {"company": company, "account": receivable_account})
@@ -2042,49 +2175,55 @@ class TestJournalEntry(unittest.TestCase):
 		so.save()
 
 		pe_doc = get_payment_entry_against_order("Sales Order", so.name)
-  
+
 		accounts = pe_doc.accounts
 		self.assertTrue(any(d.party == customer and d.party_type == "Customer" for d in accounts))
 		self.assertTrue(any("Debtors" in d.account for d in accounts))
-		self.assertTrue(any(d.debit_in_account_currency > 0 or d.credit_in_account_currency > 0 for d in accounts))
-		
+		self.assertTrue(
+			any(d.debit_in_account_currency > 0 or d.credit_in_account_currency > 0 for d in accounts)
+		)
+
 		self.assertEqual(pe_doc.accounts[0].is_advance, "Yes")
-  
+
 	def test_validate_party_exceptions_TC_ACC_559(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+
 		company = "_Test Company"
 		create_company(company_name=company)
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		if not frappe.db.exists("Account", f"Accounts Receivable - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Accounts Receivable",
-				"parent_account": f"Debtors - {abbr}",
-				"company": company,
-				"is_group": 1,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Accounts Receivable",
+					"parent_account": f"Debtors - {abbr}",
+					"company": company,
+					"is_group": 1,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
 		if not frappe.db.exists("Account", f"Cash and Bank - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Cash and Bank",
-				"parent_account": f"Application of Funds (Assets) - {abbr}",
-				"company": company,
-				"is_group": 1,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Cash and Bank",
+					"parent_account": f"Application of Funds (Assets) - {abbr}",
+					"company": company,
+					"is_group": 1,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
-		receivable_account = get_or_create_account("Debtors - VP1", company, f"Accounts Receivable - {abbr}", "Receivable", "Asset")
-		bank_account = get_or_create_account("Bank - VP1", company, f"Cash and Bank - {abbr}", "Bank", "Asset")
-
-		je1 = make_journal_entry(
-			account1=receivable_account,
-			account2=bank_account,
-			amount=100,
-			save=False
+		receivable_account = get_or_create_account(
+			"Debtors - VP1", company, f"Accounts Receivable - {abbr}", "Receivable", "Asset"
 		)
+		bank_account = get_or_create_account(
+			"Bank - VP1", company, f"Cash and Bank - {abbr}", "Bank", "Asset"
+		)
+
+		je1 = make_journal_entry(account1=receivable_account, account2=bank_account, amount=100, save=False)
 		for d in je1.accounts:
 			d.party_type = None
 			d.party = None
@@ -2095,135 +2234,160 @@ class TestJournalEntry(unittest.TestCase):
 
 		supplier = get_or_create_supplier("_Test Supplier VP")
 
-		je2 = make_journal_entry(
-			account1=receivable_account,
-			account2=bank_account,
-			amount=200,
-			save=False
-		)
+		je2 = make_journal_entry(account1=receivable_account, account2=bank_account, amount=200, save=False)
 		je2.accounts[0].party_type = "Supplier"
 		je2.accounts[0].party = supplier
 
 		with self.assertRaises(frappe.ValidationError) as cm2:
 			je2.validate_party()
 		self.assertIn("have different account types", str(cm2.exception))
-  
+
 	def test_validate_entries_for_advance_exceptions_TC_ACC_560(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+
 		company = "_Test Company"
 		create_company(company_name=company)
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
-		if not frappe.db.exists("Account", f"Accounts Receivable - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Accounts Receivable",
-				"parent_account": f"Debtors - {abbr}",
-				"company": company,
-				"is_group": 1,  
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
-		else:
-			frappe.db.set_value("Account", f"Accounts Receivable - {abbr}", "is_group", 1)
+		ar_account = f"Accounts Receivable - {abbr}"
+		cr_account = f"Creditors - {abbr}"
 
-		if not frappe.db.exists("Account", f"Creditors - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Creditors",
-				"parent_account": f"Current Liabilities - {abbr}",
-				"company": company,
-				"is_group": 1,  
-				"root_type": "Liability",
-			}).insert(ignore_permissions=True)
-		else:
-			frappe.db.set_value("Account", f"Creditors - {abbr}", "is_group", 1)
-
-		receivable_account = get_or_create_account(
-			"Debtors - ADV",
-			company,
-			f"Accounts Receivable - {abbr}",
-			"Receivable",
-			"Asset"
+		# Backup current state so we can restore later
+		ar_was_group = (
+			frappe.db.get_value("Account", ar_account, "is_group")
+			if frappe.db.exists("Account", ar_account)
+			else None
+		)
+		cr_was_group = (
+			frappe.db.get_value("Account", cr_account, "is_group")
+			if frappe.db.exists("Account", cr_account)
+			else None
 		)
 
-		payable_account = get_or_create_account(
-			"Creditors - ADV",
-			company,
-			f"Creditors - {abbr}",
-			"Payable",
-			"Liability"
-		)
+		try:
+			if not frappe.db.exists("Account", ar_account):
+				frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": "Accounts Receivable",
+						"parent_account": f"Debtors - {abbr}",
+						"company": company,
+						"is_group": 1,
+						"root_type": "Asset",
+					}
+				).insert(ignore_permissions=True)
+			else:
+				frappe.db.set_value("Account", ar_account, "is_group", 1)
 
-		je1 = make_journal_entry(account1=receivable_account, account2=payable_account, amount=300, save=False)
-		je1.accounts[0].party_type = "Customer"
-		je1.accounts[0].credit = 300
-		je1.accounts[0].is_advance = ""
-		je1.accounts[0].reference_type = "Sales Order"
+			if not frappe.db.exists("Account", cr_account):
+				frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": "Creditors",
+						"parent_account": f"Current Liabilities - {abbr}",
+						"company": company,
+						"is_group": 1,
+						"root_type": "Liability",
+					}
+				).insert(ignore_permissions=True)
+			else:
+				frappe.db.set_value("Account", cr_account, "is_group", 1)
 
-		with self.assertRaises(frappe.ValidationError) as cm1:
-			je1.validate_entries_for_advance()
-		self.assertIn("Payment against Sales/Purchase Order should always be marked as advance", str(cm1.exception))
+			receivable_account = get_or_create_account(
+				"Debtors - ADV", company, ar_account, "Receivable", "Asset"
+			)
 
-		je2 = make_journal_entry(account1=receivable_account, account2=payable_account, amount=400, save=False)
-		je2.accounts[0].party_type = "Customer"
-		je2.accounts[0].is_advance = "Yes"
-		je2.accounts[0].debit = 400
-		je2.accounts[0].credit = 0
+			payable_account = get_or_create_account(
+				"Creditors - ADV", company, cr_account, "Payable", "Liability"
+			)
 
-		with self.assertRaises(frappe.ValidationError) as cm2:
-			je2.validate_entries_for_advance()
-		self.assertIn("Advance against Customer must be credit", str(cm2.exception))
+			je1 = make_journal_entry(
+				account1=receivable_account, account2=payable_account, amount=300, save=False
+			)
+			je1.accounts[0].party_type = "Customer"
+			je1.accounts[0].credit = 300
+			je1.accounts[0].is_advance = ""
+			je1.accounts[0].reference_type = "Sales Order"
 
-		je3 = make_journal_entry(account1=receivable_account, account2=payable_account, amount=500, save=False)
-		je3.accounts[0].party_type = "Supplier"
-		je3.accounts[0].is_advance = "Yes"
-		je3.accounts[0].credit = 500
-		je3.accounts[0].debit = 0
+			with self.assertRaises(frappe.ValidationError) as cm1:
+				je1.validate_entries_for_advance()
+			self.assertIn(
+				"Payment against Sales/Purchase Order should always be marked as advance", str(cm1.exception)
+			)
 
-		with self.assertRaises(frappe.ValidationError) as cm3:
-			je3.validate_entries_for_advance()
-		self.assertIn("Advance against Supplier must be debit", str(cm3.exception))
+			je2 = make_journal_entry(
+				account1=receivable_account, account2=payable_account, amount=400, save=False
+			)
+			je2.accounts[0].party_type = "Customer"
+			je2.accounts[0].is_advance = "Yes"
+			je2.accounts[0].debit = 400
+			je2.accounts[0].credit = 0
 
-  
+			with self.assertRaises(frappe.ValidationError) as cm2:
+				je2.validate_entries_for_advance()
+
+			self.assertIn("Advance against Customer must be credit", str(cm2.exception))
+			je3 = make_journal_entry(
+				account1=receivable_account, account2=payable_account, amount=500, save=False
+			)
+			je3.accounts[0].party_type = "Supplier"
+			je3.accounts[0].is_advance = "Yes"
+			je3.accounts[0].credit = 500
+			je3.accounts[0].debit = 0
+
+			with self.assertRaises(frappe.ValidationError) as cm3:
+				je3.validate_entries_for_advance()
+			self.assertIn("Advance against Supplier must be debit", str(cm3.exception))
+
+		finally:
+			# Always restore accounts to their original is_group state
+			if ar_was_group is not None:
+				frappe.db.set_value("Account", ar_account, "is_group", ar_was_group)
+			if cr_was_group is not None:
+				frappe.db.set_value("Account", cr_account, "is_group", cr_was_group)
+
 	def test_validate_stock_accounts_exceptions_TC_ACC_561(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+
 		company = "_Test Company"
 		create_company(company_name=company)
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		if not frappe.db.exists("Account", f"Stock In Hand - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Stock In Hand",
-				"parent_account": f"Current Assets - {abbr}",
-				"company": company,
-				"is_group": 0,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Stock In Hand",
+					"parent_account": f"Current Assets - {abbr}",
+					"company": company,
+					"is_group": 0,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
 		if not frappe.db.exists("Account", f"Cash - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Cash",
-				"parent_account": f"Current Assets - {abbr}",
-				"company": company,
-				"is_group": 0,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Cash",
+					"parent_account": f"Current Assets - {abbr}",
+					"company": company,
+					"is_group": 0,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
 		je = make_journal_entry(
-			account1=f"Stock In Hand - {abbr}",
-			account2=f"Cash - {abbr}",
-			amount=100,
-			save=True
+			account1=f"Stock In Hand - {abbr}", account2=f"Cash - {abbr}", amount=100, save=True
 		)
 		with self.assertRaises(frappe.ValidationError) as cm:
 			je.validate_stock_accounts()
 
 		self.assertIn("can only be updated via Stock Transactions", str(cm.exception))
-  
+
 	def test_validate_against_jv_exceptions_TC_ACC_562(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+
 		company = "_Test Company"
 		create_company(company_name=company)
 		abbr = frappe.get_cached_value("Company", company, "abbr")
@@ -2231,32 +2395,40 @@ class TestJournalEntry(unittest.TestCase):
 		get_or_create_customer("_Test Customer")
 
 		if not frappe.db.exists("Account", f"Debtors - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Debtors",
-				"parent_account": f"Accounts Receivable - {abbr}",
-				"company": company,
-				"is_group": 1,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Debtors",
+					"parent_account": f"Accounts Receivable - {abbr}",
+					"company": company,
+					"is_group": 1,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 		else:
 			frappe.db.set_value("Account", f"Debtors - {abbr}", "is_group", 1)
 
 		if not frappe.db.exists("Account", f"Current Liabilities - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Current Liabilities",
-				"parent_account": f"Liabilities - {abbr}",
-				"company": company,
-				"is_group": 1,
-				"root_type": "Liability",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Current Liabilities",
+					"parent_account": f"Liabilities - {abbr}",
+					"company": company,
+					"is_group": 1,
+					"root_type": "Liability",
+				}
+			).insert(ignore_permissions=True)
 		else:
 			frappe.db.set_value("Account", f"Current Liabilities - {abbr}", "is_group", 1)
 
-		asset_account = get_or_create_account("Debtors - JV", company, f"Debtors - {abbr}", "Receivable", "Asset")
+		asset_account = get_or_create_account(
+			"Debtors - JV", company, f"Debtors - {abbr}", "Receivable", "Asset"
+		)
 
-		liability_account = get_or_create_account("Creditors - JV", company, f"Current Liabilities - {abbr}", "Payable", "Liability")
+		liability_account = get_or_create_account(
+			"Creditors - JV", company, f"Current Liabilities - {abbr}", "Payable", "Liability"
+		)
 
 		je1 = make_journal_entry(account1=asset_account, account2=liability_account, amount=200, save=False)
 		je1.accounts[0].reference_type = "Journal Entry"
@@ -2273,7 +2445,7 @@ class TestJournalEntry(unittest.TestCase):
 		with self.assertRaises(frappe.ValidationError) as cm2:
 			je2.validate_against_jv()
 		self.assertIn("you can select reference document only if account gets debited", str(cm2.exception))
-  
+
 		je3 = make_journal_entry(account1=asset_account, account2=liability_account, amount=400, save=False)
 		je3.accounts[0].party_type = "Customer"
 		je3.accounts[0].party = "_Test Customer"
@@ -2281,9 +2453,13 @@ class TestJournalEntry(unittest.TestCase):
 		je3.accounts[0].reference_name = je3.name
 		with self.assertRaises(frappe.ValidationError) as cm3:
 			je3.validate_against_jv()
-		self.assertIn("You can not enter current voucher in 'Against Journal Entry' column", str(cm3.exception))
-  
-		ref_je = make_journal_entry(account1=asset_account, account2=liability_account, amount=500, save=False)
+		self.assertIn(
+			"You can not enter current voucher in 'Against Journal Entry' column", str(cm3.exception)
+		)
+
+		ref_je = make_journal_entry(
+			account1=asset_account, account2=liability_account, amount=500, save=False
+		)
 		ref_je.accounts[0].party_type = "Customer"
 		ref_je.accounts[0].party = "_Test Customer"
 		ref_je.accounts[1].party_type = "Supplier"
@@ -2298,38 +2474,44 @@ class TestJournalEntry(unittest.TestCase):
 
 		with self.assertRaises(frappe.ValidationError) as cm4:
 			je4.validate_against_jv()
-		self.assertIn("does not have any unmatched", str(cm4.exception)) 
+		self.assertIn("does not have any unmatched", str(cm4.exception))
 
 	def test_get_outstanding_for_journal_entry_TC_ACC_563(self):
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_outstanding
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-  
+
 		company = "_Test Company"
 		create_company(company_name=company)
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 		get_or_create_customer("_Test Customer")
 
 		if not frappe.db.exists("Account", f"Accounts Receivable - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Accounts Receivable",
-				"parent_account": f"Current Assets - {abbr}",
-				"company": company,
-				"is_group": 1,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Accounts Receivable",
+					"parent_account": f"Current Assets - {abbr}",
+					"company": company,
+					"is_group": 1,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
 		if not frappe.db.exists("Account", f"Cash In Hand - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Cash In Hand",
-				"parent_account": f"Current Assets - {abbr}",
-				"company": company,
-				"is_group": 1,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Cash In Hand",
+					"parent_account": f"Current Assets - {abbr}",
+					"company": company,
+					"is_group": 1,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
-		asset_account = get_or_create_account("Debtors - OUT", company, f"Accounts Receivable - {abbr}", "Receivable", "Asset")
+		asset_account = get_or_create_account(
+			"Debtors - OUT", company, f"Accounts Receivable - {abbr}", "Receivable", "Asset"
+		)
 
 		cash_account = get_or_create_account("Cash - OUT", company, f"Cash In Hand - {abbr}", "Cash", "Asset")
 		je = make_journal_entry(account1=asset_account, account2=cash_account, amount=250, save=False)
@@ -2337,19 +2519,29 @@ class TestJournalEntry(unittest.TestCase):
 		je.accounts[0].party = "_Test Customer"
 		je.save()
 
-		args = {"doctype": "Journal Entry","docname": je.name, "account": asset_account, "company": company,}
+		args = {
+			"doctype": "Journal Entry",
+			"docname": je.name,
+			"account": asset_account,
+			"company": company,
+		}
 		out = get_outstanding(args)
 
 		self.assertTrue(
 			"debit_in_account_currency" in out or "credit_in_account_currency" in out,
 			"Outstanding dict must include debit_in_account_currency or credit_in_account_currency",
 		)
-		self.assertEqual(abs(out.get("debit_in_account_currency", 0) or out.get("credit_in_account_currency", 0)), 250)
-  
+		self.assertEqual(
+			abs(out.get("debit_in_account_currency", 0) or out.get("credit_in_account_currency", 0)), 250
+		)
+
 	def test_get_payment_entry_against_invoice_TC_ACC_564(self):
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_payment_entry_against_invoice
-		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice, create_company
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+			create_company,
+			create_sales_invoice,
+		)
 
 		company = "_Test Company"
 		create_company(company_name=company)
@@ -2357,34 +2549,46 @@ class TestJournalEntry(unittest.TestCase):
 
 		receivable_acc = frappe.db.get_value("Account", {"account_type": "Receivable", "company": company})
 		if not receivable_acc:
-			receivable_acc = frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Test Receivable",
-				"parent_account": f"Accounts Receivable - {abbr}",
-				"company": company,
-				"is_group": 0,
-				"account_type": "Receivable",
-				"root_type": "Asset"
-			}).insert(ignore_permissions=True).name
+			receivable_acc = (
+				frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": "Test Receivable",
+						"parent_account": f"Accounts Receivable - {abbr}",
+						"company": company,
+						"is_group": 0,
+						"account_type": "Receivable",
+						"root_type": "Asset",
+					}
+				)
+				.insert(ignore_permissions=True)
+				.name
+			)
 
 		payable_acc = frappe.db.get_value("Account", {"account_type": "Payable", "company": company})
 		if not payable_acc:
-			payable_acc = frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Test Payable",
-				"parent_account": f"Creditors - {abbr}",
-				"company": company,
-				"is_group": 0,
-				"account_type": "Payable",
-				"root_type": "Liability"
-			}).insert(ignore_permissions=True).name
+			payable_acc = (
+				frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": "Test Payable",
+						"parent_account": f"Creditors - {abbr}",
+						"company": company,
+						"is_group": 0,
+						"account_type": "Payable",
+						"root_type": "Liability",
+					}
+				)
+				.insert(ignore_permissions=True)
+				.name
+			)
 
 		si = create_sales_invoice(
 			customer="_Test Customer",
 			company=company,
 			posting_date=frappe.utils.nowdate(),
 			debit_to=receivable_acc,
-			outstanding_amount=100
+			outstanding_amount=100,
 		)
 		get_payment_entry_against_invoice("Sales Invoice", si.name)
 
@@ -2393,7 +2597,7 @@ class TestJournalEntry(unittest.TestCase):
 			company=company,
 			posting_date=frappe.utils.nowdate(),
 			debit_to=receivable_acc,
-			outstanding_amount=0
+			outstanding_amount=0,
 		)
 
 		pi = make_purchase_invoice(
@@ -2412,29 +2616,34 @@ class TestJournalEntry(unittest.TestCase):
 			posting_date=frappe.utils.nowdate(),
 			credit_to=payable_acc,
 			uom="Nos",
-			outstanding_amount=100
+			outstanding_amount=100,
 		)
 		get_payment_entry_against_invoice("Purchase Invoice", pi2.name)
-  
+
 	def test_get_exchange_rate_TC_ACC_565(self):
+		from frappe.utils import nowdate
+
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_exchange_rate
 		from erpnext.accounts.doctype.journal_entry.test_journal_entry import get_or_create_account
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-		from frappe.utils import nowdate
 
 		company = "_Test Company"
 		create_company(company_name=company)
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		if not frappe.db.exists("Account", f"Current Assets - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Current Assets",
-				"parent_account": f"Assets - {abbr}" if frappe.db.exists("Account", f"Assets - {abbr}") else None,
-				"company": company,
-				"is_group": 1,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Current Assets",
+					"parent_account": f"Assets - {abbr}"
+					if frappe.db.exists("Account", f"Assets - {abbr}")
+					else None,
+					"company": company,
+					"is_group": 1,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
 		cash_acc = get_or_create_account(
 			"Test Cash",
@@ -2443,7 +2652,7 @@ class TestJournalEntry(unittest.TestCase):
 			"Cash",
 			"Asset",
 		)
-  
+
 		with self.assertRaises(frappe.ValidationError):
 			get_exchange_rate(nowdate(), account="_Nonexistent Account")
 
@@ -2451,7 +2660,9 @@ class TestJournalEntry(unittest.TestCase):
 		self.assertTrue(rate_company_none is not None)
 		self.assertEqual(rate_company_none, 1)
 
-		rate_currency_none = get_exchange_rate(nowdate(), account=cash_acc, company=company, account_currency=None)
+		rate_currency_none = get_exchange_rate(
+			nowdate(), account=cash_acc, company=company, account_currency=None
+		)
 		self.assertTrue(rate_currency_none is not None)
 		self.assertEqual(rate_currency_none, 1)
 
@@ -2462,35 +2673,38 @@ class TestJournalEntry(unittest.TestCase):
 			"Bank",
 			"Asset",
 		)
-		rate_foreign = get_exchange_rate(nowdate(), account=foreign_acc, company=company, account_currency="USD")
+		rate_foreign = get_exchange_rate(
+			nowdate(), account=foreign_acc, company=company, account_currency="USD"
+		)
 		self.assertTrue(rate_foreign > 0)
-  
+
 	def test_get_account_details_and_party_type_TC_ACC_566(self):
+		from frappe.utils import nowdate
+
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_account_details_and_party_type
 		from erpnext.accounts.doctype.journal_entry.test_journal_entry import get_or_create_account
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
-		from frappe.utils import nowdate
 
 		company = "_Test Company"
 		create_company(company_name=company)
 		abbr = frappe.get_cached_value("Company", company, "abbr")
 
 		if not frappe.db.exists("Account", f"Current Assets - {abbr}"):
-			frappe.get_doc({
-				"doctype": "Account",
-				"account_name": "Current Assets",
-				"parent_account": f"Assets - {abbr}" if frappe.db.exists("Account", f"Assets - {abbr}") else None,
-				"company": company,
-				"is_group": 1,
-				"root_type": "Asset",
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": "Current Assets",
+					"parent_account": f"Assets - {abbr}"
+					if frappe.db.exists("Account", f"Assets - {abbr}")
+					else None,
+					"company": company,
+					"is_group": 1,
+					"root_type": "Asset",
+				}
+			).insert(ignore_permissions=True)
 
 		receivable_acc = get_or_create_account(
-			"Test Receivable - PARTY",
-			company,
-			f"Current Assets - {abbr}",
-			"Receivable",
-			"Asset"
+			"Test Receivable - PARTY", company, f"Current Assets - {abbr}", "Receivable", "Asset"
 		)
 		res_receivable = get_account_details_and_party_type(receivable_acc, nowdate(), company)
 		self.assertEqual(res_receivable["party_type"], "Customer")
@@ -2498,11 +2712,7 @@ class TestJournalEntry(unittest.TestCase):
 		self.assertTrue(res_receivable["exchange_rate"] > 0)
 
 		payable_acc = get_or_create_account(
-			"Test Payable - PARTY",
-			company,
-			f"Current Assets - {abbr}",
-			"Payable",
-			"Liability"
+			"Test Payable - PARTY", company, f"Current Assets - {abbr}", "Payable", "Liability"
 		)
 		res_payable = get_account_details_and_party_type(payable_acc, nowdate(), company)
 		self.assertEqual(res_payable["party_type"], "Supplier")
@@ -2510,16 +2720,13 @@ class TestJournalEntry(unittest.TestCase):
 		self.assertTrue(res_payable["exchange_rate"] > 0)
 
 		cash_acc = get_or_create_account(
-			"Test Cash - PARTY",
-			company,
-			f"Current Assets - {abbr}",
-			"Cash",
-			"Asset"
+			"Test Cash - PARTY", company, f"Current Assets - {abbr}", "Cash", "Asset"
 		)
 		res_cash = get_account_details_and_party_type(cash_acc, nowdate(), company)
 		self.assertEqual(res_cash["party_type"], "")
 		self.assertEqual(res_cash["account_type"], "Cash")
-		self.assertIn("party", res_cash) 
+		self.assertIn("party", res_cash)
+
 
 def make_journal_entry(
 	account1,
@@ -2571,6 +2778,8 @@ def make_journal_entry(
 
 
 test_records = frappe.get_test_records("Journal Entry")
+
+
 def create_custom_test_accounts():
 	accounts = [
 		["_Test Account Tax Assets", "Current Assets", 1, None, None],
@@ -2580,7 +2789,6 @@ def create_custom_test_accounts():
 		["_Test Account Cost for Goods Sold", "Expenses", 0, None, None],
 		["_Test Bank", "Bank Accounts", 0, "Bank", None],
 		["_Test Account IGST", "_Test Account Tax Assets", 0, "Tax", None],
-
 		["Input Tax CGST", "_Test Account Tax Assets", 0, "Tax", None],
 		["Input Tax SGST", "_Test Account Tax Assets", 0, "Tax", None],
 		["Input Tax IGST", "_Test Account Tax Assets", 0, "Tax", None],
@@ -2593,80 +2801,93 @@ def create_custom_test_accounts():
 	abbr = "_TC"
 
 	for account_name, parent_account, is_group, account_type, currency in accounts:
-		if not frappe.db.exists("Account", account_name+" - "+abbr):
-			doc = frappe.get_doc({
+		if not frappe.db.exists("Account", account_name + " - " + abbr):
+			doc = frappe.get_doc(
+				{
+					"doctype": "Account",
+					"account_name": account_name,
+					"parent_account": f"{parent_account} - {abbr}",
+					"company": company,
+					"is_group": is_group,
+					"account_type": account_type,
+					"account_currency": currency
+					or frappe.get_cached_value("Company", company, "default_currency"),
+					"account_number": "",
+				}
+			)
+			doc.insert(ignore_permissions=True)
+
+
+def get_or_create_account(account_name, company, parent, account_type, root_type):
+	abbr = frappe.get_cached_value("Company", company, "abbr")
+	full_name = f"{account_name} - {abbr}"
+	if not frappe.db.exists("Account", full_name):
+		frappe.get_doc(
+			{
 				"doctype": "Account",
 				"account_name": account_name,
-				"parent_account": f"{parent_account} - {abbr}",
+				"parent_account": parent,
 				"company": company,
-				"is_group": is_group,
 				"account_type": account_type,
-				"account_currency": currency or frappe.get_cached_value("Company", company, "default_currency"),
-				"account_number": "", 
-			})
-			doc.insert(ignore_permissions=True)
-   
-def get_or_create_account(account_name, company, parent, account_type, root_type):
-    abbr = frappe.get_cached_value("Company", company, "abbr")
-    full_name = f"{account_name} - {abbr}"
-    if not frappe.db.exists("Account", full_name):
-        frappe.get_doc({
-            "doctype": "Account",
-            "account_name": account_name,
-            "parent_account": parent,
-            "company": company,
-            "account_type": account_type,
-            "root_type": root_type,
-        }).insert(ignore_permissions=True)
-    return full_name
+				"root_type": root_type,
+			}
+		).insert(ignore_permissions=True)
+	return full_name
+
 
 def get_or_create_supplier(name="_Test Supplier Payable"):
-    if not frappe.db.exists("Supplier", name):
-        frappe.get_doc({
-            "doctype": "Supplier",
-            "supplier_name": name,
-            "supplier_group": "All Supplier Groups",
-            "supplier_type": "Company",
-        }).insert(ignore_permissions=True)
-    return name
+	if not frappe.db.exists("Supplier", name):
+		frappe.get_doc(
+			{
+				"doctype": "Supplier",
+				"supplier_name": name,
+				"supplier_group": "All Supplier Groups",
+				"supplier_type": "Company",
+			}
+		).insert(ignore_permissions=True)
+	return name
+
 
 def get_or_create_customer(name="_Test Customer", group="_Test Customer Group", territory="_Test Territory"):
-    if not frappe.db.exists("Customer", name):
-        frappe.get_doc({
-            "doctype": "Customer",
-            "customer_name": name,
-            "customer_group": group,
-            "territory": territory,
-        }).insert(ignore_permissions=True)
-    return name
+	if not frappe.db.exists("Customer", name):
+		frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": name,
+				"customer_group": group,
+				"territory": territory,
+			}
+		).insert(ignore_permissions=True)
+	return name
+
 
 def get_or_create_warehouse(name="_Test Warehouse 1 - _TC", company="_Test Company"):
-    if not frappe.db.exists("Warehouse", name):
-        frappe.get_doc({
-            "doctype": "Warehouse",
-            "warehouse_name": name,
-            "company": company
-        }).insert(ignore_permissions=True)
-    return name
+	if not frappe.db.exists("Warehouse", name):
+		frappe.get_doc({"doctype": "Warehouse", "warehouse_name": name, "company": company}).insert(
+			ignore_permissions=True
+		)
+	return name
+
 
 def get_or_create_tds_category(name="_Test TDS Category", company="_Test Company", account=None):
-    if not frappe.db.exists("Tax Withholding Category", name):
-        frappe.get_doc({
-            "doctype": "Tax Withholding Category",
-            "name": name,
-            "company": company,
-            "accounts": [{
-                "account": account,
-                "company": company,
-                "tax_withholding_rate": 10.0,
-                "threshold": 0.0
-            }],
-            "rates": [{
-                "from_date": frappe.utils.nowdate(),
-                "to_date": frappe.utils.add_years(frappe.utils.nowdate(), 1),
-                "tax_withholding_rate": 10.0,
-                "single_threshold": 0.0,
-                "cumulative_threshold": 0.0
-            }]
-        }).insert(ignore_permissions=True)
-    return name
+	if not frappe.db.exists("Tax Withholding Category", name):
+		frappe.get_doc(
+			{
+				"doctype": "Tax Withholding Category",
+				"name": name,
+				"company": company,
+				"accounts": [
+					{"account": account, "company": company, "tax_withholding_rate": 10.0, "threshold": 0.0}
+				],
+				"rates": [
+					{
+						"from_date": frappe.utils.nowdate(),
+						"to_date": frappe.utils.add_years(frappe.utils.nowdate(), 1),
+						"tax_withholding_rate": 10.0,
+						"single_threshold": 0.0,
+						"cumulative_threshold": 0.0,
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
+	return name


### PR DESCRIPTION
### Title:

Fix: Reset Accounts in tests to avoid using Group Accounts in transactions

### Description:

During full coverage runs, multiple tests failed with:
ValidationError: Account ... is a Group Account and group accounts cannot be used in transactions.

### Root Cause:

Some tests (e.g. test_validate_entries_for_advance_exceptions_TC_ACC_560) set Accounts Receivable and Creditors as group accounts but did not reset them, leaking invalid state into other tests.

### Steps to Reproduce:

Run bench run-tests --app erpnext.

Transaction-related tests fail with group account errors.

### Actual Result:

Tests fail unpredictably due to leftover group accounts.

### Expected Result:

Tests pass consistently with valid account states.

### Fix Summary:

Added reset of Accounts in test_validate_entries_for_advance_exceptions_TC_ACC_560 using a finally block.

Prevents invalid account state from affecting other tests.

### Test Cases Covered:

test_validate_entries_for_advance_exceptions_TC_ACC_560

Stabilizes all JE/Invoice related tests.

### Linked Issue:

#2895 
#2893 