### PR TITLE
test: add new test cases for Mode of Payment Payment Ledger Entry and Pos closing Entry doctype.

### DIFF
--- a/erpnext/accounts/doctype/mode_of_payment/test_mode_of_payment.py
+++ b/erpnext/accounts/doctype/mode_of_payment/test_mode_of_payment.py
@@ -8,6 +8,10 @@ import frappe
 
 
 class TestModeofPayment(unittest.TestCase):
+	def tearDown(self):
+		super().tearDown()
+		frappe.db.rollback()
+  
 	def test_mode_of_payment_in_payment_entry_TC_ACC_105(self):
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
@@ -47,6 +51,113 @@ class TestModeofPayment(unittest.TestCase):
 			if entry.account == paid_from:
 				# Here we can add further checks, like verifying the amount and whether it's debit/credit
 				self.assertEqual(entry.credit, pe.paid_amount)  # Assuming full payment is being made in Cash
+    
+	def test_validate_pos_mode_of_payment_TC_ACC_348(self):
+		from frappe import _
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company, make_test_item
+		from erpnext.accounts.doctype.account.test_account import create_account
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+
+		create_company("_Test Company")
+
+		create_account(
+			account_name="_Test Cash",
+			account_type="Cash",
+			company="_Test Company",
+			parent_account="Cash In Hand - _TC",
+			account_currency="INR"
+		)
+		create_warehouse(warehouse_name = "_Test Warehouse", company = "_Test Company")
+		create_cost_center(cost_center_name="_Test Cost Center", company= "_Test Company")
+		make_test_item(item_name="_Test Item")
+
+		mop = frappe.new_doc("Mode of Payment")
+		mop.mode_of_payment = "Test MOP Throws"
+		mop.enabled = 0
+		mop.type = "Cash"
+		mop.append("accounts", {
+			"company": "_Test Company",
+			"default_account": "_Test Cash - _TC"
+		})
+		mop.insert(ignore_permissions=True)
+
+		pos_profile = frappe.new_doc("POS Profile")
+		pos_profile.name = "Test POS Throw"
+		pos_profile.company = "_Test Company"
+		pos_profile.write_off_account = "_Test Cash - _TC"
+		pos_profile.warehouse = "_Test Warehouse - _TC"
+		pos_profile.write_off_cost_center = "_Test Cost Center - _TC"
+		pos_profile.append("payments", {
+			"mode_of_payment": mop.name,
+			"default": 1
+		})
+		pos_profile.insert(ignore_permissions=True)
+
+		si = frappe.new_doc("Sales Invoice")
+		si.company = "_Test Company"
+		si.customer = "_Test Customer"
+		si.is_pos = 1
+		si.pos_profile = pos_profile.name
+		si.currency = "INR"
+		si.debit_to = "Debtors - _TC"
+		si.append("items", {
+			"item_code": "_Test Item",
+			"qty": 1,
+			"rate": 100
+		})
+		si.append("payments", {
+			"mode_of_payment": mop.name,
+			"amount": 100
+		})
+		si.save(ignore_permissions=True)
+		si.submit()
+
+		with self.assertRaises(frappe.ValidationError) as cm:
+			mop.validate_pos_mode_of_payment()
+   
+	def test_validate_accounts_TC_ACC_349(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.accounts.doctype.account.test_account import create_account
+		import frappe
+		from frappe.exceptions import ValidationError
+
+		# Create company and accounts
+		create_company("_Test Company 1")
+		create_company("_Test Company 2")
+
+		account_a = create_account(
+			account_name="_Test Cash 1",
+			account_type="Cash",
+			company="_Test Company 1",
+			parent_account="Cash In Hand - _TC1",
+			account_currency="INR"
+		)
+	
+		mop = frappe.new_doc("Mode of Payment")
+		mop.mode_of_payment = "Test MOP Validate Accounts"
+
+		mop.append("accounts", {
+			"company": "_Test Company 1",
+			"default_account": account_a
+		})
+
+		mop.validate_accounts()  
+		
+		mop.accounts = []
+		mop.append("accounts", {
+			"company": "_Test Company 2",
+			"default_account": account_a
+		})
+		mop.name ="Test MOP Validate Accounts"
+		with self.assertRaises(frappe.ValidationError) as cm:
+			mop.validate_accounts()
+
+		self.assertEqual(
+			str(cm.exception),
+			f"Account {account_a} does not match with Company _Test Company 2 in Mode of Account: Test MOP Validate Accounts"
+		)
 
 def set_default_account_for_mode_of_payment(mode_of_payment, company, account):
 	mode_of_payment.reload()

--- a/erpnext/accounts/doctype/open_item_reconciliation/open_item_reconciliation.py
+++ b/erpnext/accounts/doctype/open_item_reconciliation/open_item_reconciliation.py
@@ -12,7 +12,7 @@ class OpenItemReconciliation(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from erpnext.accounts.doctype.gl_entry_allocation.gl_entry_allocation import GLEntryAllocation
 		from erpnext.accounts.doctype.gl_reconciliation_details.gl_reconciliation_details import GLReconciliationDetails
 		from frappe.types import DF

--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
@@ -12,7 +12,7 @@ class PaymentGatewayAccount(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		currency: DF.ReadOnly | None

--- a/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py
@@ -26,7 +26,7 @@ class PaymentLedgerEntry(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		account: DF.Link | None

--- a/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
@@ -537,3 +537,239 @@ class TestPaymentLedgerEntry(FrappeTestCase):
 		# with references removed, deletion should be possible
 		so.delete()
 		self.assertRaises(frappe.DoesNotExistError, frappe.get_doc, so.doctype, so.name)
+  
+	def test_validate_account_details_TC_ACC_334(self):
+		from frappe.exceptions import ValidationError
+		from erpnext.accounts.doctype.account.test_account import create_account
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from frappe.utils import nowdate
+
+		create_company("_Test Company")
+		create_company("_Another Test Company", abbr="_ATC")
+
+		ledger_account = create_account(
+			account_name="_Test Ledger Account",
+			is_group=0,
+			account_type=None,
+			parent_account=frappe.db.get_value(
+				"Account", {"company": "_Test Company", "is_group": 1}
+			),
+			company="_Test Company",
+			account_currency="USD",
+			do_not_save=True,
+		)
+		ledger_account.save(ignore_permissions=True)
+  
+		ple = frappe.new_doc("Payment Ledger Entry")
+		ple.voucher_type = "Journal Entry"
+		ple.voucher_no = "TEST-JE-0001"
+		ple.account = ledger_account.name
+		ple.company = "_Test Company"
+		ple.posting_date = nowdate()
+
+		ple.validate_account_details()
+
+		ledger_account.is_group = 1
+		ledger_account.save(ignore_permissions=True)
+		with self.assertRaises(ValidationError) as e:
+			ple.validate_account_details()
+   
+		self.assertEqual(
+			str(e.exception).strip(),
+			f"Journal Entry {ple.voucher_no}: Account {ple.account} is a Group Account and group accounts cannot be used in transactions"
+		)
+
+		ledger_account.is_group = 0
+		ledger_account.save(ignore_permissions=True)
+
+		ple.company = "_Another Test Company"
+		ledger_account.save()
+		with self.assertRaises(ValidationError) as e:
+			ple.validate_account_details()
+
+		self.assertEqual(
+			str(e.exception).strip(),
+			f"Journal Entry {ple.voucher_no}: Account {ple.account} does not belong to Company {ple.company}"
+		)
+
+	def test_validate_allowed_dimensions_TC_ACC_335(self):
+		from erpnext.accounts.doctype.account.test_account import create_account
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import validate_fiscal_year
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		create_company("_Test Company", abbr="_TC", currency="INR")
+		validate_fiscal_year("_Test Company")
+		create_cost_center(cost_center_name="Test Cost Center", company="_Test Company")
+		create_supplier(supplier_name="_Test Supplier", default_currency="INR")
+		parent_acc = frappe.db.get_value("Account", {"company": "_Test Company", "is_group": 1}, "name")
+		account_name = create_account(
+			account_name="_Test Ledger Account",
+			is_group=0,
+			company="_Test Company",
+			account_currency="INR",
+			account_type="Payable",
+			parent_account=parent_acc,
+		)
+		account_name_1 = create_account(
+			account_name="_Test Ledger Account 1",
+			is_group=0,
+			company="_Test Company",
+			account_currency="INR",
+			parent_account=parent_acc,
+		)
+
+		acc_f = frappe.get_doc({
+			"doctype":"Accounting Dimension Filter",
+			"company":"_Test Company",
+			"accounting_dimension":"Cost Center",
+			"allow_or_restrict":"Allow",
+			"apply_restriction_on_values":1,
+			"accounts":[{
+				"applicable_on_account":account_name,
+				"is_mandatory":1
+			}],
+			"dimensions":[{
+				"accounting_dimension":"Cost Center",
+				"dimension_value":"Test Cost Center - _TC"
+			}],
+			"disabled":0
+		}).insert(ignore_permissions=True)
+
+		jv = make_journal_entry(
+			account1=account_name,
+			account2=account_name_1,
+			amount=100,
+			cost_center="Test Cost Center - _TC",
+			save=False
+		)
+		jv.accounts[0].party_type = "Supplier"
+		jv.accounts[0].party = "_Test Supplier"
+		jv.save(ignore_permissions=True)
+		jv.submit()	
+
+		ple = frappe.get_doc({
+			"doctype":"Payment Ledger Entry",
+			"voucher_type":"Journal Entry",
+			"voucher_no":jv.name,
+			"account_type":"Payable",
+			"company":"_Test Company",
+			"against_voucher_type":"Journal Entry",
+			"party_type":"Supplier",
+			"party":"_Test Supplier",
+			"against_voucher_no":jv.name,
+			# "cost_center":"Test Cost Center - _TC",
+			"account":account_name,
+			"amount":100,
+			"currency":"INR",
+		})
+		with self.assertRaises(frappe.ValidationError) as e:
+			ple.validate_allowed_dimensions()
+		#validate cost center
+		self.assertEqual(
+			str(e.exception).strip(),
+			f"Cost Center is mandatory for account _Test Ledger Account - _TC"
+		)
+		ple.cost_center = "Test Cost Center - _TC1"
+		with self.assertRaises(frappe.ValidationError) as e:
+			ple.validate_allowed_dimensions()
+
+		self.assertEqual(
+			str(e.exception).strip(),
+			f"Invalid value Test Cost Center - _TC1 for Cost Center against account _Test Ledger Account - _TC"
+		)
+	
+	def test_validate_dimensions_for_pl_and_bs_TC_ACC_347(self):
+		
+		from erpnext.accounts.doctype.account.test_account import create_account
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_company
+		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import validate_fiscal_year
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+		from .payment_ledger_entry import on_doctype_update
+
+		create_company("_Test Company", abbr="_TC", currency="INR")
+		validate_fiscal_year("_Test Company")
+		create_cost_center(cost_center_name="Test Cost Center", company="_Test Company")
+		create_supplier(supplier_name="_Test Supplier", default_currency="INR")
+		parent_acc = frappe.db.get_value("Account", {"company": "_Test Company", "is_group": 1}, "name")
+		account_name = create_account(
+			account_name="_Test Ledger Account",
+			is_group=0,
+			company="_Test Company",
+			account_currency="INR",
+			account_type="Payable",
+			parent_account=parent_acc,
+			do_not_save=True
+		)
+		account_name.save(ignore_permissions=True)
+		account_name.db_set("report_type", "Profit and Loss")
+		frappe._set_document_in_cache(account_name.doctype, account_name)
+		account_name_1 = create_account(
+			account_name="_Test Ledger Account 1",
+			is_group=0,
+			company="_Test Company",
+			account_currency="INR",
+			parent_account=parent_acc,
+		)
+
+		jv = make_journal_entry(
+			account1=account_name.name,
+			account2=account_name_1,
+			amount=100,
+			cost_center="Test Cost Center - _TC",
+			save=False
+		)
+		jv.accounts[0].party_type = "Supplier"
+		jv.accounts[0].party = "_Test Supplier"
+		jv.save(ignore_permissions=True)
+		jv.submit()	
+		
+  
+		ple = frappe.get_doc({
+			"doctype":"Payment Ledger Entry",
+			"voucher_type":"Journal Entry",
+			"voucher_no":jv.name,
+			"account_type":"Payable",
+			"company":"_Test Company",
+			"against_voucher_type":"Journal Entry",
+			"party_type":"Supplier",
+			"party":"_Test Supplier",
+			"against_voucher_no":jv.name,
+			"cost_center":"Test Cost Center - _TC",
+			"account":account_name.name,
+			"amount":100,
+			"currency":"INR",
+		}).insert(ignore_permissions=True)
+  
+		ad = frappe.get_doc({
+			"doctype":"Accounting Dimension",
+			"document_type":"Payment Ledger Entry",
+			"label":"Payment Ledger Entry",
+			"dimension_defaults":[{
+				"company":"_Test Company",
+				"reference_document":"Payment Ledger Entry",
+				"default_dimension":ple.name,
+				"offsetting_account":account_name.name,
+				"mandatory_for_pl":1,
+				"mandatory_for_bs":1
+			}]
+		}).insert(ignore_permissions=True)
+		with self.assertRaises(frappe.ValidationError) as e:
+			ple.validate_dimensions_for_pl_and_bs()
+		self.assertEqual(
+			str(e.exception).strip(),
+			f"Accounting Dimension {ad.label} is required for 'Profit and Loss' account {account_name.name}."
+		)
+
+		account_name.db_set("report_type", "Balance Sheet")
+		frappe._set_document_in_cache(account_name.doctype, account_name)
+		with self.assertRaises(frappe.ValidationError) as e:
+			ple.validate_dimensions_for_pl_and_bs()
+		self.assertEqual(
+			str(e.exception).strip(),
+			f"Accounting Dimension {ad.label} is required for 'Balance Sheet' account {account_name.name}."
+		)
+		

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -19,7 +19,7 @@ class POSClosingEntry(StatusUpdater):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.pos_closing_entry_detail.pos_closing_entry_detail import (

--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -290,6 +290,102 @@ class TestPOSClosingEntry(unittest.TestCase):
 
 		batch_qty_with_pos = get_batch_qty(batch_no, "_Test Warehouse - _TC", item_code)
 		self.assertEqual(batch_qty_with_pos, 10.0)
+  
+	def test_validate_pos_invoices_TC_ACC_568(self):
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_company
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_customer
+		from erpnext.stock.doctype.item.test_item import make_item
+		from frappe.utils import nowdate
+
+		
+		create_company("_Test Company", abbr="_TC", currency="INR", country="India")
+		create_customer("_Test Customer")
+		create_warehouse("_Test Warehouse")
+		make_item("_Test Item")
+
+		if not frappe.db.exists("POS Profile", "_Test POS Profile 1"):
+			pos_profile = frappe.new_doc("POS Profile")
+			pos_profile.name = "_Test POS Profile 1"
+			pos_profile.company = "_Test Company"
+			pos_profile.warehouse = "_Test Warehouse - _TC"
+			pos_profile.write_off_account = "Sales - _TC"
+			pos_profile.write_off_cost_center = "Main - _TC"
+			pos_profile.append("payments", {
+				"mode_of_payment": "Cash",
+				"default": 1 
+			})
+			pos_profile.insert(ignore_permissions=True)
+		def make_pos_invoice_doc(rate=100, qty=1, pos_profile="_Test POS Profile 1", submit=True, owner=None):
+			from frappe.utils import nowdate
+
+			posting_date = nowdate()
+			user = owner or frappe.session.user or "Administrator"
+
+			
+			if not frappe.db.exists("POS Opening Entry", {"pos_profile": pos_profile, "docstatus": 1}):
+				poe = frappe.new_doc("POS Opening Entry")
+				poe.pos_profile = pos_profile
+				poe.company = "_Test Company"
+				poe.period_start_date = posting_date
+				poe.period_end_date = posting_date
+				poe.user = user   
+				poe.append("balance_details", {
+					"mode_of_payment": "Cash",
+					"opening_amount": 1000,
+				})
+				poe.insert(ignore_permissions=True)
+				poe.submit()
+
+			
+			inv = frappe.new_doc("POS Invoice")
+			inv.customer = "_Test Customer"
+			inv.company = "_Test Company"
+			inv.pos_profile = pos_profile
+			inv.set_posting_time = 1
+			inv.posting_date = posting_date
+			inv.append("items", {
+				"item_code": "_Test Item",
+				"qty": qty,
+				"rate": rate,
+				"warehouse": "_Test Warehouse - _TC",
+			})
+			inv.append("payments", {
+				"mode_of_payment": "Cash",
+				"amount": rate * qty,
+			})
+			inv.owner = user
+			inv.insert(ignore_permissions=True)
+			return inv
+
+
+		valid_inv = make_pos_invoice_doc(rate=100, submit=True, owner=frappe.session.user)
+
+		
+		pce = frappe.new_doc("POS Closing Entry")
+		pce.company = "_Test Company"
+		pce.pos_profile = pos_profile.name
+		pce.user = frappe.session.user
+		pce.append("pos_transactions", {"pos_invoice": valid_inv.name})
+		pce.append("pos_transactions", {"pos_invoice": valid_inv.name})
+
+		frappe.db.set_value("POS Invoice", valid_inv.name, "pos_profile", "Test POS Profile 2")
+		frappe.db.set_value("POS Invoice", valid_inv.name, "owner", "Test User 2")
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pce.validate_pos_invoices()
+
+		err = str(cm.exception)
+		self.assertIn("POS Profile doesn't match", err)
+		self.assertIn("POS Invoice is not submitted", err)
+		self.assertIn("POS Invoice isn't created by user", err)
+		frappe.db.set_value("POS Invoice", valid_inv.name, "pos_profile", "Test POS Profile 1")
+		frappe.db.set_value("POS Invoice", valid_inv.name, "owner", frappe.session.user)
+		frappe.db.set_value("POS Invoice", valid_inv.name, "consolidated_invoice", 1)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			pce.validate_pos_invoices()
+
+		err = str(cm.exception)
+		self.assertIn("POS Invoice is already consolidated", err)
 
 
 def init_user_and_profile(**args):

--- a/erpnext/accounts/doctype/pos_closing_entry_detail/pos_closing_entry_detail.py
+++ b/erpnext/accounts/doctype/pos_closing_entry_detail/pos_closing_entry_detail.py
@@ -11,7 +11,7 @@ class POSClosingEntryDetail(Document):
 
 	from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
+	if TYPE_CHECKING: # pragma: no cover
 		from frappe.types import DF
 
 		closing_amount: DF.Currency


### PR DESCRIPTION
📌 Summary

This PR introduces new unit tests to cover critical validation scenarios in Payment Ledger Entry, Mode of Payment, POS Closing Entry, and Payment Request/Order workflows. These tests ensure stronger data integrity and prevent misconfigurations in ERPNext’s financial flows.

🔹 Detailed Test Cases
Payment Ledger Entry

TC_ACC_334 – test_validate_account_details
✔ Validates that:

A Group Account cannot be used in transactions.

An account must belong to the same company as the Payment Ledger Entry.
🛑 Example: Trying to post a JE against a group account or account from another company throws a ValidationError.

TC_ACC_335 – test_validate_allowed_dimensions
✔ Ensures that:

Certain accounts require mandatory dimensions (e.g., Cost Center).

Only allowed dimension values can be used.
🛑 Example: Posting a JE without Cost Center or with a restricted Cost Center triggers validation.

TC_ACC_347 – test_validate_dimensions_for_pl_and_bs
✔ Covers both Profit & Loss and Balance Sheet accounts.

If dimensions are mandatory, they must be set.

Validates enforcement of Accounting Dimension rules.
🛑 Example: JE with P&L account missing required dimension raises error.

Mode of Payment (MOP)

TC_ACC_348 – test_validate_pos_mode_of_payment
✔ Ensures disabled MOPs cannot be used in POS transactions.
🛑 Example: Sales Invoice with disabled Mode of Payment → throws ValidationError.

TC_ACC_349 – test_validate_accounts
✔ Validates that account-company mapping in MOP is correct.
🛑 Example: Using an account from Company A in MOP for Company B raises error.

POS Closing Entry

TC_ACC_568 – test_validate_pos_invoices
✔ Validates that POS Closing Entry only accepts valid invoices.
🛑 Example: Error raised if invoice is:

From another POS Profile

Not submitted

Created by another user

Already consolidated

Payment Requests & Orders

TC_ACC_361 – test_cancel_old_payment_requests
✔ Tests cancellation of old Payment Requests when a new one is created.
🛑 Ensures docstatus is updated to Cancelled and linked Integration Requests are updated to Cancelled.

TC_ACC_362 – test_get_irequest_status
✔ Fetches status of Integration Requests linked to Payment Requests.
🛑 Ensures correct retrieval of completed vs. pending statuses.

TC_ACC_363 – test_make_payment_records
✔ Validates creation of Journal Entries from Payment Orders.
🛑 Ensures linkage between Payment Order, Payment Request, and Supplier is intact.

TC_ACC_364 – test_get_supplier_query
✔ Tests supplier search in Payment Orders.
🛑 Ensures filtering works correctly and only valid suppliers are returned.

TC_ACC_365 – test_get_mop_query
✔ Tests Mode of Payment search in Payment Orders.
🛑 Ensures query only returns valid and configured MOPs.

🔍 Scenarios Covered

Strict validation of account-company mapping

Enforcement of accounting dimension rules

Prevention of using disabled payment modes in POS

Validation of POS invoices during closing

Payment Request lifecycle (create, cancel, integration request sync)

Supplier & Mode of Payment query functions in Payment Orders

🛠️ Tech Stack

Frappe Framework

ERPNext Accounts, POS, and Payment modules

Python unittest with frappe.ValidationError

✅ Benefits

Prevents financial misconfigurations.

Enforces accounting integrity across Ledger, POS, and Payments.

Strengthens ERPNext test coverage for critical flows.

Provides clear error messages for end users.