### PR TITLE
fix:resolved AttributeError: 'dict' object has no attribute #2888 issue

### DIFF
--- a/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
+++ b/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
@@ -65,6 +65,7 @@ class TestAccountingPeriod(unittest.TestCase):
 		frappe.flags.in_test = False
 
 	def test_bootstrap_doctypes_for_closing_TC_ACC_230(self):
+		from frappe import _dict
 		frappe.flags.in_test = True
 		try:
 			# Create test Accounting Period doc
@@ -77,10 +78,10 @@ class TestAccountingPeriod(unittest.TestCase):
 
 			# Patch get_doctypes_for_closing to return dict-like list
 			ap.get_doctypes_for_closing = lambda: [
-				dict(document_type="Sales Invoice", closed=1),
-				dict(document_type="Purchase Invoice", closed=1),
+				_dict(document_type="Sales Invoice", closed=1),
+				_dict(document_type="Purchase Invoice", closed=1),
 			]
-
+			
 			# Call bootstrap method
 			ap.bootstrap_doctypes_for_closing()
 

--- a/erpnext/accounts/report/gross_and_net_profit_report/test_gross_and_net_profit_report.py
+++ b/erpnext/accounts/report/gross_and_net_profit_report/test_gross_and_net_profit_report.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
-
+from frappe import _dict
 from erpnext.accounts.report.gross_and_net_profit_report import (
 	gross_and_net_profit_report as r,
 )
@@ -51,7 +51,7 @@ class TestProfitAndLossStatement(FrappeTestCase):
 			r.get_columns = orig_get_columns
 
 	def test_execute_full_flow_including_gross_and_net_profit_TC_ACC_408(self):
-		period_list = [dict(key="P1"), dict(key="P2")]
+		period_list = [_dict(key="P1"), _dict(key="P2")]
 
 		income_rows = [
 			{
@@ -186,7 +186,7 @@ class TestProfitAndLossStatement(FrappeTestCase):
 			r.get_columns = orig_get_columns
 
 	def test_get_revenue_removes_empty_group_and_adjusts_totals_TC_ACC_409(self):
-		plist = [dict(key="P1"), dict(key="P2")]
+		plist = [_dict(key="P1"), _dict(key="P2")]
 		rows = [
 			{
 				"account": "G",
@@ -260,7 +260,7 @@ class TestProfitAndLossStatement(FrappeTestCase):
 		orig_get_cached_value = frappe.get_cached_value
 		frappe.get_cached_value = lambda doctype, name, field: "EUR"
 		try:
-			plist = [dict(key="M1"), dict(key="M2")]
+			plist = [_dict(key="M1"), _dict(key="M2")]
 			gross_income = [{"M1": 100, "M2": 50, "total": 0}]
 			non_gross_income = [{"M1": 5, "M2": 5, "total": 0}]
 			gross_expense = [{"M1": 60, "M2": 70, "total": 0}]


### PR DESCRIPTION
**Title**

Fix: Replace dict with frappe._dict in specific tests to ensure consistent behavior

**Description**

Some tests were failing due to use of plain dicts where frappe._dict was expected. Since ERPNext functions rely on dict-like objects that support attribute-style access, using frappe._dict prevents type-related issues and ensures consistency.

**Fix Summary**

Replaced plain dicts with frappe._dict in the affected test cases.

**Test Cases Covered**

test_bootstrap_doctypes_for_closing_TC_ACC_230

test_execute_full_flow_including_gross_and_net_profit_TC_ACC_408

test_get_revenue_removes_empty_group_and_adjusts_totals_TC_ACC_409

test_get_net_profit_currency_fallback_TC_ACC_411

**Linked Issue**

#2866