### PR TITLE
fix: resolved erpnext.accounts.utils.FiscalYearError: Date 03-01-2024 is not in any active Fiscal Year for <strong>_Test Company</strong> #2864 

### DIFF
--- a/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
+++ b/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
@@ -65,6 +65,7 @@ class TestAccountingPeriod(unittest.TestCase):
 		frappe.flags.in_test = False
 
 	def test_bootstrap_doctypes_for_closing_TC_ACC_230(self):
+		from frappe import _dict
 		frappe.flags.in_test = True
 		try:
 			# Create test Accounting Period doc
@@ -77,10 +78,10 @@ class TestAccountingPeriod(unittest.TestCase):
 
 			# Patch get_doctypes_for_closing to return dict-like list
 			ap.get_doctypes_for_closing = lambda: [
-				dict(document_type="Sales Invoice", closed=1),
-				dict(document_type="Purchase Invoice", closed=1),
+				_dict(document_type="Sales Invoice", closed=1),
+				_dict(document_type="Purchase Invoice", closed=1),
 			]
-
+			
 			# Call bootstrap method
 			ap.bootstrap_doctypes_for_closing()
 

--- a/erpnext/accounts/doctype/process_deferred_accounting/test_process_deferred_accounting.py
+++ b/erpnext/accounts/doctype/process_deferred_accounting/test_process_deferred_accounting.py
@@ -91,7 +91,7 @@ class TestProcessDeferredAccounting(unittest.TestCase):
 		supplier = make_supplier("_Test Supplier", currency="INR")
 
 		# Step 1: Set dynamic dates (2 years back)
-		backdate = getdate(add_years(nowdate(), -2))
+		backdate = getdate(add_years(nowdate(), -1))
 		start_date = get_first_day(add_months(backdate, 4))
 		end_date = get_last_day(add_months(backdate, 6))
 		posting_date = get_first_day(add_months(backdate, 6))
@@ -209,12 +209,12 @@ class TestProcessDeferredAccounting(unittest.TestCase):
 
 		customer = create_customer("_Test Customer", currency="INR")
 
-		base_date = getdate(add_years(nowdate(), -2))
+		base_date = getdate(add_years(nowdate(), -1))
 		start_date = get_first_day(add_months(base_date, 4))
 		end_date = get_last_day(add_months(base_date, 6))
 		posting_date = get_first_day(add_months(base_date, 6))
 		acc_frozen_upto = get_last_day(add_months(base_date, 3))
-
+		create_fiscal_year("_Test Company",date(base_date.year,1,1),date(base_date.year,12,31))
 		# Step 2: Set Accounting Settings
 		change_acc_settings(acc_frozen_upto=acc_frozen_upto, book_deferred_entries_based_on="Months")
 

--- a/erpnext/accounts/report/gross_and_net_profit_report/test_gross_and_net_profit_report.py
+++ b/erpnext/accounts/report/gross_and_net_profit_report/test_gross_and_net_profit_report.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
-
+from frappe import _dict
 from erpnext.accounts.report.gross_and_net_profit_report import (
 	gross_and_net_profit_report as r,
 )
@@ -51,7 +51,7 @@ class TestProfitAndLossStatement(FrappeTestCase):
 			r.get_columns = orig_get_columns
 
 	def test_execute_full_flow_including_gross_and_net_profit_TC_ACC_408(self):
-		period_list = [dict(key="P1"), dict(key="P2")]
+		period_list = [_dict(key="P1"), _dict(key="P2")]
 
 		income_rows = [
 			{
@@ -186,7 +186,7 @@ class TestProfitAndLossStatement(FrappeTestCase):
 			r.get_columns = orig_get_columns
 
 	def test_get_revenue_removes_empty_group_and_adjusts_totals_TC_ACC_409(self):
-		plist = [dict(key="P1"), dict(key="P2")]
+		plist = [_dict(key="P1"), _dict(key="P2")]
 		rows = [
 			{
 				"account": "G",
@@ -260,7 +260,7 @@ class TestProfitAndLossStatement(FrappeTestCase):
 		orig_get_cached_value = frappe.get_cached_value
 		frappe.get_cached_value = lambda doctype, name, field: "EUR"
 		try:
-			plist = [dict(key="M1"), dict(key="M2")]
+			plist = [_dict(key="M1"), _dict(key="M2")]
 			gross_income = [{"M1": 100, "M2": 50, "total": 0}]
 			non_gross_income = [{"M1": 5, "M2": 5, "total": 0}]
 			gross_expense = [{"M1": 60, "M2": 70, "total": 0}]


### PR DESCRIPTION
Title

Fix: Update test date ranges in deferred accounting tests to avoid outdated fiscal years

Description

Some deferred expense and revenue tests were using dates set 2 years back from the current date. This caused issues in scenarios where fiscal years or accounting settings didn’t align correctly during test runs. By reducing the backdate offset from 2 years to 1 year, the tests now use more recent fiscal years and remain stable.

Fix Summary

Updated backdate/base_date calculations in deferred accounting test cases from -2 years to -1 year.

Ensured fiscal year creation and accounting settings align with the adjusted dates.

Test Cases Covered

test_auto_deferred_expense_entries_TC_ACC_092

test_auto_deferred_revenue_TC_ACC_093

Linked Issue

#2864