### PR TITLE
fix: resolved NameError: name 'flt' is not defined #2894 issue

### DIFF
--- a/erpnext/accounts/doctype/monthly_distribution/test_monthly_distribution.py
+++ b/erpnext/accounts/doctype/monthly_distribution/test_monthly_distribution.py
@@ -7,7 +7,7 @@ import unittest
 import frappe
 
 test_records = frappe.get_test_records("Monthly Distribution")
-
+from frappe.utils import flt
 
 class TestMonthlyDistribution(unittest.TestCase):
 	def tearDown(self):


### PR DESCRIPTION
Title

Fix: Add missing flt import in Monthly Distribution test

Description

The TestMonthlyDistribution test case was using the flt utility without importing it, leading to NameError: name 'flt' is not defined during test execution.

Fix Summary

Added from frappe.utils import flt to the Monthly Distribution test file to ensure the utility is available.

Test Cases Covered

TestMonthlyDistribution

Linked Issue

#2894