### PR TITLE
fix: Fixed HSN/SAC Code is required. Please enter a valid HSN/SAC cod…

### DIFF
--- a/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
+++ b/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
@@ -27,6 +27,7 @@ def test_create_test_data():
 				"item_code": "_Test Tesla Car",
 				"item_group": "_Test Item Group",
 				"item_name": "_Test Tesla Car",
+				"gst_hsn_code" : "01011010" ,
 				"apply_warehouse_wise_reorder_level": 0,
 				"warehouse": "Stores - _TC",
 				"valuation_rate": 5000,


### PR DESCRIPTION
Fixed failing test case in test_coupon_code.py caused by missing HSN/SAC Code validation from the india_compliance app.

Issue: During test setup, Item creation failed because gst_hsn_code was not set, and validation threw:

MandatoryError: HSN/SAC Code is required. Please enter a valid HSN/SAC code.

Solution: Updated test data creation to include a valid HSN/SAC Code for items.

Result: Test cases now pass successfully without triggering validation errors from GST compliance overrides.