### PR TITLE
test: Reset account is_group parameter after TC execution

### DIFF
--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -408,8 +408,6 @@ class TestBudget(unittest.TestCase):
 			for entry in expected_entries:
 				self.assertIn(entry, gl_entries, msg=f"Expected GL Entry {entry} not found in {gl_entries}")
 
-			print(f"Provisional Accounting validated for {pr.name}")
-
 		finally:
 			# Step 6: Cleanup
 			if pr and pr.docstatus == 1:

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -862,7 +862,6 @@ class TestJournalEntry(unittest.TestCase):
 			jv.name,
 			as_dict=True,
 		)
-		print("Here we are printing the GL Entries ", gl_entries)
 		# Expected GL entries
 		expected_gl_entries = [
 			{"account": credit_account, "debit": 0, "credit": amount},
@@ -2394,87 +2393,108 @@ class TestJournalEntry(unittest.TestCase):
 		get_or_create_supplier("_Test Supplier")
 		get_or_create_customer("_Test Customer")
 
-		if not frappe.db.exists("Account", f"Debtors - {abbr}"):
-			frappe.get_doc(
-				{
-					"doctype": "Account",
-					"account_name": "Debtors",
-					"parent_account": f"Accounts Receivable - {abbr}",
-					"company": company,
-					"is_group": 1,
-					"root_type": "Asset",
-				}
-			).insert(ignore_permissions=True)
-		else:
-			frappe.db.set_value("Account", f"Debtors - {abbr}", "is_group", 1)
+		debtors_account = f"Debtors - {abbr}"
+		liabilities_account = f"Current Liabilities - {abbr}"
 
-		if not frappe.db.exists("Account", f"Current Liabilities - {abbr}"):
-			frappe.get_doc(
-				{
-					"doctype": "Account",
-					"account_name": "Current Liabilities",
-					"parent_account": f"Liabilities - {abbr}",
-					"company": company,
-					"is_group": 1,
-					"root_type": "Liability",
-				}
-			).insert(ignore_permissions=True)
-		else:
-			frappe.db.set_value("Account", f"Current Liabilities - {abbr}", "is_group", 1)
+		try:
+			if not frappe.db.exists("Account", debtors_account):
+				frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": "Debtors",
+						"parent_account": f"Accounts Receivable - {abbr}",
+						"company": company,
+						"is_group": 1,
+						"root_type": "Asset",
+					}
+				).insert(ignore_permissions=True)
+			else:
+				frappe.db.set_value("Account", debtors_account, "is_group", 1)
 
-		asset_account = get_or_create_account(
-			"Debtors - JV", company, f"Debtors - {abbr}", "Receivable", "Asset"
-		)
+			if not frappe.db.exists("Account", liabilities_account):
+				frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": "Current Liabilities",
+						"parent_account": f"Liabilities - {abbr}",
+						"company": company,
+						"is_group": 1,
+						"root_type": "Liability",
+					}
+				).insert(ignore_permissions=True)
+			else:
+				frappe.db.set_value("Account", liabilities_account, "is_group", 1)
 
-		liability_account = get_or_create_account(
-			"Creditors - JV", company, f"Current Liabilities - {abbr}", "Payable", "Liability"
-		)
+			asset_account = get_or_create_account(
+				"Debtors - JV", company, debtors_account, "Receivable", "Asset"
+			)
+			liability_account = get_or_create_account(
+				"Creditors - JV", company, liabilities_account, "Payable", "Liability"
+			)
 
-		je1 = make_journal_entry(account1=asset_account, account2=liability_account, amount=200, save=False)
-		je1.accounts[0].reference_type = "Journal Entry"
-		je1.accounts[0].debit = 200
-		je1.accounts[0].credit = 0
-		with self.assertRaises(frappe.ValidationError) as cm1:
-			je1.validate_against_jv()
-		self.assertIn("you can select reference document only if account gets credited", str(cm1.exception))
+			je1 = make_journal_entry(
+				account1=asset_account, account2=liability_account, amount=200, save=False
+			)
+			je1.accounts[0].reference_type = "Journal Entry"
+			je1.accounts[0].debit = 200
+			je1.accounts[0].credit = 0
+			with self.assertRaises(frappe.ValidationError) as cm1:
+				je1.validate_against_jv()
+			self.assertIn(
+				"you can select reference document only if account gets credited", str(cm1.exception)
+			)
 
-		je2 = make_journal_entry(account1=liability_account, account2=asset_account, amount=300, save=False)
-		je2.accounts[0].reference_type = "Journal Entry"
-		je2.accounts[0].credit = 300
-		je2.accounts[0].debit = 0
-		with self.assertRaises(frappe.ValidationError) as cm2:
-			je2.validate_against_jv()
-		self.assertIn("you can select reference document only if account gets debited", str(cm2.exception))
+			je2 = make_journal_entry(
+				account1=liability_account, account2=asset_account, amount=300, save=False
+			)
+			je2.accounts[0].reference_type = "Journal Entry"
+			je2.accounts[0].credit = 300
+			je2.accounts[0].debit = 0
+			with self.assertRaises(frappe.ValidationError) as cm2:
+				je2.validate_against_jv()
+			self.assertIn(
+				"you can select reference document only if account gets debited", str(cm2.exception)
+			)
 
-		je3 = make_journal_entry(account1=asset_account, account2=liability_account, amount=400, save=False)
-		je3.accounts[0].party_type = "Customer"
-		je3.accounts[0].party = "_Test Customer"
-		je3.accounts[0].reference_type = "Journal Entry"
-		je3.accounts[0].reference_name = je3.name
-		with self.assertRaises(frappe.ValidationError) as cm3:
-			je3.validate_against_jv()
-		self.assertIn(
-			"You can not enter current voucher in 'Against Journal Entry' column", str(cm3.exception)
-		)
+			je3 = make_journal_entry(
+				account1=asset_account, account2=liability_account, amount=400, save=False
+			)
+			je3.accounts[0].party_type = "Customer"
+			je3.accounts[0].party = "_Test Customer"
+			je3.accounts[0].reference_type = "Journal Entry"
+			je3.accounts[0].reference_name = je3.name
+			with self.assertRaises(frappe.ValidationError) as cm3:
+				je3.validate_against_jv()
+			self.assertIn(
+				"You can not enter current voucher in 'Against Journal Entry' column", str(cm3.exception)
+			)
 
-		ref_je = make_journal_entry(
-			account1=asset_account, account2=liability_account, amount=500, save=False
-		)
-		ref_je.accounts[0].party_type = "Customer"
-		ref_je.accounts[0].party = "_Test Customer"
-		ref_je.accounts[1].party_type = "Supplier"
-		ref_je.accounts[1].party = "_Test Supplier"
-		ref_je.submit()
+			ref_je = make_journal_entry(
+				account1=asset_account, account2=liability_account, amount=500, save=False
+			)
+			ref_je.accounts[0].party_type = "Customer"
+			ref_je.accounts[0].party = "_Test Customer"
+			ref_je.accounts[1].party_type = "Supplier"
+			ref_je.accounts[1].party = "_Test Supplier"
+			ref_je.submit()
 
-		je4 = make_journal_entry(account1=asset_account, account2=liability_account, amount=500, save=False)
-		je4.accounts[0].reference_type = "Journal Entry"
-		je4.accounts[0].reference_name = ref_je.name
-		je4.accounts[0].party_type = "Customer"
-		je4.accounts[0].party = "_Test Customer"
+			je4 = make_journal_entry(
+				account1=asset_account, account2=liability_account, amount=500, save=False
+			)
+			je4.accounts[0].reference_type = "Journal Entry"
+			je4.accounts[0].reference_name = ref_je.name
+			je4.accounts[0].party_type = "Customer"
+			je4.accounts[0].party = "_Test Customer"
 
-		with self.assertRaises(frappe.ValidationError) as cm4:
-			je4.validate_against_jv()
-		self.assertIn("does not have any unmatched", str(cm4.exception))
+			with self.assertRaises(frappe.ValidationError) as cm4:
+				je4.validate_against_jv()
+			self.assertIn("does not have any unmatched", str(cm4.exception))
+
+		finally:
+			if frappe.db.exists("Account", debtors_account):
+				frappe.db.set_value("Account", debtors_account, "is_group", 0)
+			if frappe.db.exists("Account", liabilities_account):
+				frappe.db.set_value("Account", liabilities_account, "is_group", 0)
 
 	def test_get_outstanding_for_journal_entry_TC_ACC_563(self):
 		from erpnext.accounts.doctype.journal_entry.journal_entry import get_outstanding


### PR DESCRIPTION
### Title:

Fix: Reset Accounts in tests to avoid using Group Accounts in transactions

### Description:

During full coverage runs, multiple tests failed with:
ValidationError: Account ... is a Group Account and group accounts cannot be used in transactions.

### Root Cause:

Some tests (e.g. test_validate_entries_for_advance_exceptions_TC_ACC_560) set Accounts Receivable and Creditors as group accounts but did not reset them, leaking invalid state into other tests.

### Steps to Reproduce:

Run bench run-tests --app erpnext.

Transaction-related tests fail with group account errors.

### Actual Result:

Tests fail unpredictably due to leftover group accounts.

### Expected Result:

Tests pass consistently with valid account states.

### Fix Summary:

Added reset of Accounts in test_validate_entries_for_advance_exceptions_TC_ACC_560 using a finally block.

Prevents invalid account state from affecting other tests.

### Test Cases Covered:

test_validate_entries_for_advance_exceptions_TC_ACC_560

Stabilizes all JE/Invoice related tests.

### Linked Issue:

#2895 
#2893 