### PR TITLE
fix: fiscal year date issue

### DIFF
--- a/erpnext/accounts/doctype/process_deferred_accounting/test_process_deferred_accounting.py
+++ b/erpnext/accounts/doctype/process_deferred_accounting/test_process_deferred_accounting.py
@@ -95,7 +95,7 @@ class TestProcessDeferredAccounting(unittest.TestCase):
 		start_date = get_first_day(add_months(backdate, 4))
 		end_date = get_last_day(add_months(backdate, 6))
 		posting_date = get_first_day(add_months(backdate, 6))
-		create_fiscal_year("_Test Company", date(backdate.year, 1, 1), date(backdate.year, 12, 31))
+		create_fiscal_year("_Test Company", date(posting_date.year, 1, 1), date(posting_date.year, 12, 31))
 		# Step 2: Set Accounting Settings
 		change_acc_settings(acc_frozen_upto=start_date, book_deferred_entries_based_on="Months")
 


### PR DESCRIPTION
## Title: FiscalYearError
### Description:
FiscalYearError: Date 03-01-2024 is not in any active Fiscal Year for <strong>_Test Company</strong>" 

### Root Cause:
The test case test_auto_deferred_expense_entries_TC_ACC_092 was creating a fiscal year with a static backdate that did not align with the dynamically generated posting date, causing the posting date to fall outside any active fiscal year.

### Actual Result:
FiscalYearError: Date 03-01-2024 is not in any active Fiscal Year for <strong>_Test Company</strong>" 

### Expected Result:
The test should consistently pass by ensuring the posting date is always within an active fiscal year.

### Fix Summary:
Updated the test to dynamically create a fiscal year based on the calculated posting_date

### Test Cases Covered:
test_auto_deferred_expense_entries_TC_ACC_092
test_auto_deferred_revenue_TC_ACC_093

### Linked Issue: 2901