### PR TITLE
Added no pragma to Maintenance Schedule Item and Maintenance Schedule Detail Doctypes to ignore the files on code coverage

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
@@ -4,7 +4,7 @@ import frappe
 from frappe.model.document import Document
 
 
-class MaintenanceScheduleDetail(Document):
+class MaintenanceScheduleDetail(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_detail/maintenance_schedule_detail.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-
-
+import frappe
 from frappe.model.document import Document
 
 

--- a/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
@@ -4,7 +4,7 @@ import frappe
 from frappe.model.document import Document
 
 
-class MaintenanceScheduleItem(Document):
+class MaintenanceScheduleItem(Document):  # pragma: no cover
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-
-
+import frappe
 from frappe.model.document import Document
 
 


### PR DESCRIPTION
**Title**: Added no pragma to Maintenance Schedule Item and Maintenance Schedule Detail Doctypes to ignore the files on code coverage

**Description**:

**Optimization Summary**
As we are using # pragma: no cover, this directive tells coverage tools to ignore those lines. Since child tables do not contain business logic or testable functions/methods, they are excluded from test coverage. To improve the overall code coverage percentage, the no cover pragma was added where appropriate.

**Before vs After**
**Old Behavior:** Code coverage percentage for the Maintenance module was low due to untestable child table definitions.

**New Behavior**: After explicitly marking those lines, the code coverage percentage improved as those lines are now excluded from the coverage report.

**Affected Areas**
Maintenance module DocTypes with child tables lacking testable methods.

**Linked Issue**
N/A – No issue was created for this task.

**Child Table Doctypes:**

Maintenance Schedule Item

Maintenance Schedule Detail