### PR TITLE
Fix: Remittance of TDS certificate Validation Errors

### DIFF
--- a/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
+++ b/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.file_manager import save_file
 
-from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import unzip_file
+from erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import unzip_file
 
 
 class DummyFile:
@@ -202,11 +202,11 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		extracted_file_names = [f.file_name for f in extracted_files]
 		self.assertIn("test_inside.txt", extracted_file_names)
 
-	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.unzip_file")
+	@patch("erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.unzip_file")
 	def test_unpack_TC_B_227(self, mock_unzip_file):
 		doc = frappe.get_doc(
 			{
-				"doctype": "Remittance of TDS Certificate",
+				"doctype": "Remittance of TDS certificate",
 				"upload_doc": "/files/test.zip",
 				"subject": "Test Email",
 				"description": "This is a test email body.",
@@ -217,9 +217,9 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		mock_unzip_file.return_value = None
 
 		with patch(
-			"erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_email_list"
+			"erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_email_list"
 		) as mock_get_email_list, patch(
-			"erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.create_attachment"
+			"erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.create_attachment"
 		) as mock_create_attachment, patch("frappe.sendmail") as mock_sendmail:
 			mock_get_email_list.return_value = [
 				{


### PR DESCRIPTION
The Remittance of TDS Certificate belongs to the ERPNext India module but was being imported from the ERPNext core module, which caused import and test failures. 
Also corrected the case-sensitive mismatch in the Doctype name used in the get_doc function.

Summary
fix(remittance_of_tds_certificate): corrected module import path and case-sensitive doctype name

Test Cases Covered
test_unpack_TC_B_227

Linked Issue
https://github.com/8848digital/erpnext/issues/2870