### PR TITLE
Fix: Corrected ORDER BY syntax in Stock Ledger Entry to avoid syntax error

### DIFF
--- a/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
+++ b/erpnext/buying/doctype/remittance_of_tds_certificate/test_remittance_of_tds_certificate.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.file_manager import save_file
 
-from erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import unzip_file
+from erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate import unzip_file
 
 
 class DummyFile:
@@ -202,11 +202,11 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		extracted_file_names = [f.file_name for f in extracted_files]
 		self.assertIn("test_inside.txt", extracted_file_names)
 
-	@patch("erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.unzip_file")
+	@patch("erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.unzip_file")
 	def test_unpack_TC_B_227(self, mock_unzip_file):
 		doc = frappe.get_doc(
 			{
-				"doctype": "Remittance of TDS Certificate",
+				"doctype": "Remittance of TDS certificate",
 				"upload_doc": "/files/test.zip",
 				"subject": "Test Email",
 				"description": "This is a test email body.",
@@ -217,9 +217,9 @@ class TestRemittanceofTDScertificate(FrappeTestCase):
 		mock_unzip_file.return_value = None
 
 		with patch(
-			"erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_email_list"
+			"erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.get_email_list"
 		) as mock_get_email_list, patch(
-			"erpnext.buying.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.create_attachment"
+			"erpnext_india.erpnext_india.doctype.remittance_of_tds_certificate.remittance_of_tds_certificate.create_attachment"
 		) as mock_create_attachment, patch("frappe.sendmail") as mock_sendmail:
 			mock_get_email_list.return_value = [
 				{

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -1315,7 +1315,7 @@ class TestStockLedgerEntry(FrappeTestCase, StockTestMixin):
 			"Stock Ledger Entry",
 			fields=["*"],
 			filters=filters,
-			order_by="timestamp(posting_date, posting_time), creation",
+			order_by="posting_date asc, posting_time asc, creation asc",
 		)
 		self.assertEqual(abs(sles[0].stock_value_difference), sles[1].stock_value_difference)
 


### PR DESCRIPTION
The original query used timestamp(posting_date, posting_time), which is invalid syntax for the ORDER BY clause in PostgreSQL. So updated the order_by clause in frappe.get_all to correctly order by individual fields

Summary
fix(stock_ledger_entry): corrected ORDER BY syntax in get_all query

Test Cases Covered
test_transfer_invariants

Linked Issue
https://github.com/8848digital/erpnext/issues/2845