### PR TITLE
fix: pass item_code parameter in create_purchase_invoice

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -2430,7 +2430,7 @@ class TestPaymentEntry(FrappeTestCase):
 		make_test_item("_Test Item")
 		get_or_create_fiscal_year("_Test Company")
 
-		pi = create_purchase_invoice(supplier=supplier)
+		pi = create_purchase_invoice(supplier=supplier, item_code="_Test Item")
 
 		# Insert GL Entries for a customer
 		gl_entry = frappe.get_doc(
@@ -3223,7 +3223,7 @@ class TestPaymentEntry(FrappeTestCase):
 		item = make_test_item("_Test Item")
 		get_or_create_fiscal_year(company)
 		# Step 1: Create a Sales Invoice with Payment Terms
-		si = create_sales_invoice(customer=customer, company=company, qty=2, rate=100, do_not_save = True)
+		si = create_sales_invoice(customer=customer, company=company, qty=2, rate=100, do_not_save=True)
 		si.payment_terms_template = "_Test Payment Term Template"
 		si.taxes_and_charges = ""
 		si.taxes = []
@@ -3232,9 +3232,7 @@ class TestPaymentEntry(FrappeTestCase):
 
 		# Step 2: Build references like Payment Entry would
 		references = [
-			frappe._dict(
-				reference_doctype="Sales Invoice", reference_name=si.name, payment_term="_Test COD"
-			)
+			frappe._dict(reference_doctype="Sales Invoice", reference_name=si.name, payment_term="_Test COD")
 		]
 		# Step 3: Call function
 		result = get_outstanding_of_references_with_payment_term(references)


### PR DESCRIPTION
Title: Fix: frappe.exceptions.MandatoryError
Description:
Item Name was not added while creating Purchase Invoice

Root Cause:
Item Name Missing

Actual Result:
Tests failed frappe.exceptions.MandatoryError for Item name.

Expected Result:
Tests should pass consistently both individually and at the app level.

Fix Summary:
Added Item Name

Test Cases Covered:
test_paid_amount_for_supplier_TC_ACC_375

Linked Issue:
https://github.com/8848digital/erpnext/issues/2861